### PR TITLE
Added MissedReadingService RESTART COLLECTOR

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -1289,6 +1289,7 @@ public class WatchUpdaterService extends WearableListenerService implements
             dataMap.putString("falling_bg_val", mPrefs.getString("falling_bg_val", "2"));
             dataMap.putBoolean("rising_alert", mPrefs.getBoolean("rising_alert", false));
             dataMap.putString("rising_bg_val", mPrefs.getString("rising_bg_val", "2"));
+            dataMap.putBoolean("aggressive_service_restart", mPrefs.getBoolean("aggressive_service_restart", false));
 
             //Extra Status Line
             dataMap.putBoolean("extra_status_line", mPrefs.getBoolean("extra_status_line", false));

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -131,6 +131,10 @@
         <service
             android:name=".Services.SnoozeOnNotificationDismissService"
             android:exported="false" />
+        <service
+            android:name=".Services.MissedReadingService"
+            android:enabled="true"
+            android:exported="true" />
         <activity
             android:name=".NWPreferences"
             android:icon="@drawable/ic_icon"

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -434,7 +434,7 @@ public class Home extends BaseWatchFace {
     {
         if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreAlarm) return (60000 * 13);
         if (DexCollectionType.getDexCollectionType() == DexCollectionType.DexcomG5 &&
-            Home.getPreferencesBooleanDefaultFalse("engineering_mode")) return (60000 * 6);
+            Home.getPreferencesBooleanDefaultFalse("engineering_mode")) return (60000 * 5);
         return (60000 * 11);
     }
 }

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
@@ -20,6 +20,8 @@ import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 
 import android.Manifest;
 import android.app.ActivityManager;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothManager;
 import android.bluetooth.BluetoothProfile;
@@ -1338,6 +1340,7 @@ public class ListenerService extends WearableListenerService implements GoogleAp
             prefs.putString("falling_bg_val", dataMap.getString("falling_bg_val", "2"));
             prefs.putBoolean("rising_alert", dataMap.getBoolean("rising_alert", false));
             prefs.putString("rising_bg_val", dataMap.getString("rising_bg_val", "2"));
+            prefs.putBoolean("aggressive_service_restart", dataMap.getBoolean("aggressive_service_restart", false));
             //Step Counter
             prefs.putBoolean("use_wear_health", dataMap.getBoolean("use_wear_health", true));
             //Extra Status Line
