### PR TITLE
hidden calibration params for adrian - only in engineering mode

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -50,6 +50,26 @@ class DexParameters extends SlopeParameters {
 
 }
 
+class DexParametersAdrian extends SlopeParameters {
+
+    /*
+    * Other default vlaues and thresholds that can be only activated in settings, when in engineering mode.
+    * */
+
+    DexParametersAdrian() {
+        LOW_SLOPE_1 = 0.75;
+        LOW_SLOPE_2 = 0.70;
+        HIGH_SLOPE_1 = 1.3;
+        HIGH_SLOPE_2 = 1.4;
+        DEFAULT_LOW_SLOPE_LOW = 75;
+        DEFAULT_LOW_SLOPE_HIGH = 70;
+        DEFAULT_SLOPE = 1;
+        DEFAULT_HIGH_SLOPE_HIGH = 1.3;
+        DEFAUL_HIGH_SLOPE_LOW = 1.2;
+    }
+
+}
+
 class LiParameters extends SlopeParameters {
     LiParameters() {
         LOW_SLOPE_1 = 1;
@@ -593,7 +613,17 @@ public class Calibration extends Model {
 
     @NonNull
     private static SlopeParameters getSlopeParameters() {
-        return CollectionServiceStarter.isLimitter() ? new LiParameters() : new DexParameters();
+
+        if (CollectionServiceStarter.isLimitter()) {
+            return new LiParameters();
+        }
+
+        if (Home.getPreferencesBooleanDefaultFalse("engineering_mode") && Home.getPreferencesBooleanDefaultFalse("adrian_calibration_mode")) {
+            JoH.static_toast_long("Using possibly UNSAFE Adrian calibration mode!");
+            return new DexParametersAdrian();
+        }
+
+        return new DexParameters();
     }
 
     private double slopeOOBHandler(int status) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -739,6 +739,7 @@ public class Preferences extends PreferenceActivity {
             final PreferenceCategory alertsCategory = (PreferenceCategory) findPreference("alerts_category");
             final Preference disableAlertsStaleDataMinutes = findPreference("disable_alerts_stale_data_minutes");
             final Preference widgetRangeLines = findPreference("widget_range_lines");
+            final Preference adrian_calibration_mode = (Preference) findPreference("xdrip_plus_motion_settings");
 
             disableAlertsStaleDataMinutes.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
@@ -973,6 +974,7 @@ public class Preferences extends PreferenceActivity {
 
                 if (!engineering_mode) {
                     getPreferenceScreen().removePreference(motionScreen);
+                    getPreferenceScreen().removePreference(adrian_calibration_mode);
                 }
 
             } catch (NullPointerException e) {

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -346,8 +346,12 @@
                     android:summary="Show slope and intercept in short form."
                     android:title="@string/calibration_data_short" />
             </PreferenceScreen>
-
-
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:dependency="engineering_mode"
+                android:key="adrian_calibration_mode"
+                android:summary="Wider range of allowed slopes. Less failsafes! (engineering mode only)"
+                android:title="Adrian calibration mode" />
             <PreferenceCategory
                 android:key="community_help_category"
                 android:title="@string/help_the_community">


### PR DESCRIPTION
This just works in engineering mode. I used to patch in these parameters manually to get the calibration algorithm working for me.

Tested that even when the new setting was on, it will NOT be used when engineering mode is switched off.

Tested that slopes now can really be lower if the regression algorithm has that result. -> working.