### PR TITLE
manual calibration overwrite in engineering mode

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
@@ -1,12 +1,24 @@
 package com.eveningoutpost.dexdrip;
 
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.EditText;
 import android.widget.TextView;
 
 import com.eveningoutpost.dexdrip.Models.Calibration;
+import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.utils.ActivityWithMenu;
+import com.eveningoutpost.dexdrip.wearintegration.WatchUpdaterService;
 
 import java.text.DateFormat;
 import java.text.DecimalFormat;
@@ -114,4 +126,111 @@ public class CalibrationGraph extends ActivityWithMenu {
         line.setHasLabels(true);
         return line;
     }
+
+
+
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+
+
+        //Just generate the menu in engineering mode
+        if (!prefs.getBoolean("engineering_mode", false)){
+            return false;
+        }
+
+        getMenuInflater().inflate(R.menu.menu_calibrationgraph, menu);
+
+        // Only show elements if there is a calibration to overwrite
+        if(Calibration.lastValid()!= null){
+            menu.findItem(R.id.action_overwrite_intercept).setVisible(true);
+            menu.findItem(R.id.action_overwrite_slope).setVisible(true);
+            menu.findItem(R.id.action_overwrite_calibration_impossible).setVisible(false);
+        }
+
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+
+        switch (item.getItemId()) {
+            case R.id.action_overwrite_intercept:
+                overWriteIntercept();
+                break;
+            case R.id.action_overwrite_slope:
+                overWriteSlope();
+        }
+
+        return true; //consume event
+    }
+
+    private void overWriteIntercept() {
+        final EditText editText = new EditText(this);
+        editText.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+
+        new AlertDialog.Builder(this)
+                .setTitle("Ovewrite Intercept")
+                .setMessage("Overwrite Intercept")
+                .setView(editText)
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        String text = editText.getText().toString();
+                        if (!TextUtils.isEmpty(text)) {
+                            double doubleValue = Double.parseDouble(text);
+                            Calibration calibration = Calibration.lastValid();
+                            calibration.intercept = doubleValue;
+                            calibration.save();
+                            recreate();
+                        } else {
+                            JoH.static_toast_long("Input not found! Cancelled!");
+                        }
+                    }
+                })
+                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        JoH.static_toast_long("Cancelled!");
+                    }
+                })
+                .show();
+    }
+
+    private void overWriteSlope() {
+        final EditText editText = new EditText(this);
+        editText.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+
+        new AlertDialog.Builder(this)
+                .setTitle("Ovewrite Slope")
+                .setMessage("Overwrite Slope")
+                .setView(editText)
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        String text = editText.getText().toString();
+                        if (!TextUtils.isEmpty(text)) {
+                            double doubleValue = Double.parseDouble(text);
+                            Calibration calibration = Calibration.lastValid();
+                            calibration.slope = doubleValue;
+                            calibration.save();
+                            recreate();
+                        } else {
+                            JoH.static_toast_long("Input not found! Cancelled!");
+                        }
+                    }
+                })
+                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        JoH.static_toast_long("Cancelled!");
+                    }
+                })
+                .show();
+    }
+
+
+
 }

--- a/app/src/main/res/menu/menu_calibrationgraph.xml
+++ b/app/src/main/res/menu/menu_calibrationgraph.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/action_overwrite_slope"
+        android:title="Overwrite Slope (engineering only!)"
+        android:orderInCategory="1"
+        android:visible="false"/>
+    <item android:id="@+id/action_overwrite_intercept"
+        android:title="Overwrite Intercept (engineering only!)"
+        android:orderInCategory="1"
+        android:visible="false"/>
+    <item android:id="@+id/action_overwrite_calibration_impossible"
+        android:title="Manual overwrite not possible!"
+        android:orderInCategory="1"
+        android:visible="true"/>
+</menu>


### PR DESCRIPTION
This will allow to manually set the slope and intercept from a menu in the calibration graph.

![screenshot_2016-09-28-16-58-58](https://cloud.githubusercontent.com/assets/9692866/18920965/56da3880-85a3-11e6-8927-12788dad2fe5.png)

![screenshot_2016-09-28-16-58-51](https://cloud.githubusercontent.com/assets/9692866/18920796/c2ecedf2-85a2-11e6-978a-ab96d2cb63fb.png)

The text entry is limited to decimals and for slopes also to positive values:
![screenshot_2016-09-28-17-42-00](https://cloud.githubusercontent.com/assets/9692866/18920872/0bca9768-85a3-11e6-9404-b425af4aab72.png)

It will modify the last valid calibration; the calibration graph is updated:
![screenshot_2016-09-28-17-06-42](https://cloud.githubusercontent.com/assets/9692866/18920897/1f48ca30-85a3-11e6-8153-6aae513eba51.png)

When engineering mode is disabled, the menu won't show:
![screenshot_2016-09-28-17-00-40](https://cloud.githubusercontent.com/assets/9692866/18921063/b1579528-85a3-11e6-8c60-aa9898421d05.png)

No History rewrite happens. Just the values are calculated with that slope from now on.