### PR TITLE
Statistics in History

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
@@ -5,6 +5,8 @@ import android.app.Dialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -158,31 +160,32 @@ public class BGHistory extends ActivityWithMenu {
 
     private void setupStatistics(long from, long to) {
 
-        if ((prefs == null) && (xdrip.getAppContext() != null)) {
-            prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+        if (Home.getPreferencesBoolean("show_history_stats", true)) {
+            StatsResult statsResult = new StatsResult(PreferenceManager.getDefaultSharedPreferences(this.getApplicationContext()), from, to);
+
+            StringBuilder sb = new StringBuilder();
+
+            sb.append(statsResult.getAverageUnitised());
+            sb.append(' ');
+            sb.append(statsResult.getA1cDCCT());
+            sb.append(" | ");
+            sb.append(statsResult.getA1cIFCC(true));
+            sb.append('\n');
+            sb.append(statsResult.getInPercentage());
+            sb.append(' ');
+            sb.append(statsResult.getHighPercentage());
+            sb.append(' ');
+            sb.append(statsResult.getLowPercentage());
+            sb.append('\n');
+            sb.append(statsResult.getCapturePercentage(true));
+            sb.append(' ');
+
+            statisticsTextView.setText(sb);
+            statisticsTextView.setVisibility(View.VISIBLE);
+
+        } else {
+            statisticsTextView.setVisibility(View.GONE);
         }
-        if (prefs==null) return;
-
-        StatsResult statsResult = new StatsResult(PreferenceManager.getDefaultSharedPreferences(this.getApplicationContext()), from, to);
-
-        StringBuilder sb = new StringBuilder();
-
-        sb.append(statsResult.getAverageUnitised());
-        sb.append(' ');
-        sb.append(statsResult.getA1cDCCT());
-        sb.append(" | ");
-        sb.append(statsResult.getA1cIFCC(true));
-        sb.append('\n');
-        sb.append(statsResult.getInPercentage());
-        sb.append(' ');
-        sb.append(statsResult.getHighPercentage());
-        sb.append(' ');
-        sb.append(statsResult.getLowPercentage());
-        sb.append('\n');
-        sb.append(statsResult.getCapturePercentage(true));
-        sb.append(' ');
-
-        statisticsTextView.setText(sb);
     }
 
 
@@ -228,4 +231,28 @@ public class BGHistory extends ActivityWithMenu {
         return days;
     }
 
-}
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_history, menu);
+
+        MenuItem menuItem = menu.findItem(R.id.action_toggle_historystats);
+        menuItem.setChecked(Home.getPreferencesBoolean("show_history_stats", true));
+
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_toggle_historystats) {
+            Home.setPreferencesBoolean("show_history_stats", !Home.getPreferencesBoolean("show_history_stats", true));
+            invalidateOptionsMenu();
+            setupCharts();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+
+
+    }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
@@ -138,7 +138,7 @@ public class BGHistory extends ActivityWithMenu {
 
         Calendar endDate = (GregorianCalendar) date1.clone();
         endDate.add(Calendar.DATE, noDays);
-        int numValues = noDays * (60 / 5) * 24;
+        int numValues = noDays * (60 / 2) * 24; // LimiTTer sample rate 1 per 2 minutes
         BgGraphBuilder bgGraphBuilder = new BgGraphBuilder(this, date1.getTimeInMillis(), endDate.getTimeInMillis(), numValues, false);
 
         chart = (LineChartView) findViewById(R.id.chart);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1843,9 +1843,10 @@ public class Home extends ActivityWithMenu {
                 || prefs.getBoolean("status_line_a1c_ifcc", false
                 || prefs.getBoolean("status_line_in", false))
                 || prefs.getBoolean("status_line_high", false)
-                || prefs.getBoolean("status_line_low", false)) {
+                || prefs.getBoolean("status_line_low", false)
+                || prefs.getBoolean("status_line_capture_percentage", false)) {
 
-            StatsResult statsResult = new StatsResult(prefs);
+            StatsResult statsResult = new StatsResult(prefs, getPreferencesBooleanDefaultFalse("extra_status_stats_24h"));
 
             if (prefs.getBoolean("status_line_avg", false)) {
                 if (extraline.length() != 0) extraline.append(' ');
@@ -1871,11 +1872,10 @@ public class Home extends ActivityWithMenu {
                 if (extraline.length() != 0) extraline.append(' ');
                 extraline.append(statsResult.getLowPercentage());
             }
-        }
-        if (prefs.getBoolean("status_line_capture_percentage", false)) {
-            if (extraline.length() != 0) extraline.append(' ');
-            if (BgGraphBuilder.capturePercentage>-1)
-                extraline.append("Cap: "+JoH.qs(BgGraphBuilder.capturePercentage)+"%");
+            if (prefs.getBoolean("status_line_capture_percentage", false)) {
+                if (extraline.length() != 0) extraline.append(' ');
+                extraline.append(statsResult.getCapturePercentage(false));
+            }
         }
         if (prefs.getBoolean("status_line_time", false)) {
             SimpleDateFormat sdf = new SimpleDateFormat("HH:mm");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
@@ -26,9 +26,14 @@ public class StatsResult {
     private long possibleCaptures;
 
 
-    public StatsResult(SharedPreferences settings) {
-        this(settings, DBSearchUtil.getTodayTimestamp(), System.currentTimeMillis());
+    public StatsResult(SharedPreferences settings, boolean sliding24Hours) {
+        this(settings, sliding24Hours, System.currentTimeMillis());
     }
+
+    public StatsResult(SharedPreferences settings, boolean sliding24Hours, long to) {
+        this(settings, sliding24Hours?DBSearchUtil.getTodayTimestamp():to-(24*60*60*1000), to);
+    }
+
 
     public StatsResult(SharedPreferences settings, long from, long to){
         this.from = from;
@@ -73,6 +78,8 @@ public class StatsResult {
         if ((to - from) % (5*60*1000) != 0) possibleCaptures += 1;
 
     }
+
+
 
     public int getAbove() {
         return above;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
@@ -23,15 +23,16 @@ public class StatsResult {
     private final boolean mgdl;
     private final long from;
     private final long to;
+    private long possibleCaptures;
 
 
     public StatsResult(SharedPreferences settings) {
         this(settings, DBSearchUtil.getTodayTimestamp(), System.currentTimeMillis());
     }
 
-        public StatsResult(SharedPreferences settings, long from, long to){
-            this.from = from;
-            this.to = to;
+    public StatsResult(SharedPreferences settings, long from, long to){
+        this.from = from;
+        this.to = to;
 
         mgdl = "mgdl".equals(settings.getString("units", "mgdl"));
 
@@ -67,6 +68,9 @@ public class StatsResult {
             avg = 0;
         }
 
+        possibleCaptures = (to - from) / (5*60*1000);
+        //while already in the next 5 minutes, a package could already have arrived.
+        if ((to - from) % (5*60*1000) != 0) possibleCaptures += 1;
 
     }
 
@@ -90,6 +94,8 @@ public class StatsResult {
         return in + above + below;
     }
 
+    public long getPossibleCaptures() {return possibleCaptures;}
+
     public String getInPercentage(){
         return "in:" +  ((getTotalReadings()>0)?(in*100/getTotalReadings()) + "%":"-%");
     }
@@ -107,9 +113,13 @@ public class StatsResult {
         return "A1c:" + (Math.round(10 * (avg + 46.7) / 28.7) / 10d) + "%";
     }
 
-    public String getA1cIFCC(){
-        if(getTotalReadings()==0) return "A1c:?%";
-        return "A1c:" + ((int) Math.round(((avg + 46.7) / 28.7 - 2.15) * 10.929));
+    public String getA1cIFCC() {
+        return getA1cIFCC(false);
+    }
+
+        public String getA1cIFCC(boolean shortVersion){
+        if(getTotalReadings()==0) return "A1c:?";
+        return (shortVersion?"":"A1c:") + ((int) Math.round(((avg + 46.7) / 28.7 - 2.15) * 10.929));
     }
 
     public String getAverageUnitised(){
@@ -118,10 +128,14 @@ public class StatsResult {
         return "Avg:" + (new DecimalFormat("#.0")).format(avg*Constants.MGDL_TO_MMOLL);
     }
 
-    public String getCapturePercentage(){
-        //while already in the first 5 minutes, a package could already have arrived.
-        long possibleCaptures = (to - from) / 5*60*1000 + 1;
-        return "Cap:" +  ((possibleCaptures>0)?Math.round(getTotalReadings()*100d/possibleCaptures) + "%":"-%");
+    public String getCapturePercentage(boolean extended){
+        String result =  "Cap:" + ((possibleCaptures>0)?Math.round(getTotalReadings()*100d/possibleCaptures) + "%":"-%");
+
+        if (extended) {
+            result += " (" + getTotalReadings() +  "/" +  getPossibleCaptures() + ")";
+        }
+
+        return result;
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
@@ -31,7 +31,7 @@ public class StatsResult {
     }
 
     public StatsResult(SharedPreferences settings, boolean sliding24Hours, long to) {
-        this(settings, sliding24Hours?DBSearchUtil.getTodayTimestamp():to-(24*60*60*1000), to);
+        this(settings, sliding24Hours?to-(24*60*60*1000):DBSearchUtil.getTodayTimestamp(), to);
     }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -738,8 +738,8 @@ public class Preferences extends PreferenceActivity {
             final PreferenceScreen calibrationAlertsScreen = (PreferenceScreen) findPreference("calibration_alerts_screen");
             final PreferenceCategory alertsCategory = (PreferenceCategory) findPreference("alerts_category");
             final Preference disableAlertsStaleDataMinutes = findPreference("disable_alerts_stale_data_minutes");
-            final Preference widgetRangeLines = findPreference("widget_range_lines");
-            final Preference adrian_calibration_mode = findPreference("xdrip_plus_motion_settings");
+            final PreferenceScreen lessCommonScreen = (PreferenceScreen) findPreference("xdrip_less_common_settings");
+            final Preference adrian_calibration_mode = findPreference("adrian_calibration_mode");
 
             disableAlertsStaleDataMinutes.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
@@ -974,7 +974,7 @@ public class Preferences extends PreferenceActivity {
 
                 if (!engineering_mode) {
                     getPreferenceScreen().removePreference(motionScreen);
-                    getPreferenceScreen().removePreference(adrian_calibration_mode);
+                    lessCommonScreen.removePreference(adrian_calibration_mode);
                 }
 
             } catch (NullPointerException e) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -739,7 +739,7 @@ public class Preferences extends PreferenceActivity {
             final PreferenceCategory alertsCategory = (PreferenceCategory) findPreference("alerts_category");
             final Preference disableAlertsStaleDataMinutes = findPreference("disable_alerts_stale_data_minutes");
             final Preference widgetRangeLines = findPreference("widget_range_lines");
-            final Preference adrian_calibration_mode = (Preference) findPreference("xdrip_plus_motion_settings");
+            final Preference adrian_calibration_mode = findPreference("xdrip_plus_motion_settings");
 
             disableAlertsStaleDataMinutes.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
@@ -1205,19 +1205,6 @@ public class Preferences extends PreferenceActivity {
 
             bindWidgetUpdater();
 
-
-            widgetRangeLines.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-                @Override
-                public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    Context context = preference.getContext();
-                    if(AppWidgetManager.getInstance(context).getAppWidgetIds(new ComponentName(context, xDripWidget.class)).length > 0){
-                        context.startService(new Intent(context, WidgetUpdateService.class));
-                    }
-                    return true;
-                }
-            });
-
-
             bindPreferenceSummaryToValue(transmitterId);
             transmitterId.getEditText().setFilters(new InputFilter[]{new InputFilter.AllCaps()});
 
@@ -1363,6 +1350,9 @@ public class Preferences extends PreferenceActivity {
             findPreference("status_line_high").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("status_line_low").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("extra_status_line").setOnPreferenceChangeListener(new WidgetListener());
+            findPreference("status_line_capture_percentage").setOnPreferenceChangeListener(new WidgetListener());
+            findPreference("extra_status_stats_24h").setOnPreferenceChangeListener(new WidgetListener());
+
         }
 
         private void update_force_english_title(String param) {

--- a/app/src/main/res/layout/activity_bghistory.xml
+++ b/app/src/main/res/layout/activity_bghistory.xml
@@ -33,6 +33,23 @@
                     android:layout_height="match_parent"
                     android:layout_below="@+id/buttonlayout"/>
 
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:id="@+id/historystats"
+                    android:paddingEnd="10dp"
+                    android:paddingStart="10dp"
+                    android:gravity="left|top"
+                    android:text="History Statistics"
+                    android:background="@android:color/transparent"
+                    android:layout_below="@+id/buttonlayout"
+                    android:shadowColor="#ff212121"
+                    android:shadowDx="0"
+                    android:shadowDy="0"
+                    android:shadowRadius="14"
+                    android:layout_alignParentStart="true" />
+
                 <LinearLayout
                     android:id="@+id/buttonlayout"
                     android:orientation="horizontal"

--- a/app/src/main/res/menu/menu_history.xml
+++ b/app/src/main/res/menu/menu_history.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:id="@+id/action_toggle_historystats"
+        android:title="@string/statistics"
+        android:checkable="true"
+        android:orderInCategory="1"
+        android:visible="true"/>
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -500,5 +500,7 @@
     <string name="short_off_text_for_switches">OFF</string>
     <string name="short_on_text_for_switches">ON</string>
     <string name="install_pebble_apps">Install Pebble Apps</string>
+    <string name="sliding_24_hour_window_summary">Use last 24 hours instead of time since midnight for statistics.</string>
+    <string name="sliding_24_hour_window">Sliding Window</string>
 
 </resources>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -277,6 +277,14 @@
                     android:key="extra_status_line"
                     android:summary="@string/additional_text_status"
                     android:title="@string/extra_status_line" />
+                <SwitchPreference
+                    android:switchTextOff="@string/short_off_text_for_switches"
+                    android:switchTextOn="@string/short_on_text_for_switches"
+                    android:defaultValue="false"
+                    android:dependency="extra_status_line"
+                    android:key="extra_status_stats_24h"
+                    android:summary="@string/sliding_24_hour_window_summary"
+                    android:title="@string/sliding_24_hour_window" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:dependency="extra_status_line"


### PR DESCRIPTION
I've added a small statistics overlay in the History:
![screenshot_2016-10-03-13-57-26](https://cloud.githubusercontent.com/assets/9692866/19036905/5313b9fa-8973-11e6-9878-aa9df441d6fc.png)
It can be enabled/disabled from the menu (for small screen phones e.g.):

![screenshot_2016-10-03-13-57-32](https://cloud.githubusercontent.com/assets/9692866/19036917/6d05850a-8973-11e6-9f66-69656e65fb8e.png)
![screenshot_2016-10-03-13-57-38](https://cloud.githubusercontent.com/assets/9692866/19036923/737de8a0-8973-11e6-9008-103de28b128f.png)

I checked that the values shown for "Yesterday" are the same as in the statistics activity.