### PR TITLE
Add the data that is received from BT to the printing (in the case th…

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -377,7 +377,7 @@ public class DexCollectionService extends Service {
             wakeLock1.acquire();
             try {
                 final byte[] data = characteristic.getValue();
-                Log.i(TAG, "onCharacteristicChanged entered " + HexDump.dumpHexString(data, 0, data.length));
+                Log.i(TAG, "onCharacteristicChanged entered " + HexDump.dumpHexString(data));
                 if (data != null && data.length > 0) {
                     setSerialDataToTransmitterRawData(data, data.length);
                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -375,8 +375,8 @@ public class DexCollectionService extends Service {
                     "DexCollectionService");
             wakeLock1.acquire();
             try {
-                Log.i(TAG, "onCharacteristicChanged entered");
                 final byte[] data = characteristic.getValue();
+                Log.i(TAG, "onCharacteristicChanged entered " + new String(data));
                 if (data != null && data.length > 0) {
                     setSerialDataToTransmitterRawData(data, data.length);
                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -38,6 +38,7 @@ import android.preference.PreferenceManager;
 
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
+import com.eveningoutpost.dexdrip.ImportedLibraries.usbserial.util.HexDump;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 
@@ -376,7 +377,7 @@ public class DexCollectionService extends Service {
             wakeLock1.acquire();
             try {
                 final byte[] data = characteristic.getValue();
-                Log.i(TAG, "onCharacteristicChanged entered " + new String(data));
+                Log.i(TAG, "onCharacteristicChanged entered " + HexDump.dumpHexString(data, 0, data.length));
                 if (data != null && data.length > 0) {
                     setSerialDataToTransmitterRawData(data, data.length);
                 }


### PR DESCRIPTION
…at we are already printing).

This makes debugging the data that is received from Limitter for example simpler.
Only works when one has already enabled printing on this tag.
Was checked against all bytes. this seems to give good results when ascii text is sent (prints well to our log mechanism).
Negative bytes, are not printed well, but are not part of limiter/ xdrip data.
For some reason it does not print nice to my pc. Probably wrong character set or something similar.