### PR TITLE
Import re-raise alerts from xdrip.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/AlertType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/AlertType.java
@@ -22,6 +22,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -152,7 +153,7 @@ public class AlertType extends Model {
      * In the case of "unclear state" for more than predefined time, return the "55" alert
      * In case that alerts are turned off, only return the 55.
      */
-    public static AlertType get_highest_active_alert(Context context, double bg) {
+    public static AlertType get_highest_active_alert(Context context, double bg, AtomicBoolean unclearReading) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         if(prefs.getLong("alerts_disabled_until", 0) > new Date().getTime()){
             Log.d("NOTIFICATIONS", "Notifications are currently disabled!!");
@@ -171,6 +172,7 @@ public class AlertType extends Model {
         AlertType at;
         if (UnclearTime >= UnclearTimeSetting && bg_unclear_readings_alerts ) {
             Log.d("NOTIFICATIONS", "Readings have been unclear for too long!!");
+            unclearReading.set(true);
             Notifications.bgUnclearAlert(context);
         }
         if ((UnclearTime > 0 ) && bg_unclear_readings_alerts) {
@@ -427,15 +429,15 @@ public class AlertType extends Model {
 
 
     public static void testAll(Context context) {
-
+        AtomicBoolean unclearReading = new AtomicBoolean(false);
         remove_all();
         add_alert(null, "high alert 1", true, 180, true, 10, null, 0, 0, true, 20, true, true);
         add_alert(null, "high alert 2", true, 200, true, 10, null, 0, 0, true, 20, true, true);
         add_alert(null, "high alert 3", true, 220, true, 10, null, 0, 0, true, 20, true, true);
         print_all();
-        AlertType a1 = get_highest_active_alert(context, 190);
+        AlertType a1 = get_highest_active_alert(context, 190, unclearReading);
         Log.d(TAG, "a1 = " + a1.toString());
-        AlertType a2 = get_highest_active_alert(context, 210);
+        AlertType a2 = get_highest_active_alert(context, 210, unclearReading);
         Log.d(TAG, "a2 = " + a2.toString());
 
 
@@ -445,11 +447,11 @@ public class AlertType extends Model {
         add_alert(null, "low alert 1", false, 80, true, 10, null, 0, 0, true, 20, true, true);
         add_alert(null, "low alert 2", false, 60, true, 10, null, 0, 0, true, 20, true, true);
 
-        AlertType al1 = get_highest_active_alert(context, 90);
+        AlertType al1 = get_highest_active_alert(context, 90, unclearReading);
         Log.d(TAG, "al1 should be null  " + al1);
-        al1 = get_highest_active_alert(context, 80);
+        al1 = get_highest_active_alert(context, 80, unclearReading);
         Log.d(TAG, "al1 = " + al1.toString());
-        AlertType al2 = get_highest_active_alert(context, 50);
+        AlertType al2 = get_highest_active_alert(context, 50, unclearReading);
         Log.d(TAG, "al2 = " + al2.toString());
 
         Log.d(TAG, "HigherAlert(a1, a2) = a1?" +  (HigherAlert(a1,a2) == a2));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/AlertType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/AlertType.java
@@ -153,7 +153,7 @@ public class AlertType extends Model {
      * In the case of "unclear state" for more than predefined time, return the "55" alert
      * In case that alerts are turned off, only return the 55.
      */
-    public static AlertType get_highest_active_alert(Context context, double bg, AtomicBoolean unclearReading) {
+    public static AlertType get_highest_active_alert(Context context, double bg) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         if(prefs.getLong("alerts_disabled_until", 0) > new Date().getTime()){
             Log.d("NOTIFICATIONS", "Notifications are currently disabled!!");
@@ -164,21 +164,7 @@ public class AlertType extends Model {
             return null;
         }
 
-        Boolean bg_unclear_readings_alerts = prefs.getBoolean("bg_unclear_readings_alerts", false);
-        Long UnclearTimeSetting = Long.parseLong(prefs.getString("bg_unclear_readings_minutes", "90")) * 60000;
-
-        Long UnclearTime = BgReading.getUnclearTime(UnclearTimeSetting);
-
         AlertType at;
-        if (UnclearTime >= UnclearTimeSetting && bg_unclear_readings_alerts ) {
-            Log.d("NOTIFICATIONS", "Readings have been unclear for too long!!");
-            unclearReading.set(true);
-            Notifications.bgUnclearAlert(context);
-        }
-        if ((UnclearTime > 0 ) && bg_unclear_readings_alerts) {
-            Log.d(TAG_ALERT, "We are in an clear state, but not for too long. Alerts are disabled");
-            return null;
-        }
         at = get_highest_active_alert_helper(bg, prefs);
         if (at != null) {
             Log.d(TAG_ALERT, "get_highest_active_alert_helper returned alert uuid = " + at.uuid + " alert name = " + at.name);
@@ -429,15 +415,14 @@ public class AlertType extends Model {
 
 
     public static void testAll(Context context) {
-        AtomicBoolean unclearReading = new AtomicBoolean(false);
         remove_all();
         add_alert(null, "high alert 1", true, 180, true, 10, null, 0, 0, true, 20, true, true);
         add_alert(null, "high alert 2", true, 200, true, 10, null, 0, 0, true, 20, true, true);
         add_alert(null, "high alert 3", true, 220, true, 10, null, 0, 0, true, 20, true, true);
         print_all();
-        AlertType a1 = get_highest_active_alert(context, 190, unclearReading);
+        AlertType a1 = get_highest_active_alert(context, 190);
         Log.d(TAG, "a1 = " + a1.toString());
-        AlertType a2 = get_highest_active_alert(context, 210, unclearReading);
+        AlertType a2 = get_highest_active_alert(context, 210);
         Log.d(TAG, "a2 = " + a2.toString());
 
 
@@ -447,11 +432,11 @@ public class AlertType extends Model {
         add_alert(null, "low alert 1", false, 80, true, 10, null, 0, 0, true, 20, true, true);
         add_alert(null, "low alert 2", false, 60, true, 10, null, 0, 0, true, 20, true, true);
 
-        AlertType al1 = get_highest_active_alert(context, 90, unclearReading);
+        AlertType al1 = get_highest_active_alert(context, 90);
         Log.d(TAG, "al1 should be null  " + al1);
-        al1 = get_highest_active_alert(context, 80, unclearReading);
+        al1 = get_highest_active_alert(context, 80);
         Log.d(TAG, "al1 = " + al1.toString());
-        AlertType al2 = get_highest_active_alert(context, 50, unclearReading);
+        AlertType al2 = get_highest_active_alert(context, 50);
         Log.d(TAG, "al2 = " + al2.toString());
 
         Log.d(TAG, "HigherAlert(a1, a2) = a1?" +  (HigherAlert(a1,a2) == a2));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -1274,12 +1274,19 @@ public class BgReading extends Model implements ShareUploadableBg {
         return true;
     }
 
+    // Make sure that this function either sets the alert or removes it.
     public static boolean getAndRaiseUnclearReading(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        if(prefs.getLong("alerts_disabled_until", 0) > new Date().getTime()){
+            Log.d("NOTIFICATIONS", "getAndRaiseUnclearReading Notifications are currently disabled!!");
+            UserNotification.DeleteNotificationByType("bg_unclear_readings_alert");
+            return false;
+        }
         
         Boolean bg_unclear_readings_alerts = prefs.getBoolean("bg_unclear_readings_alerts", false);
         if (!bg_unclear_readings_alerts || (!DexCollectionType.hasFiltered())) {
             Log.d(TAG_ALERT, "getUnclearReading returned false since feature is disabled");
+            UserNotification.DeleteNotificationByType("bg_unclear_readings_alert");
             return false;
         }
         Long UnclearTimeSetting = Long.parseLong(prefs.getString("bg_unclear_readings_minutes", "90")) * 60000;
@@ -1291,6 +1298,9 @@ public class BgReading extends Model implements ShareUploadableBg {
             Notifications.bgUnclearAlert(context);
             return true;
         }
+        
+        UserNotification.DeleteNotificationByType("bg_unclear_readings_alert");
+        
         if (UnclearTime > 0 ) {
             Log.d(TAG_ALERT, "We are in an clear state, but not for too long. Alerts are disabled");
             return true;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserNotification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserNotification.java
@@ -160,7 +160,7 @@ public class UserNotification extends Model {
             userNotification.bg_fall_alert = true;
         } else {
             Log.d(TAG,"Saving workaround for: "+type+" "+message);
-            Home.setPreferencesString("UserNotification:timestamp:" + type, JoH.qs((JoH.ts())));
+            Home.setPreferencesString("UserNotification:timestamp:" + type, JoH.qs(timestamp));
             Home.setPreferencesString("UserNotification:message:" + type, message);
            return null;
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserNotification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserNotification.java
@@ -1,7 +1,6 @@
 package com.eveningoutpost.dexdrip.Models;
 
 import android.provider.BaseColumns;
-import android.util.Log;
 
 import com.activeandroid.Model;
 import com.activeandroid.annotation.Column;
@@ -12,6 +11,8 @@ import com.eveningoutpost.dexdrip.Home;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import com.eveningoutpost.dexdrip.Models.UserError.Log;
+import com.eveningoutpost.dexdrip.UtilityModels.AlertPlayer;
 
 /**
  * Created by stephenblack on 11/29/14.
@@ -20,6 +21,8 @@ import java.util.List;
 @Table(name = "Notifications", id = BaseColumns._ID)
 public class UserNotification extends Model {
 
+    // For 'other alerts' this will be the time that the alert should be raised again.
+    // For calibration alerts this is the time that the alert was played.
     @Column(name = "timestamp", index = true)
     public double timestamp;
 
@@ -54,7 +57,7 @@ public class UserNotification extends Model {
             "bg_alert", "calibration_alert", "double_calibration_alert",
             "extra_calibration_alert", "bg_unclear_readings_alert",
             "bg_missed_alerts", "bg_rise_alert", "bg_fall_alert");
-    private final static String TAG = "UserNotification";
+    private final static String TAG = AlertPlayer.class.getSimpleName();
 
 
     public static UserNotification lastBgAlert() {
@@ -124,9 +127,20 @@ public class UserNotification extends Model {
         }
     }
     
-    public static UserNotification create(String message, String type) {
+    public static void snoozeAlert(String type, long snoozeMinutes) {
+        UserNotification userNotification = GetNotificationByType(type);
+        if(userNotification == null) {
+            Log.e(TAG, "Error snoozeAlert did not find an alert for type " + type);
+            return;
+        }
+        userNotification.timestamp = new Date().getTime() + snoozeMinutes * 60000;
+        userNotification.save();
+        
+    }
+    
+    public static UserNotification create(String message, String type, long timestamp) {
         UserNotification userNotification = new UserNotification();
-        userNotification.timestamp = new Date().getTime();
+        userNotification.timestamp = timestamp;
         userNotification.message = message;
         if (type == "bg_alert") {
             userNotification.bg_alert = true;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
@@ -104,7 +104,7 @@ public class MissedReadingService extends IntentService {
         if(userNotification == null) {
             // No active alert exists, should not happen, we have just created it.
         	Log.wtf(TAG, "No active alert exists.");
-            setAlarm(getOtherAlertReraiseSec(context) * 1000, false);
+            setAlarm(getOtherAlertReraiseSec(context, "bg_missed_alerts") * 1000, false);
         } else {
             // we have an alert that should be re-raised on userNotification.timestamp
         	long alarmIn = (long)userNotification.timestamp - now;
@@ -147,13 +147,14 @@ public class MissedReadingService extends IntentService {
         }
     }
     
-    static public long getOtherAlertReraiseSec(Context context) {
+    static public long getOtherAlertReraiseSec(Context context, String alertName) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        boolean enableAlertsReraise = prefs.getBoolean("enable_alerts_reraise", false);
+        boolean enableAlertsReraise = prefs.getBoolean(alertName + "_enable_alerts_reraise" , false);
         if(enableAlertsReraise) {
-            return readPerfsInt(prefs, "other_alerts_reraise_sec", 60);
+            return readPerfsInt(prefs, alertName + "_reraise_sec", 60);
         } else {
-            return 60 * readPerfsInt(prefs, "other_alerts_snooze", 20);
+            int defaultSnooze = readPerfsInt(prefs, "other_alerts_snooze", 20);
+            return 60 * readPerfsInt(prefs, alertName + "_snooze", defaultSnooze);
         }
 
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
@@ -149,8 +149,8 @@ public class MissedReadingService extends IntentService {
     
     static public long getOtherAlertReraiseSec(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        boolean disableAlertsReraise = prefs.getBoolean("disable_alerts_reraise", false);
-        if(disableAlertsReraise) {
+        boolean enableAlertsReraise = prefs.getBoolean("enable_alerts_reraise", false);
+        if(enableAlertsReraise) {
             return readPerfsInt(prefs, "other_alerts_reraise_sec", 60);
         } else {
             return 60 * readPerfsInt(prefs, "other_alerts_snooze", 20);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
@@ -72,14 +72,13 @@ public class MissedReadingService extends IntentService {
         }
 
         bg_missed_minutes =  readPerfsInt(prefs, "bg_missed_minutes", 30);
-        otherAlertSnooze =  readPerfsInt(prefs, "other_alerts_snooze", 20);
         final long now = new Date().getTime();
 
         if (BgReading.getTimeSinceLastReading() >= (bg_missed_minutes * 1000 * 60) &&
                 prefs.getLong("alerts_disabled_until", 0) <= now &&
                 inTimeFrame(prefs)) {
             Notifications.bgMissedAlert(context);
-            checkBackAfterSnoozeTime(now);
+            checkBackAfterSnoozeTime(context, now);
         } else  {
             
             long disabletime = prefs.getLong("alerts_disabled_until", 0) - now;
@@ -99,23 +98,30 @@ public class MissedReadingService extends IntentService {
         return AlertType.s_in_time_frame(allDay, startMinutes, endMinutes);
     }
 
-    public void checkBackAfterSnoozeTime(long now) {
+    private void checkBackAfterSnoozeTime(Context context, long now) {
     	// This is not 100% acurate, need to take in account also the time of when this alert was snoozed.
         UserNotification userNotification = UserNotification.GetNotificationByType("bg_missed_alerts");
         if(userNotification == null) {
-            setAlarm(otherAlertSnooze * 1000 * 60);
+            // No active alert exists, should not happen, we have just created it.
+        	Log.wtf(TAG, "No active alert exists.");
+            setAlarm(getOtherAlertReraiseSec(context) * 1000, false);
         } else {
-            // we have an alert that is snoozed until userNotification.timestamp
-            setAlarm((long)userNotification.timestamp - now + otherAlertSnooze * 1000 * 60);
+            // we have an alert that should be re-raised on userNotification.timestamp
+        	long alarmIn = (long)userNotification.timestamp - now;
+        	if(alarmIn < 0) {
+        		alarmIn = 0;
+        	}
+            setAlarm(alarmIn, true);
         }
     }
 
     public void checkBackAfterMissedTime(long alarmIn) {
-        setAlarm(alarmIn);
+        setAlarm(alarmIn, false);
     }
-
-    public void setAlarm(long alarmIn) {
-        if(alarmIn < 5 * 60 * 1000) {
+    
+    // alarmIn is relative time ms
+    public void setAlarm(long alarmIn, boolean force) {
+        if(!force && (alarmIn < 5 * 60 * 1000)) {
             // No need to check more than once every 5 minutes
             alarmIn = 5 * 60 * 1000;
         }
@@ -139,5 +145,16 @@ public class MissedReadingService extends IntentService {
         } catch (Exception e) {
             return defaultValue;
         }
+    }
+    
+    static public long getOtherAlertReraiseSec(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        boolean disableAlertsReraise = prefs.getBoolean("disable_alerts_reraise", false);
+        if(disableAlertsReraise) {
+            return readPerfsInt(prefs, "other_alerts_reraise_sec", 60);
+        } else {
+            return 60 * readPerfsInt(prefs, "other_alerts_snooze", 20);
+        }
+
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/SnoozeOnNotificationDismissService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/SnoozeOnNotificationDismissService.java
@@ -40,7 +40,12 @@ public class SnoozeOnNotificationDismissService extends IntentService {
            alertType.equals("bg_missed_alerts") ||
            alertType.equals("bg_predict_alert") ||
            alertType.equals("persistent_high_alert")) {
-            snoozeOtherAlert(alertType);
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+            boolean disableAlertsReraise = prefs.getBoolean("disable_alerts_reraise", false);
+            if(disableAlertsReraise) {
+                // Only snooze these alert if it the reraise function is enabled. 
+                snoozeOtherAlert(alertType);
+            }
             return;
         }
         Log.e(TAG, "SnoozeOnNotificationDismissService called for unknown source = " + alertType);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/SnoozeOnNotificationDismissService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/SnoozeOnNotificationDismissService.java
@@ -37,9 +37,7 @@ public class SnoozeOnNotificationDismissService extends IntentService {
             return;
         }
         if(alertType.equals("bg_unclear_readings_alert") || 
-           alertType.equals("bg_missed_alerts") ||
-           alertType.equals("bg_predict_alert") ||
-           alertType.equals("persistent_high_alert")) {
+           alertType.equals("bg_missed_alerts")) {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
             boolean enableAlertsReraise = prefs.getBoolean(alertType + "_enable_alerts_reraise", false);
             if(enableAlertsReraise) {
@@ -48,6 +46,13 @@ public class SnoozeOnNotificationDismissService extends IntentService {
             }
             return;
         }
+        
+        if(alertType.equals("bg_predict_alert") ||
+                alertType.equals("persistent_high_alert")) {
+            Log.wtf(TAG, "SnoozeOnNotificationDismissService called for unsupported type!!! source = " + alertType);
+            
+        }
+        
         Log.e(TAG, "SnoozeOnNotificationDismissService called for unknown source = " + alertType);
     }
     

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/SnoozeOnNotificationDismissService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/SnoozeOnNotificationDismissService.java
@@ -41,7 +41,7 @@ public class SnoozeOnNotificationDismissService extends IntentService {
            alertType.equals("bg_predict_alert") ||
            alertType.equals("persistent_high_alert")) {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-            boolean enableAlertsReraise = prefs.getBoolean("enable_alerts_reraise", false);
+            boolean enableAlertsReraise = prefs.getBoolean(alertType + "_enable_alerts_reraise", false);
             if(enableAlertsReraise) {
                 // Only snooze these alert if it the reraise function is enabled. 
                 snoozeOtherAlert(alertType);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/SnoozeOnNotificationDismissService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/SnoozeOnNotificationDismissService.java
@@ -41,8 +41,8 @@ public class SnoozeOnNotificationDismissService extends IntentService {
            alertType.equals("bg_predict_alert") ||
            alertType.equals("persistent_high_alert")) {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-            boolean disableAlertsReraise = prefs.getBoolean("disable_alerts_reraise", false);
-            if(disableAlertsReraise) {
+            boolean enableAlertsReraise = prefs.getBoolean("enable_alerts_reraise", false);
+            if(enableAlertsReraise) {
                 // Only snooze these alert if it the reraise function is enabled. 
                 snoozeOtherAlert(alertType);
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -338,6 +338,7 @@ public class AlertPlayer {
     }
     private PendingIntent snoozeIntent(Context ctx){
         Intent intent = new Intent(ctx, SnoozeOnNotificationDismissService.class);
+        intent.putExtra("alertType", "bg_alerts");
         return PendingIntent.getService(ctx, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -360,9 +360,9 @@ public class Notifications extends IntentService {
 
         UserNotification userNotification = UserNotification.GetNotificationByType("bg_unclear_readings_alert");
         if (userNotification == null) {
-            // An alert should have already being played, how is this NULL.
-        	Log.wtf(TAG, "No active alert exists.");
-            wakeTimeUnclear = now + MissedReadingService.getOtherAlertReraiseSec(ctx, "bg_unclear_readings_alert") * 1000;
+            // This is the case, that we are in unclear sensor reading, but for small time, so there is no call 
+        	Log.i(TAG, "No active alert exists. returning Long.MAX_VALUE");
+        	return Long.MAX_VALUE;
         } else {
             // This alert is snoozed
             // reminder - userNotification.timestamp is the time that the alert should be played again
@@ -446,8 +446,11 @@ public class Notifications extends IntentService {
 
         
         if(wakeTime < now || wakeTime >=  now + 6 * 60000 ) {
-          Log.e("Notifications" , "ArmTimer recieved a negative time, will fire in 6 minutes");
-          wakeTime = now + 6 * 60000;
+            Log.e("Notifications" , "ArmTimer recieved a negative time, will fire in 6 minutes");
+            wakeTime = now + 6 * 60000;
+        } else if (wakeTime == now) {
+            Log.e("Notifications", "should arm right now, waiting one more second to avoid infinitue loop");
+            wakeTime = now + 1;
         }
         
         AlarmManager alarm = (AlarmManager) getSystemService(ALARM_SERVICE);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -362,7 +362,7 @@ public class Notifications extends IntentService {
         if (userNotification == null) {
             // An alert should have already being played, how is this NULL.
         	Log.wtf(TAG, "No active alert exists.");
-            wakeTimeUnclear = now + MissedReadingService.getOtherAlertReraiseSec(ctx) * 1000;
+            wakeTimeUnclear = now + MissedReadingService.getOtherAlertReraiseSec(ctx, "bg_unclear_readings_alert") * 1000;
         } else {
             // This alert is snoozed
             // reminder - userNotification.timestamp is the time that the alert should be played again
@@ -719,12 +719,12 @@ public class Notifications extends IntentService {
     }
 
     public static void bgUnclearAlert(Context context) {
-        long otherAlertReraiseSec = MissedReadingService.getOtherAlertReraiseSec(context);
+        long otherAlertReraiseSec = MissedReadingService.getOtherAlertReraiseSec(context, "bg_unclear_readings_alert");
         OtherAlert(context, "bg_unclear_readings_alert", "Unclear Sensor Readings" + "  (@" + JoH.hourMinuteString() + ")", uncleanAlertNotificationId, otherAlertReraiseSec);
     }
 
     public static void bgMissedAlert(Context context) {
-        long otherAlertReraiseSec = MissedReadingService.getOtherAlertReraiseSec(context);
+        long otherAlertReraiseSec = MissedReadingService.getOtherAlertReraiseSec(context, "bg_missed_alerts");
         OtherAlert(context, "bg_missed_alerts", "BG Readings Missed" + "  (@" + JoH.hourMinuteString() + ")", missedAlertNotificationId, otherAlertReraiseSec);
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -38,7 +38,7 @@ import com.eveningoutpost.dexdrip.Models.CalibrationRequest;
 import com.eveningoutpost.dexdrip.Models.UserNotification;
 import com.eveningoutpost.dexdrip.Services.ActivityRecognizedService;
 import com.eveningoutpost.dexdrip.Services.MissedReadingService;
-
+import com.eveningoutpost.dexdrip.Services.SnoozeOnNotificationDismissService;
 import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.Models.Sensor;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
@@ -47,6 +47,7 @@ import com.eveningoutpost.dexdrip.xdrip;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.eveningoutpost.dexdrip.UtilityModels.ColorCache.getCol;
 import static com.eveningoutpost.dexdrip.UtilityModels.ColorCache.X;
@@ -111,6 +112,7 @@ public class Notifications extends IntentService {
         PowerManager pm = (PowerManager) getApplicationContext().getSystemService(Context.POWER_SERVICE);
         PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "NotificationsIntent");
         wl.acquire(60000);
+        AtomicBoolean unclearReading = new AtomicBoolean(false);
         try {
             Log.d("Notifications", "Running Notifications Intent Service");
             final Context context = getApplicationContext();
@@ -120,8 +122,8 @@ public class Notifications extends IntentService {
             }
 
             ReadPerfs(context);
-            notificationSetter(context);
-            ArmTimer(context);
+            notificationSetter(context, unclearReading);
+            ArmTimer(context, unclearReading.get());
             context.startService(new Intent(context, MissedReadingService.class));
 
 
@@ -166,7 +168,7 @@ public class Notifications extends IntentService {
  */
 
 
-    private void FileBasedNotifications(Context context) {
+    private void FileBasedNotifications(Context context, AtomicBoolean unclearReading) {
         ReadPerfs(context);
         Sensor sensor = Sensor.currentSensor();
 
@@ -183,8 +185,9 @@ public class Notifications extends IntentService {
         // If the last reading does not have a sensor, or that sensor was stopped.
         // or the sensor was started, but the 2 hours did not still pass? or there is no calibrations.
         // In all this cases, bgReading.calculated_value should be 0.
+        // TODO Tzachi: remove sensor != null once sensor data code is checked in.
         if (((sensor != null) || (Home.get_follower())) && bgReading != null && bgReading.calculated_value != 0) {
-            AlertType newAlert = AlertType.get_highest_active_alert(context, bgReading.calculated_value);
+            AlertType newAlert = AlertType.get_highest_active_alert(context, bgReading.calculated_value, unclearReading);
 
             if (newAlert == null) {
                 Log.d(TAG, "FileBasedNotifications - No active notifcation exists, stopping all alerts");
@@ -273,7 +276,7 @@ public class Notifications extends IntentService {
  * *****************************************************************************************************************
  */
 
-    private void notificationSetter(Context context) {
+    private void notificationSetter(Context context, AtomicBoolean unclearReading) {
         ReadPerfs(context);
         final long end = System.currentTimeMillis() + (60000 * 5);
         final long start = end - (60000 * 60 * 3) - (60000 * 10);
@@ -286,7 +289,7 @@ public class Notifications extends IntentService {
             Log.d("NOTIFICATIONS", "Notifications are currently disabled!!");
             return;
         }
-        FileBasedNotifications(context);
+        FileBasedNotifications(context, unclearReading);
         BgReading.checkForDropAllert(context);
         BgReading.checkForRisingAllert(context);
         BgReading.checkForPersistentHigh();
@@ -338,26 +341,69 @@ public class Notifications extends IntentService {
         }
     }
 
-    private long calcuatleArmTime(Context ctx, long now) {
+    // This is the absolute time, not time from now.
+    private long calcuatleArmTimeUnclearalert(Context ctx, long now, boolean unclearAlert) {
+        if (!unclearAlert) {
+            return Long.MAX_VALUE;
+        }
+        Long wakeTimeUnclear = Long.MAX_VALUE;
 
-        Long wakeTime = Long.MAX_VALUE; // This is the absalute time, not time from now.
+        UserNotification userNotification = UserNotification.GetNotificationByType("bg_unclear_readings_alert");
+        if (userNotification == null) {
+            // An alert should have already being played, how is this NULL.
+        	Log.wtf(TAG, "No active alert exists.");
+            wakeTimeUnclear = now + MissedReadingService.getOtherAlertReraiseSec(ctx) * 1000;
+        } else {
+            // This alert is snoozed
+            // reminder - userNotification.timestamp is the time that the alert should be played again
+            wakeTimeUnclear = (long)userNotification.timestamp;
+        }
+        
+        if(wakeTimeUnclear < now ) {
+            // we should alert now,
+            wakeTimeUnclear = now;
+        }
+        if( wakeTimeUnclear == Long.MAX_VALUE) {
+            // Should not happen
+            Log.e(TAG ,"calcuatleArmTimeUnclearalert wakeTimeUnclear bad value setting it to one minute from now " + new Date(wakeTimeUnclear) + " in " +  ((wakeTimeUnclear - now)/60000d) + " minutes" );
+            return now + 60 * 1000;
+        }
+        Log.w(TAG ,"calcuatleArmTimeUnclearalert returning " + new Date(wakeTimeUnclear) + " in " +  ((wakeTimeUnclear - now)/60000d) + " minutes" );
+        return wakeTimeUnclear;
+    }
+    
+    // This is the absolute time, not time from now.
+    private long calcuatleArmTimeBg(long now) {
+        Long wakeTimeBg = Long.MAX_VALUE;
         ActiveBgAlert activeBgAlert = ActiveBgAlert.getOnly();
         if (activeBgAlert != null) {
             AlertType alert = AlertType.get_alert(activeBgAlert.alert_uuid);
             if (alert != null) {
-                wakeTime = activeBgAlert.next_alert_at ;
-                Log.d(TAG , "ArmTimer waking at: "+ new Date(wakeTime) +" in " +  (wakeTime - now)/60000d + " minutes");
-                if (wakeTime < now) {
+                wakeTimeBg = activeBgAlert.next_alert_at ;
+                Log.d(TAG , "ArmTimer BG alert -waking at: "+ new Date(wakeTimeBg) +" in " +  (wakeTimeBg - now)/60000d + " minutes");
+                if (wakeTimeBg < now) {
                     // next alert should be at least one minute from now.
-                    wakeTime = now + 60000;
+                    wakeTimeBg = now + 60000;
                     Log.w(TAG , "setting next alert to 1 minute from now (no problem right now, but needs a fix someplace else)");
                 }
-
+                
             }
-        } else {
-            // no active alert exists
-            wakeTime = now + 6 * 60000;
         }
+        Log.d("Notifications" , "calcuatleArmTimeBg returning: "+ new Date(wakeTimeBg) +" in " +  (wakeTimeBg - now)/60000d + " minutes");
+        return wakeTimeBg;
+    }
+    
+    
+    
+ // This is the absolute time, not time from now.
+    private long calcuatleArmTime(Context ctx, long now, boolean unclearAlert) {
+        Long wakeTimeBg = calcuatleArmTimeBg(now);
+        Long wakeTimeUnclear = calcuatleArmTimeUnclearalert(ctx, now, unclearAlert);
+        Long wakeTime = Math.min(wakeTimeBg, wakeTimeUnclear);
+        
+        Log.d("Notifications" , "calcuatleArmTimeBg returning: "+ new Date(wakeTime) +" in " +  (wakeTime - now)/60000d + " minutes");
+        return wakeTime;
+
 /*
  *
  *       leaving this code here since this is a code for a more correct calculation
@@ -379,22 +425,17 @@ public class Notifications extends IntentService {
       // All this requires listeners on snooze changes...
       // check when the first alert should be fired. take care of that ???
   */
-        Log.d("Notifications" , "calcuatleArmTime returning: "+ new Date(wakeTime) +" in " +  (wakeTime - now)/60000d + " minutes");
-        return wakeTime;
     }
     
-    private void ArmTimer(Context ctx) {
+    private void ArmTimer(Context ctx, boolean unclearAlert) {
         Calendar calendar = Calendar.getInstance();
         final long now = calendar.getTimeInMillis();
         Log.d("Notifications", "ArmTimer called");
 
-        long wakeTime = calcuatleArmTime(ctx, now);
-        if(wakeTime == Long.MAX_VALUE) {
-          Log.d("Notifications" , "ArmTimer timer will not br armed");
-          return;
-        }
+        long wakeTime = calcuatleArmTime(ctx, now, unclearAlert);
+
         
-        if(wakeTime < now ) {
+        if(wakeTime < now || wakeTime == Long.MAX_VALUE) {
           Log.e("Notifications" , "ArmTimer recieved a negative time, will fire in 6 minutes");
           wakeTime = now + 6 * 60000;
         }
@@ -635,7 +676,7 @@ public class Notifications extends IntentService {
         UserNotification userNotification = UserNotification.lastCalibrationAlert();
         if ((userNotification == null) || (userNotification.timestamp <= ((new Date().getTime()) - (60000 * calibration_snooze)))) {
             if (userNotification != null) { userNotification.delete(); }
-            UserNotification.create("12 hours since last Calibration  (@" + JoH.hourMinuteString() + ")", "calibration_alert");
+            UserNotification.create("12 hours since last Calibration  (@" + JoH.hourMinuteString() + ")", "calibration_alert", new Date().getTime());
             String title = "Calibration Needed";
             String content = "12 hours since last calibration";
             Intent intent = new Intent(mContext, AddCalibration.class);
@@ -647,7 +688,7 @@ public class Notifications extends IntentService {
         UserNotification userNotification = UserNotification.lastDoubleCalibrationAlert();
         if ((userNotification == null) || (userNotification.timestamp <= ((new Date().getTime()) - (60000 * calibration_snooze)))) {
             if (userNotification != null) { userNotification.delete(); }
-            UserNotification.create("Double Calibration", "double_calibration_alert");
+            UserNotification.create("Double Calibration", "double_calibration_alert", new Date().getTime());
             String title = "Sensor is ready";
             String content = getString(R.string.sensor_is_ready_please_enter_double_calibration) + "  (@" + JoH.hourMinuteString() + ")";
             Intent intent = new Intent(mContext, DoubleCalibrationActivity.class);
@@ -659,7 +700,7 @@ public class Notifications extends IntentService {
         UserNotification userNotification = UserNotification.lastExtraCalibrationAlert();
         if ((userNotification == null) || (userNotification.timestamp <= ((new Date().getTime()) - (60000 * calibration_snooze)))) {
             if (userNotification != null) { userNotification.delete(); }
-            UserNotification.create("Extra Calibration Requested", "extra_calibration_alert");
+            UserNotification.create("Extra Calibration Requested", "extra_calibration_alert", new Date().getTime());
             String title = "Calibration Needed";
             String content = "A calibration entered now will GREATLY increase performance" + "  (@" + JoH.hourMinuteString() + ")";
             Intent intent = new Intent(mContext, AddCalibration.class);
@@ -668,15 +709,13 @@ public class Notifications extends IntentService {
     }
 
     public static void bgUnclearAlert(Context context) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        int otherAlertSnooze = MissedReadingService.readPerfsInt(prefs, "other_alerts_snooze", 20);
-        OtherAlert(context, "bg_unclear_readings_alert", "Unclear Sensor Readings" + "  (@" + JoH.hourMinuteString() + ")", uncleanAlertNotificationId, otherAlertSnooze);
+        long otherAlertReraiseSec = MissedReadingService.getOtherAlertReraiseSec(context);
+        OtherAlert(context, "bg_unclear_readings_alert", "Unclear Sensor Readings" + "  (@" + JoH.hourMinuteString() + ")", uncleanAlertNotificationId, otherAlertReraiseSec);
     }
 
     public static void bgMissedAlert(Context context) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        int otherAlertSnooze = MissedReadingService.readPerfsInt(prefs, "other_alerts_snooze", 20);
-        OtherAlert(context, "bg_missed_alerts", "BG Readings Missed" + "  (@" + JoH.hourMinuteString() + ")", missedAlertNotificationId, otherAlertSnooze);
+        long otherAlertReraiseSec = MissedReadingService.getOtherAlertReraiseSec(context);
+        OtherAlert(context, "bg_missed_alerts", "BG Readings Missed" + "  (@" + JoH.hourMinuteString() + ")", missedAlertNotificationId, otherAlertReraiseSec);
     }
 
     public static void RisingAlert(Context context, boolean on) {
@@ -735,14 +774,14 @@ public class Notifications extends IntentService {
         }
     }
 
-    private static void OtherAlert(Context context, String type, String message, int notificatioId, int snooze) {
+    private static void OtherAlert(Context context, String type, String message, int notificatioId, long reraiseSec) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String otherAlertsSound = prefs.getString(type+"_sound",prefs.getString("other_alerts_sound", "content://settings/system/notification_sound"));
         Boolean otherAlertsOverrideSilent = prefs.getBoolean("other_alerts_override_silent", false);
 
-        Log.d(TAG,"OtherAlert called " + type + " " + message + " snooze = " + snooze);
+        Log.d(TAG,"OtherAlert called " + type + " " + message + " reraiseSec = " + reraiseSec);
         UserNotification userNotification = UserNotification.GetNotificationByType(type); //"bg_unclear_readings_alert"
-        if ((userNotification == null) || (userNotification.timestamp <= ((new Date().getTime()) - (60000 * snooze)))) {
+        if ((userNotification == null) || userNotification.timestamp <= new Date().getTime() ) {
             if (userNotification != null) {
                 try {
                     userNotification.delete();
@@ -751,14 +790,18 @@ public class Notifications extends IntentService {
                 }
                 Log.d(TAG, "Delete");
             }
-            UserNotification.create(message, type);
+            UserNotification.create(message, type, new Date().getTime() + reraiseSec * 1000);
+
+            Intent deleteIntent = new Intent(context, SnoozeOnNotificationDismissService.class);
+            deleteIntent.putExtra("alertType", type);
             Intent intent = new Intent(context, Home.class);
             NotificationCompat.Builder mBuilder =
                     new NotificationCompat.Builder(context)
                             .setSmallIcon(R.drawable.ic_action_communication_invert_colors_on)
                             .setContentTitle(message)
                             .setContentText(message)
-                            .setContentIntent(PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT));
+                            .setContentIntent(PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT))
+                            .setDeleteIntent(PendingIntent.getService(context, 0, deleteIntent, PendingIntent.FLAG_UPDATE_CURRENT));
             mBuilder.setVibrate(vibratePattern);
             mBuilder.setLights(0xff00ff00, 300, 1000);
             if (AlertPlayer.notSilencedDueToCall()) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -545,7 +545,6 @@ public class Preferences extends PreferenceActivity {
             bindPreferenceSummaryToValue(findPreference("falling_bg_val"));
             bindPreferenceSummaryToValue(findPreference("rising_bg_val"));
             bindPreferenceSummaryToValue(findPreference("other_alerts_sound"));
-            bindPreferenceSummaryToValueAndEnsureNumeric(findPreference("other_alerts_snooze"));
 
             addPreferencesFromResource(R.xml.pref_data_source);
 
@@ -1602,20 +1601,6 @@ public class Preferences extends PreferenceActivity {
             });
         }
 
-
-        private static Preference.OnPreferenceChangeListener sBgMissedAlertsHandler = new Preference.OnPreferenceChangeListener() {
-            @Override
-            public boolean onPreferenceChange(Preference preference, Object newValue) {
-                Context context = preference.getContext();
-                context.startService(new Intent(context, MissedReadingService.class));
-                return true;
-            }
-        };
-
-
-        private void bindBgMissedAlertsListener() {
-            findPreference("other_alerts_snooze").setOnPreferenceChangeListener(sBgMissedAlertsHandler);
-        }
 
 
         // Will update the widget if any setting relevant to the widget gets changed.

--- a/app/src/main/res/layout/activity_missed_readings.xml
+++ b/app/src/main/res/layout/activity_missed_readings.xml
@@ -74,7 +74,58 @@
                             android:layout_gravity="center"
                             android:gravity="right" />
                         
-                        
+                        <TextView
+                            android:id="@+id/missed_reading_bg_snooze_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="left"
+                            android:text="Number of minutes before raising the same alert after snooze"
+                            android:textSize="15sp"
+                            android:layout_gravity="left"
+                            android:paddingRight="10dp" />
+
+                        <EditText
+                            android:layout_width="101dp"
+                            android:layout_height="wrap_content"
+                            android:inputType="number"
+                            android:ems="10"
+                            android:id="@+id/missed_reading_bg_snooze"
+                            android:autoText="false"
+                            android:text=""
+                            android:singleLine="true"
+                            android:textAlignment="center"
+                            android:textSize="15sp"
+                            android:layout_alignParentStart="true" />
+                        <CheckBox
+                            android:id="@+id/missed_reading_enable_alerts_reraise"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Reraise alerts before snooze time"
+                            android:textSize="15sp"
+                            android:layout_gravity="center"
+                            android:gravity="right" />
+                        <TextView
+                            android:id="@+id/missed_reading_reraise_sec_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="left"
+                            android:text="Alert Reraise time (in SECONDS)"
+                            android:textSize="15sp"
+                            android:layout_gravity="left"
+                            android:paddingRight="10dp" />
+                        <EditText
+                            android:layout_width="101dp"
+                            android:layout_height="wrap_content"
+                            android:inputType="number"
+                            android:ems="10"
+                            android:id="@+id/missed_reading_reraise_sec"
+                            android:autoText="false"
+                            android:text=""
+                            android:singleLine="true"
+                            android:textAlignment="center"
+                            android:textSize="15sp"
+                            android:layout_alignParentStart="true" />
+
                     </LinearLayout>
 
                     <LinearLayout

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -127,6 +127,26 @@
                         android:key="bg_unclear_readings_minutes"
                         android:summary=""
                         android:title="Alert after x minutes of noisy values" />
+                    <EditTextPreference
+                        android:defaultValue="20"
+                        android:dependency="bg_unclear_readings_alerts"
+                        android:key="bg_unclear_readings_alert_snooze"
+                        android:numeric="integer"
+                        android:summary="Number of minutes before raising the same alert after snooze."
+                        android:title="Alert Snooze" />
+                    <CheckBoxPreference
+                        android:dependency="bg_unclear_readings_alerts"
+                        android:key="bg_unclear_readings_alert_enable_alerts_reraise"
+                        android:title="Reraise alerts before snooze time"
+                        android:summary="Reraise the alert if not snoozed sooner"
+                        android:defaultValue="false" />
+                    <EditTextPreference
+                        android:dependency="bg_unclear_readings_alert_enable_alerts_reraise"
+                        android:key="bg_unclear_readings_alert_reraise_sec"
+                        android:title="Alert Reraise time"
+                        android:numeric="integer"
+                        android:summary="Number of SECONDS to pass before raising the same alert."
+                        android:defaultValue="60" />
                 </PreferenceCategory>
 
                 <PreferenceCategory android:title="Falling/Rising BG">
@@ -167,24 +187,6 @@
                         android:defaultValue="false"
                         android:key="other_alerts_override_silent"
                         android:title="Override Silent mode on these alerts" />
-                    <EditTextPreference
-                        android:defaultValue="20"
-                        android:key="other_alerts_snooze"
-                        android:numeric="integer"
-                        android:summary="Number of minutes before raising the same alert after snooze."
-                        android:title="Alert Snooze" />
-                    <CheckBoxPreference
-                        android:key="enable_alerts_reraise"
-                        android:title="Reraise alerts before snooze time"
-                        android:summary="Reraise the alert if not snoozed sooner"
-                        android:defaultValue="false" />
-	                <EditTextPreference
-	                    android:dependency="enable_alerts_reraise"
-	                    android:key="other_alerts_reraise_sec"
-	                    android:title="Alert Reraise time"
-	                    android:numeric="integer"
-	                    android:summary="Number of SECONDS to pass before raising the same alert."
-	                    android:defaultValue="60" />                    
                 </PreferenceCategory>
             </PreferenceScreen>
             <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
@@ -220,6 +222,26 @@
                         android:showSilent="true"
                         android:summary="@string/choose_sound_used_for_persistent_high_alarm"
                         android:title="@string/persistent_high_sound" />
+                    <EditTextPreference
+                        android:defaultValue="20"
+                        android:dependency="persistent_high_alert_enabled"
+                        android:key="persistent_high_alert_snooze"
+                        android:numeric="integer"
+                        android:summary="Number of minutes before raising the same alert after snooze."
+                        android:title="Alert Snooze" />
+                    <CheckBoxPreference
+                        android:key="persistent_high_alert_enable_alerts_reraise"
+                        android:dependency="persistent_high_alert_enabled"
+                        android:title="Reraise alerts before snooze time"
+                        android:summary="Reraise the alert if not snoozed sooner"
+                        android:defaultValue="false" />
+                    <EditTextPreference
+                        android:dependency="persistent_high_alert_enable_alerts_reraise"
+                        android:key="persistent_high_alert_reraise_sec"
+                        android:title="Alert Reraise time"
+                        android:numeric="integer"
+                        android:summary="Number of SECONDS to pass before raising the same alert."
+                        android:defaultValue="60" />
 
                 </PreferenceCategory>
                 <PreferenceCategory
@@ -252,6 +274,26 @@
                         android:showSilent="true"
                         android:summary="@string/choose_sound_used_for_predicted_low_alarm"
                         android:title="@string/predicted_low_sound" />
+                    <EditTextPreference
+                        android:defaultValue="20"
+                        android:dependency="predict_lows"
+                        android:key="bg_predict_alert_snooze"
+                        android:numeric="integer"
+                        android:summary="Number of minutes before raising the same alert after snooze."
+                        android:title="Alert Snooze" />
+                    <CheckBoxPreference
+                        android:key="bg_predict_alert_enable_alerts_reraise"
+                        android:dependency="predict_lows"
+                        android:title="Reraise alerts before snooze time"
+                        android:summary="Reraise the alert if not snoozed sooner"
+                        android:defaultValue="false" />
+                    <EditTextPreference
+                        android:dependency="bg_predict_alert_enable_alerts_reraise"
+                        android:key="bg_predict_alert_reraise_sec"
+                        android:title="Alert Reraise time"
+                        android:numeric="integer"
+                        android:summary="Number of SECONDS to pass before raising the same alert."
+                        android:defaultValue="60" />
                 </PreferenceCategory>
                 <PreferenceCategory android:title="@string/other_xdrip_plus_alerts">
                     <SwitchPreference

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -174,12 +174,12 @@
                         android:summary="Number of minutes before raising the same alert after snooze."
                         android:title="Alert Snooze" />
                     <CheckBoxPreference
-                        android:key="disable_alerts_reraise"
+                        android:key="enable_alerts_reraise"
                         android:title="Reraise alerts before snooze time"
                         android:summary="Reraise the alert if not snoozed sooner"
                         android:defaultValue="false" />
 	                <EditTextPreference
-	                    android:dependency="disable_alerts_reraise"
+	                    android:dependency="enable_alerts_reraise"
 	                    android:key="other_alerts_reraise_sec"
 	                    android:title="Alert Reraise time"
 	                    android:numeric="integer"

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -222,27 +222,6 @@
                         android:showSilent="true"
                         android:summary="@string/choose_sound_used_for_persistent_high_alarm"
                         android:title="@string/persistent_high_sound" />
-                    <EditTextPreference
-                        android:defaultValue="20"
-                        android:dependency="persistent_high_alert_enabled"
-                        android:key="persistent_high_alert_snooze"
-                        android:numeric="integer"
-                        android:summary="Number of minutes before raising the same alert after snooze."
-                        android:title="Alert Snooze" />
-                    <CheckBoxPreference
-                        android:key="persistent_high_alert_enable_alerts_reraise"
-                        android:dependency="persistent_high_alert_enabled"
-                        android:title="Reraise alerts before snooze time"
-                        android:summary="Reraise the alert if not snoozed sooner"
-                        android:defaultValue="false" />
-                    <EditTextPreference
-                        android:dependency="persistent_high_alert_enable_alerts_reraise"
-                        android:key="persistent_high_alert_reraise_sec"
-                        android:title="Alert Reraise time"
-                        android:numeric="integer"
-                        android:summary="Number of SECONDS to pass before raising the same alert."
-                        android:defaultValue="60" />
-
                 </PreferenceCategory>
                 <PreferenceCategory
                     android:summary="When momentum trend indicates a Low would be predicted"
@@ -274,26 +253,6 @@
                         android:showSilent="true"
                         android:summary="@string/choose_sound_used_for_predicted_low_alarm"
                         android:title="@string/predicted_low_sound" />
-                    <EditTextPreference
-                        android:defaultValue="20"
-                        android:dependency="predict_lows"
-                        android:key="bg_predict_alert_snooze"
-                        android:numeric="integer"
-                        android:summary="Number of minutes before raising the same alert after snooze."
-                        android:title="Alert Snooze" />
-                    <CheckBoxPreference
-                        android:key="bg_predict_alert_enable_alerts_reraise"
-                        android:dependency="predict_lows"
-                        android:title="Reraise alerts before snooze time"
-                        android:summary="Reraise the alert if not snoozed sooner"
-                        android:defaultValue="false" />
-                    <EditTextPreference
-                        android:dependency="bg_predict_alert_enable_alerts_reraise"
-                        android:key="bg_predict_alert_reraise_sec"
-                        android:title="Alert Reraise time"
-                        android:numeric="integer"
-                        android:summary="Number of SECONDS to pass before raising the same alert."
-                        android:defaultValue="60" />
                 </PreferenceCategory>
                 <PreferenceCategory android:title="@string/other_xdrip_plus_alerts">
                     <SwitchPreference

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -171,8 +171,20 @@
                         android:defaultValue="20"
                         android:key="other_alerts_snooze"
                         android:numeric="integer"
-                        android:summary="Minimum number of minutes to pass before raising the same alert."
+                        android:summary="Number of minutes before raising the same alert after snooze."
                         android:title="Alert Snooze" />
+                    <CheckBoxPreference
+                        android:key="disable_alerts_reraise"
+                        android:title="Reraise alerts before snooze time"
+                        android:summary="Reraise the alert if not snoozed sooner"
+                        android:defaultValue="false" />
+	                <EditTextPreference
+	                    android:dependency="disable_alerts_reraise"
+	                    android:key="other_alerts_reraise_sec"
+	                    android:title="Alert Reraise time"
+	                    android:numeric="integer"
+	                    android:summary="Number of SECONDS to pass before raising the same alert."
+	                    android:defaultValue="60" />                    
                 </PreferenceCategory>
             </PreferenceScreen>
             <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
Signed-off-by: Tzachi Dar tzachi.dar@gmail.com

This adds the re-raise alerts feature from xdrip.
This is needed since some phones, only play the alert once. 
So, when one is sleeping there is a chance that a single playing of the alert will not wake him.
This feature is off by default (so if the user does not change anything, nothing will happen).
