### PR TITLE
Fix use of android.text.format.DateFormat.format 'kk' represents the hours and not 'HH'.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -444,11 +444,11 @@ public class JoH {
     }
 
     public static String hourMinuteString(long timestamp) {
-        return android.text.format.DateFormat.format("HH:mm", timestamp).toString();
+        return android.text.format.DateFormat.format("kk:mm", timestamp).toString();
     }
 
     public static String dateTimeText(long timestamp) {
-        return android.text.format.DateFormat.format("yyyy-MM-dd HH:mm:ss", timestamp).toString();
+        return android.text.format.DateFormat.format("yyyy-MM-dd kk:mm:ss", timestamp).toString();
     }
 
     public static String dateText(long timestamp) {


### PR DESCRIPTION
This is needed for android 4.2

According to http://stackoverflow.com/questions/16763968/android-text-format-dateformat-hh-is-not-recognized-like-with-java-text-simple
We should use kk and not hh. This only creates a problem on android 4.2 but it is a very simple fix.

Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>