### PR TITLE
enter notes via snackbar in history

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
@@ -156,7 +156,7 @@ public class BGHistory extends ActivityWithMenu {
         previewChart.setZoomType(ZoomType.HORIZONTAL);
 
         chart.setLineChartData(bgGraphBuilder.lineData());
-        chart.setOnValueTouchListener(bgGraphBuilder.getOnValueSelectTooltipListener(false));
+        chart.setOnValueTouchListener(bgGraphBuilder.getOnValueSelectTooltipListener(this));
         previewChart.setLineChartData(bgGraphBuilder.previewLineData(chart.getLineChartData()));
 
         previewChart.setViewportCalculationEnabled(true);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1418,7 +1418,7 @@ public class Home extends ActivityWithMenu {
         previewChart = (PreviewLineChartView) findViewById(R.id.chart_preview);
 
         chart.setLineChartData(bgGraphBuilder.lineData());
-        chart.setOnValueTouchListener(bgGraphBuilder.getOnValueSelectTooltipListener(true));
+        chart.setOnValueTouchListener(bgGraphBuilder.getOnValueSelectTooltipListener(mActivity));
 
         previewChart.setBackgroundColor(getCol(X.color_home_chart_background));
         previewChart.setZoomType(ZoomType.HORIZONTAL);
@@ -2299,7 +2299,7 @@ public class Home extends ActivityWithMenu {
                             Home.startHomeWithExtra(xdrip.getAppContext(), Home.CREATE_TREATMENT_NOTE, Long.toString(timestamp), Double.toString(position));
                         }
                     };
-                    Home.snackBar(getString(R.string.added)+":    " + treatment_text, mOnClickListener);
+                    Home.snackBar(getString(R.string.added)+":    " + treatment_text, mOnClickListener, mActivity);
                 }
 
                 if (getPreferencesBooleanDefaultFalse("default_to_voice_notes")) showcasemenu(SHOWCASE_NOTE_LONG);
@@ -2566,11 +2566,11 @@ public class Home extends ActivityWithMenu {
         }
     }
 
-    public static void snackBar(String message, View.OnClickListener mOnClickListener) {
+    public static void snackBar(String message, View.OnClickListener mOnClickListener, Activity activity) {
 
         android.support.design.widget.Snackbar.make(
 
-                mActivity.findViewById(android.R.id.content),
+                activity.findViewById(android.R.id.content),
                 message, android.support.design.widget.Snackbar.LENGTH_LONG)
                 .setAction(R.string.add_note, mOnClickListener)
                 //.setActionTextColor(Color.RED)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -1,5 +1,6 @@
 package com.eveningoutpost.dexdrip.UtilityModels;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
@@ -1564,17 +1565,17 @@ public class BgGraphBuilder {
         }
     }
 
-    public OnValueSelectTooltipListener getOnValueSelectTooltipListener(boolean interactive) {
-        return new OnValueSelectTooltipListener(interactive);
+    public OnValueSelectTooltipListener getOnValueSelectTooltipListener(Activity callerActivity) {
+        return new OnValueSelectTooltipListener(callerActivity);
     }
 
     public class OnValueSelectTooltipListener implements LineChartOnValueSelectListener {
 
         private Toast tooltip;
-        private boolean interactive;
+        private Activity callerActivity;
 
-        public OnValueSelectTooltipListener(boolean interactive) {
-            this.interactive = interactive;
+        public OnValueSelectTooltipListener(Activity callerActivity) {
+            this.callerActivity = callerActivity;
         }
 
         @Override
@@ -1606,25 +1607,15 @@ public class BgGraphBuilder {
             } else {
                 message = timeFormat.format(time) + "      " + (Math.round(pointValue.getY() * 10) / 10d) + " "+unit() +  filtered;
             }
-            if (interactive) {
-                final View.OnClickListener mOnClickListener = new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        Home.startHomeWithExtra(xdrip.getAppContext(), Home.CREATE_TREATMENT_NOTE, time.toString(), Double.toString(ypos));
-                    }
-                };
-                Home.snackBar(message, mOnClickListener);
-            } else {
 
-                if (tooltip != null) {
-                    tooltip.cancel();
+            final View.OnClickListener mOnClickListener = new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    Home.startHomeWithExtra(xdrip.getAppContext(), Home.CREATE_TREATMENT_NOTE, time.toString(), Double.toString(ypos));
                 }
+            };
+            Home.snackBar(message, mOnClickListener, callerActivity);
 
-                tooltip = Toast.makeText(context, message, Toast.LENGTH_LONG);
-                View view = tooltip.getView();
-                view.setBackgroundColor(getCol(X.color_home_chart_background));
-                tooltip.show();
-            }
         }
 
         @Override


### PR DESCRIPTION
In this PR I re-introduced the tooltips for the History as the snackbar was not working:
https://github.com/NightscoutFoundation/xDrip/pull/3/files

In fact it just would have needed the right activity to show the snackbar on.
Now it is possible to enter notes from History as well. (Tested, that funciotnality in Home stays the same).