### PR TITLE
If the snooze dialog was not pressed after 120 seconds it will be rem…

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.PowerManager;
 import android.preference.PreferenceManager;
 import android.support.v4.content.LocalBroadcastManager;
@@ -366,8 +367,29 @@ public class GcmActivity extends Activity {
                 dialog.dismiss();
             }
         });
-        AlertDialog alert = builder.create();
+        final AlertDialog alert = builder.create();
         alert.show();
+     // Hide after some seconds
+        final Handler handler  = new Handler();
+        final Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                if (alert.isShowing()) {
+                    alert.dismiss();
+                }
+            }
+        };
+
+        alert.setOnDismissListener(new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialog) {
+                handler.removeCallbacks(runnable);
+            }
+        });
+
+        handler.postDelayed(runnable, 120000);
+        
+        
     }
 
     public static void sendMotionUpdate(final long timestamp, final int activity) {


### PR DESCRIPTION
…oved from the screen.

I have noticed that many times, the confirm remote snooze dialog is not pressed.
This happens when the user dismisses the alerts from the notification dialog, or simply when he just snoozes the alerts and does not look on the tablet any more.

This will close the dialog.

Verified to work, but not really tested through.

Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>