### PR TITLE
Allow the user to configure more logging to be stored by xDrip.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserError.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserError.java
@@ -7,8 +7,10 @@ import com.activeandroid.Model;
 import com.activeandroid.annotation.Column;
 import com.activeandroid.annotation.Table;
 import com.activeandroid.query.Select;
+import com.eveningoutpost.dexdrip.Home;
 
 import java.util.Date;
+import java.util.Hashtable;
 import java.util.List;
 
 /**
@@ -18,6 +20,8 @@ import java.util.List;
 @Table(name = "UserErrors", id = BaseColumns._ID)
 public class UserError extends Model {
 
+	private final static String TAG = UserError.class.getSimpleName();
+	
     @Column(name = "shortError")
     public String shortError; // Short error message to be displayed on table
 
@@ -151,52 +155,139 @@ public class UserError extends Model {
             new UserError(a, b);
         }
 
-        public static void e(String a, String b, Exception e){
-            android.util.Log.e(a, b, e);
-            new UserError(a, b + "\n" + e.toString());
+        public static void e(String tag, String b, Exception e){
+            android.util.Log.e(tag, b, e);
+            new UserError(tag, b + "\n" + e.toString());
         }
 
-        public static void w(String a, String b){
-            android.util.Log.w(a, b);
-            UserError.UserErrorLow(a, b);
+        public static void w(String tag, String b){
+            android.util.Log.w(tag, b);
+            UserError.UserErrorLow(tag, b);
         }
-        public static void w(String a, String b, Exception e){
-            android.util.Log.w(a, b, e);
-            UserError.UserErrorLow(a, b + "\n" + e.toString());
+        public static void w(String tag, String b, Exception e){
+            android.util.Log.w(tag, b, e);
+            UserError.UserErrorLow(tag, b + "\n" + e.toString());
         }
-        public static void wtf(String a, String b){
-            android.util.Log.wtf(a, b);
-            UserError.UserErrorHigh(a, b);
+        public static void wtf(String tag, String b){
+            android.util.Log.wtf(tag, b);
+            UserError.UserErrorHigh(tag, b);
         }
-        public static void wtf(String a, String b, Exception e){
-            android.util.Log.wtf(a, b, e);
-            UserError.UserErrorHigh(a, b + "\n" + e.toString());
+        public static void wtf(String tag, String b, Exception e){
+            android.util.Log.wtf(tag, b, e);
+            UserError.UserErrorHigh(tag, b + "\n" + e.toString());
         }
-        public static void wtf(String a, Exception e){
-            android.util.Log.wtf(a, e);
-            UserError.UserErrorHigh(a, e.toString());
-        }
-
-        public static void uel(String a, String b) {
-            android.util.Log.i(a, b);
-            UserError.UserEventLow(a, b);
+        public static void wtf(String tag, Exception e){
+            android.util.Log.wtf(tag, e);
+            UserError.UserErrorHigh(tag, e.toString());
         }
 
-        public static void ueh(String a, String b) {
-            android.util.Log.i(a, b);
-            UserError.UserEventHigh(a, b);
+        public static void uel(String tag, String b) {
+            android.util.Log.i(tag, b);
+            UserError.UserEventLow(tag, b);
         }
 
-        public static void d(String a, String b){
-            android.util.Log.d(a, b);
+        public static void ueh(String tag, String b) {
+            android.util.Log.i(tag, b);
+            UserError.UserEventHigh(tag, b);
         }
 
-        public static void v(String a, String b){
-            android.util.Log.v(a, b);
+        public static void d(String tag, String b){
+            android.util.Log.d(tag, b);
+        	if(ExtraLogTags.shouldLogTag(tag, android.util.Log.DEBUG)) {
+        		UserErrorLow(tag, b);
+        	}
         }
 
-        public static void i(String a, String b){
-            android.util.Log.i(a, b);
+        public static void v(String tag, String b){
+            android.util.Log.v(tag, b);
+        	if(ExtraLogTags.shouldLogTag(tag, android.util.Log.VERBOSE)) {
+        		UserErrorLow(tag, b);
+        	}           
         }
+
+        public static void i(String tag, String b){
+            android.util.Log.i(tag, b);
+        	if(ExtraLogTags.shouldLogTag(tag, android.util.Log.INFO)) {
+        		UserErrorLow(tag, b);
+        	}
+        }
+        
+        static ExtraLogTags extraLogTags = new ExtraLogTags();
+    }
+    
+    public static class ExtraLogTags {
+    	
+    	
+    	static Hashtable <String, Integer> extraTags;
+    	ExtraLogTags () {
+    		extraTags = new Hashtable <String, Integer>();
+    		String extraLogs = Home.getPreferencesStringDefaultBlank("extra_tags_for_logging");
+    		readPreference(extraLogs);
+    	}
+    	
+    	/*
+    	 * This function reads a string representing tags that the user wants to log
+    	 * Format of string is tag1:level1,tag2,level2
+    	 * Example of string is Alerts:i,BG:W
+    	 * 
+    	 */
+    	public static void readPreference(String extraLogs) {
+    		Log.e("dddd", "called " +  extraLogs);
+    		extraTags.clear();
+    		
+    		String []tags = extraLogs.split(",");
+            if(tags.length == 0) {
+                Log.e("dddd", "Error no tags were found " + extraLogs);
+                return;
+            }
+            
+            // go over all tags and parse them
+            for(String tag : tags) {
+            	parseTag(tag);
+            }
+    	}
+    	
+    	static void parseTag(String tag) {
+    		// Format is tag:level for example  Alerts:i
+    		String[] tagAndLevel = tag.split(":");
+    		if(tagAndLevel.length != 2) {
+    			Log.e(TAG, "Failed to parse " + tag);
+    			return;
+    		}
+    		String level =  tagAndLevel[1];
+    		String tagName = tagAndLevel[0].toLowerCase();
+    		if (level.compareTo("d") == 0) {
+    			extraTags.put(tagName, android.util.Log.DEBUG);
+    			android.util.Log.e("dddd","Adding tag with DEBUG " + tagAndLevel[0] );
+    			return;
+    		}
+    		if (level.compareTo("v") == 0) {
+    			extraTags.put(tagName, android.util.Log.VERBOSE);
+    			android.util.Log.e("dddd","Adding tag with VERBOSE " + tagAndLevel[0] );
+    			return;
+    		}
+    		if (level.compareTo("i") == 0) {
+    			extraTags.put(tagName, android.util.Log.INFO);
+    			android.util.Log.e("dddd","Adding tag with info " + tagAndLevel[0] );
+    			return;
+    		}
+    		android.util.Log.e(TAG, "Unknown level for tag " + tag + " please use d v or i");
+
+    	}
+    	
+    	static boolean shouldLogTag(String tag, int level) {
+    		Integer levelForTag = extraTags.get(tag.toLowerCase());
+    		if(levelForTag == null) {
+    			android.util.Log.e("dddd", "Tag not found returning false" + tag);
+    			return false;
+    		}
+    		
+    		if(level >= levelForTag) {
+    			return true;
+    		}
+    		
+    		return false;
+    	}
+    	
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -34,6 +34,7 @@ import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.Profile;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
+import com.eveningoutpost.dexdrip.Models.UserError.ExtraLogTags;
 import com.eveningoutpost.dexdrip.NFCReaderX;
 import com.eveningoutpost.dexdrip.ParakeetHelper;
 import com.eveningoutpost.dexdrip.R;
