### PR TITLE
fix for entries between 12.00 and 12.59

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -959,7 +959,7 @@ public class Home extends ActivityWithMenu {
 
             case "time":
                 Log.d(TAG, "processing time keyword");
-                if ((timeset == false) && (thisnumber > 0)) {
+                if ((timeset == false) && (thisnumber >= 0)) {
 
                     final NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
                     final DecimalFormat df = (DecimalFormat)nf;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -974,7 +974,7 @@ public class Home extends ActivityWithMenu {
                     final SimpleDateFormat simpleDateFormat1 =
                             new SimpleDateFormat("dd/M/yyyy ",Locale.US);
                     final SimpleDateFormat simpleDateFormat2 =
-                            new SimpleDateFormat("dd/M/yyyy hh.mm",Locale.US); // TODO double check 24 hour 12.00 etc
+                            new SimpleDateFormat("dd/M/yyyy HH.mm",Locale.US); // TODO double check 24 hour 12.00 etc
                     final String datenew = simpleDateFormat1.format(c.getTime()) + df.format(thisnumber);
 
                     Log.d(TAG, "Time Timing data datenew: " + datenew);


### PR DESCRIPTION
Treatments with time between 12.00 and 12.59 were mapped to the hour after midnight - as well as 00.01 to 00.59.

According to http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html
`hh` represents the hours in 1-12 hour format and `HH` in 0-23 hour format.