### PR TITLE
Race condition workaround for predictive alert

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -666,7 +666,7 @@ public class BgGraphBuilder {
         return lines;
     }
 
-    private void addBgReadingValues() {
+    public void addBgReadingValues() {
        //UserError.Log.i(TAG, "ADD BG READINGS START");
         filteredValues.clear();
         rawInterpretedValues.clear();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -558,8 +558,16 @@ public class Notifications extends IntentService {
     }
 
     private void evaluateLowPredictionAlarm() {
+
+        if (!prefs.getBoolean("predict_lows_alarm", false)) return;
+
+
+        // force BgGraphBuilder to calculate `low_occurs_at` and `last_noise`
+        // Workaround trying to resolve race donditions as by design they are static but updated/read asynchronously.
+
+        (new BgGraphBuilder(mContext, System.currentTimeMillis() - 60*60*1000, System.currentTimeMillis() + 5*60*1000,12, true)).addBgReadingValues();
+
         if ((BgGraphBuilder.low_occurs_at > 0) && (BgGraphBuilder.last_noise < BgGraphBuilder.NOISE_TOO_HIGH_FOR_PREDICT)) {
-            if (!prefs.getBoolean("predict_lows_alarm", false)) return;
             final double low_predicted_alarm_minutes = Double.parseDouble(prefs.getString("low_predict_alarm_level", "40"));
             final double now = JoH.ts();
             final double predicted_low_in_mins = (BgGraphBuilder.low_occurs_at - now) / 60000;


### PR DESCRIPTION
This should fix the issue I have that a low prediction alarm is risen even though the trend starts to bend and with the new value in, it should not fire... but still does as it is looking at the old trend/prediction withouth regarding the new value.

NOT TESTED YET!