@@ -1726,9 +1729,9 @@ public class ListenerService extends WearableListenerService implements GoogleAp
         if (is_using_bt) {
             if (checkLocationPermissions()) {
                 Log.d(TAG, "startBtService start BT Collection Service: " + DexCollectionType.getDexCollectionType());
-                if (restartWatchDog()) {
-                    stopBtService();
-                }
+                //if (restartWatchDog()) {
+                //    stopBtService();
+                //}
                 if (!isCollectorRunning()) {
                     CollectionServiceStarter.startBtService(getApplicationContext());
                     Log.d(TAG, "startBtService AFTER startService mLocationPermissionApproved " + mLocationPermissionApproved);
@@ -1784,6 +1787,11 @@ public class ListenerService extends WearableListenerService implements GoogleAp
         Log.d(TAG, "stopService call stopService");
         CollectionServiceStarter.stopBtService(getApplicationContext());
         Log.d(TAG, "stopBtService should have called onDestroy");
+        AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
+        PendingIntent wakeIntent = PendingIntent.getService(this, 0, new Intent(this, Notifications.class), PendingIntent.FLAG_UPDATE_CURRENT);
+        wakeIntent.cancel();
+        alarmManager.cancel(wakeIntent);
+        Log.d(TAG, "stopBtService cancel Notifications wakeIntent");
     }
 
     public static void requestData(Context context) {

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Services/G5CollectionService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Services/G5CollectionService.java
@@ -652,7 +652,7 @@ public class G5CollectionService extends Service {
                 forceScreenOn();
             }
         }
-        if (JoH.ratelimit("G5-scanlogic", 2)) {
+        if (JoH.ratelimit("G5-scanlogic", 1)) {//KS test change 2 -> 1 to support restart collecter after 6 min missed readings
             try {
                 mLEScanner.stopScan(mScanCallback);
                 isScanning = false;
@@ -1854,6 +1854,7 @@ public class G5CollectionService extends Service {
         Log.e(TAG, "millisecondsSinceTxAd: " + millisecondsSinceTx );
         Log.e(TAG, "advertiseTimeMS.get(0): " + advertiseTimeMS.get(0) + " " + JoH.dateTimeText(advertiseTimeMS.get(0)));
         Log.e(TAG, "timeInMillisecondsOfLastSuccessfulSensorRead: " + " " + timeInMillisecondsOfLastSuccessfulSensorRead + JoH.dateTimeText(timeInMillisecondsOfLastSuccessfulSensorRead) );
+        Log.e(TAG, "getNextAdvertiseTime expectedTxTime: " + expectedTxTime + " " + JoH.dateTimeText(expectedTxTime));
         //Log.e(TAG, "timeToExpected: " + timeToExpected );
         //Log.e(TAG, "expectedTxTime: " + expectedTxTime );
 

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
@@ -1,0 +1,179 @@
+package com.eveningoutpost.dexdrip.Services;
+
+import android.app.IntentService;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.Home;
+import com.eveningoutpost.dexdrip.Models.AlertType;
+import com.eveningoutpost.dexdrip.Models.BgReading;
+import com.eveningoutpost.dexdrip.Models.JoH;
+//import com.eveningoutpost.dexdrip.Models.Reminder;
+import com.eveningoutpost.dexdrip.Models.UserError.Log;
+import com.eveningoutpost.dexdrip.Models.UserNotification;
+import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
+import com.eveningoutpost.dexdrip.UtilityModels.Notifications;
+//import com.eveningoutpost.dexdrip.UtilityModels.pebble.PebbleUtil;
+//import com.eveningoutpost.dexdrip.UtilityModels.pebble.PebbleWatchSync;
+import com.eveningoutpost.dexdrip.utils.DexCollectionType;
+//import com.eveningoutpost.dexdrip.wearintegration.WatchUpdaterService;
+
+import java.util.Date;
+
+//import static com.eveningoutpost.dexdrip.Home.startWatchUpdaterService;
+
+public class MissedReadingService extends IntentService {
+    int otherAlertSnooze;
+    private final static String TAG = MissedReadingService.class.getSimpleName();
+    private static int aggressive_backoff_timer = 120;
+    public MissedReadingService() {
+        super("MissedReadingService");
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        final SharedPreferences prefs;
+        final boolean bg_missed_alerts;
+        final Context context;
+        final int bg_missed_minutes;
+
+
+        context = getApplicationContext();
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        Log.d(TAG, "MissedReadingService onHandleIntent");
+
+        final long stale_millis = Home.stale_data_millis();
+
+        // send to pebble
+        /*if (prefs.getBoolean("broadcast_to_pebble", false) && (PebbleUtil.getCurrentPebbleSyncType(prefs) != 1) && !BgReading.last_within_millis(stale_millis)) {
+            if (JoH.ratelimit("peb-miss",120)) context.startService(new Intent(context, PebbleWatchSync.class));
+            // update pebble even when we don't have data to ensure missed readings show
+        }*/
+
+        /*if ((Home.get_forced_wear()) && prefs.getBoolean("disable_wearG5_on_missedreadings", false)) {
+            int bg_wear_missed_minutes = readPerfsInt(prefs, "disable_wearG5_on_missedreadings_level", 30);
+            if (BgReading.getTimeSinceLastReading() >= (bg_wear_missed_minutes * 1000 * 60)) {
+                Log.d(TAG, "Request WatchUpdaterService to disable force_wearG5 when wear is connected");
+                startWatchUpdaterService(context, WatchUpdaterService.ACTION_DISABLE_FORCE_WEAR, TAG);
+            }
+        }*/
+
+        if ((prefs.getBoolean("aggressive_service_restart", false) || DexCollectionType.isFlakey())) {//!Home.get_enable_wear() &&
+            if (!BgReading.last_within_millis(stale_millis)) {
+                if (JoH.ratelimit("aggressive-restart", aggressive_backoff_timer)) {
+                    Log.e(TAG, "Aggressively restarting collector service due to lack of reception: backoff: "+aggressive_backoff_timer);
+                    if (aggressive_backoff_timer < 1200) aggressive_backoff_timer+=60;
+                    CollectionServiceStarter.startBtService(context);
+                } else {
+                    aggressive_backoff_timer = 120; // reset
+                }
+            }
+        }
+        //Reminder.processAnyDueReminders();
+        //BluetoothGlucoseMeter.immortality();
+
+        bg_missed_alerts =  prefs.getBoolean("bg_missed_alerts", false);//KS TODO bg_missed_alerts pref not supported
+        if (!bg_missed_alerts || !Home.getPreferencesBoolean("bg_notifications", false)) {
+            // we should not do anything in this case. if the ui, changes will be called again
+            return;
+        }
+
+        bg_missed_minutes =  readPerfsInt(prefs, "bg_missed_minutes", 30);
+        final long now = new Date().getTime();
+
+        if (BgReading.getTimeSinceLastReading() >= (bg_missed_minutes * 1000 * 60) &&
+                prefs.getLong("alerts_disabled_until", 0) <= now &&
+                inTimeFrame(prefs)) {
+            Notifications.bgMissedAlert(context);
+            checkBackAfterSnoozeTime(context, now);
+        } else  {
+
+            long disabletime = prefs.getLong("alerts_disabled_until", 0) - now;
+
+            long missedTime = bg_missed_minutes* 1000 * 60 - BgReading.getTimeSinceLastReading();
+            long alarmIn = Math.max(disabletime, missedTime);
+            checkBackAfterMissedTime(alarmIn);
+        }
+    }
+
+    private boolean inTimeFrame(SharedPreferences prefs) {
+        
+        int startMinutes = prefs.getInt("missed_readings_start", 0);
+        int endMinutes = prefs.getInt("missed_readings_end", 0);
+        boolean allDay = prefs.getBoolean("missed_readings_all_day", true);
+
+        return AlertType.s_in_time_frame(allDay, startMinutes, endMinutes);
+    }
+
+    private void checkBackAfterSnoozeTime(Context context, long now) {
+    	// This is not 100% acurate, need to take in account also the time of when this alert was snoozed.
+        UserNotification userNotification = UserNotification.GetNotificationByType("bg_missed_alerts");
+        if(userNotification == null) {
+            // No active alert exists, should not happen, we have just created it.
+        	Log.wtf(TAG, "No active alert exists.");
+            setAlarm(getOtherAlertReraiseSec(context, "bg_missed_alerts") * 1000, false);
+        } else {
+            // we have an alert that should be re-raised on userNotification.timestamp
+        	long alarmIn = (long)userNotification.timestamp - now;
+        	if(alarmIn < 0) {
+        		alarmIn = 0;
+        	}
+            setAlarm(alarmIn, true);
+        }
+    }
+
+    private void checkBackAfterMissedTime(long alarmIn) {
+        setAlarm(alarmIn, false);
+    }
+    
+    // alarmIn is relative time ms
+    public void setAlarm(long alarmIn, boolean force) {
+        if(!force && (alarmIn < 5 * 60 * 1000)) {
+            // No need to check more than once every 5 minutes
+            alarmIn = 5 * 60 * 1000;
+        }
+    	Log.d(TAG, "Setting timer to  " + alarmIn / 60000 + " minutes from now" );
+        //Calendar calendar = Calendar.getInstance();
+        //AlarmManager alarm = (AlarmManager) getSystemService(ALARM_SERVICE);
+        //long wakeTime = calendar.getTimeInMillis() + alarmIn;
+        PendingIntent serviceIntent = PendingIntent.getService(this, 0, new Intent(this, this.getClass()), 0);
+        JoH.wakeUpIntent(this, alarmIn, serviceIntent);
+
+       /* if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarm.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, wakeTime, serviceIntent);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            alarm.setExact(AlarmManager.RTC_WAKEUP, wakeTime, serviceIntent);
+        } else
+            alarm.set(AlarmManager.RTC_WAKEUP, wakeTime, serviceIntent);*/
+    }
+    
+    static public int readPerfsInt(SharedPreferences prefs, String name, int defaultValue) {
+        try {
+            return Integer.parseInt(prefs.getString(name, "" + defaultValue));
+             
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+    
+    static public long getOtherAlertReraiseSec(Context context, String alertName) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        boolean enableAlertsReraise = prefs.getBoolean(alertName + "_enable_alerts_reraise" , false);
+        if(enableAlertsReraise) {
+            return readPerfsInt(prefs, alertName + "_reraise_sec", 60);
+        } else {
+            return 60 * getOtherAlertSnoozeMinutes(prefs, alertName);
+        }
+
+    }
+    
+    static public long getOtherAlertSnoozeMinutes(SharedPreferences prefs, String alertName) {
+        int defaultSnooze = readPerfsInt(prefs, "other_alerts_snooze", 20);
+        return readPerfsInt(prefs, alertName + "_snooze", defaultSnooze);
+    }
+    
+}

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
@@ -270,8 +270,11 @@ public class CollectionServiceStarter {
 
     public static void startBtService(Context context) {
         Log.d(TAG, "startBtService: " + DexCollectionType.getDexCollectionType());
-        stopBtService(context);
+        //stopBtService(context);
         CollectionServiceStarter collectionServiceStarter = new CollectionServiceStarter(context);
+        collectionServiceStarter.stopBtShareService();
+        collectionServiceStarter.stopBtWixelService();
+        collectionServiceStarter.stopG5ShareService();
         switch (DexCollectionType.getDexCollectionType()) {
             case DexcomShare:
                 collectionServiceStarter.startBtShareService();

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -40,7 +40,7 @@ import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.Models.UserNotification;
 import com.eveningoutpost.dexdrip.R;
 //KS import com.eveningoutpost.dexdrip.Services.ActivityRecognizedService;
-//KS import com.eveningoutpost.dexdrip.Services.MissedReadingService;
+import com.eveningoutpost.dexdrip.Services.MissedReadingService;
 import com.eveningoutpost.dexdrip.Services.SnoozeOnNotificationDismissService;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.utils.PowerStateReceiver;
@@ -138,9 +138,11 @@ public class Notifications extends IntentService {
 
                 ReadPerfs(context);
                 unclearReading = notificationSetter(context);
-                ArmTimer(context, unclearReading);
-                //KS context.startService(new Intent(context, MissedReadingService.class));
+                //ArmTimer(context, unclearReading);
+                //context.startService(new Intent(context, MissedReadingService.class));
             }
+            ArmTimer(context, unclearReading);//KS start this to handle Collector restart
+            context.startService(new Intent(context, MissedReadingService.class));//KS start this to handle Collector restart
 
         } finally {
             if (wl.isHeld()) wl.release();

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -497,7 +497,7 @@ public class Notifications extends IntentService {
             Log.e("Notifications" , "ArmTimer recieved a negative time, will fire in 6 minutes");
             wakeTime = now + 6 * 60000;
         } else if  (wakeTime >=  now + 6 * 60000) {
-        	 Log.i("Notifications" , "ArmTimer recieved a biger time, will fire in 6 minutes");
+        	 Log.i("Notifications" , "ArmTimer recieved a bigger time, will fire in 6 minutes");
              wakeTime = now + 6 * 60000;
         }  else if (wakeTime == now) {
             Log.e("Notifications", "should arm right now, waiting one more second to avoid infinitue loop");


### PR DESCRIPTION
I disabled Wear's MissedReadingService alarms for missed readings.  I didn't think it would be a priority at this time.
Also, I noticed that restart always missed the next reading on RESTART and often additional readings.  I think this was because scanning was disabled due to the quick restart intervals (normally scheduled wake up times, then the ArmTimer triggered restart).  So I reduced the timing in scanLogic G5-scanlogic downto 1 from 2, and that allowed the scanning to occur on RESTART.  I also changed Home.stale_data_millis down to 5 minutes (for engineering).  This allows the service to restart right away and not miss the opportunity to get the next reading.  I left non-engineering mode at 11 minutes though.  Perhaps we should reduce it as well?  I left ArmTimer at 6 minutes though.  So now RESTART does not appears to consistently read the next reading upon RESTART.  Also, maybe we want to make these changes on the phone after the watch is more thoroughly tested by others.  Otherwise, the code is ready for your review and merge.