@@ -739,6 +740,7 @@ public class Preferences extends PreferenceActivity {
             final PreferenceCategory alertsCategory = (PreferenceCategory) findPreference("alerts_category");
             final Preference disableAlertsStaleDataMinutes = findPreference("disable_alerts_stale_data_minutes");
             final Preference widgetRangeLines = findPreference("widget_range_lines");
+            final Preference extraTagsForLogs = findPreference("extra_tags_for_logging");
 
             disableAlertsStaleDataMinutes.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
@@ -1214,8 +1216,14 @@ public class Preferences extends PreferenceActivity {
                     return true;
                 }
             });
-
-
+            
+            extraTagsForLogs.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                	ExtraLogTags.readPreference((String)newValue);
+                    return true;
+                }
+            });
             bindPreferenceSummaryToValue(transmitterId);
             transmitterId.getEditText().setFilters(new InputFilter[]{new InputFilter.AllCaps()});
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,6 +218,9 @@
     <string name="run_collector_in_foreground">Run Collector in foreground</string>
     <string name="shows_a_persistent_notification">Shows a persistent notification graph, visible on lock-screen and prevents android killing the service.</string>
     <string name="list_of_receivers">List of recievers</string>
+    <string name="extra_tags_for_logging">Extra tags for logging</string>
+    <string name="extra_tags_dialog_message">The tags entered here will be logged into xDrip. Format is tag:level. Level can be v,d,i. For example bgreading:i,DexCollectionService:v. This tags will be logged with low priority to Erroe and event list.</string>
+    <string name="extra_tags_dialog_title">Enter more tags to be logged</string>
     <string name="data_source_settings">Data Source Settings</string>
     <string name="smart_watch_features">Smart Watch Features</string>
     <string name="wear_integration">Wear Integration</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -154,6 +154,13 @@
                     android:targetClass="com.eveningoutpost.dexdrip.ErrorsActivity"
                     android:targetPackage="@string/local_target_package" />
             </Preference>
+            <EditTextPreference
+            android:defaultValue=""
+            android:dialogMessage="@string/extra_tags_dialog_message"
+            android:dialogTitle="@string/extra_tags_dialog_title"
+            android:inputType="textUri"
+            android:key="extra_tags_for_logging"
+            android:title="@string/extra_tags_for_logging"/>
         <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
             android:key="xdrip_speak_readings_settings"
             android:icon="@drawable/ic_speak_reading_grey600_48dp"


### PR DESCRIPTION
This is needed if the user has a problem in some component and we want to allow him to send more logs without creating a private build for him.

Once approved I'll remove the logs with tag "dddd" that were used to debug this code.

Tested by logging different log components.