### PR TITLE
DailyIntent Save Database before pruning with new option

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DailyIntentService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DailyIntentService.java
@@ -15,6 +15,7 @@ import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.UtilityModels.BgSendQueue;
 import com.eveningoutpost.dexdrip.UtilityModels.CalibrationSendQueue;
 import com.eveningoutpost.dexdrip.UtilityModels.UploaderQueue;
+import com.eveningoutpost.dexdrip.utils.DatabaseUtil;
 import com.eveningoutpost.dexdrip.utils.Telemetry;
 import com.eveningoutpost.dexdrip.wearintegration.WatchUpdaterService;
 
@@ -37,6 +38,16 @@ public class DailyIntentService extends IntentService {
             if (JoH.pratelimit("daily-intent-service", 60000)) {
                 Log.i(TAG, "DailyIntentService onHandleIntent Starting");
                 Long start = JoH.tsl();
+
+                // @TecMunky -- save database before pruning - allows daily capture of database
+                if (Home.getPreferencesBooleanDefaultFalse("save_db_ondemand")) {
+                    try {
+                        String export = DatabaseUtil.saveSql(getBaseContext(), "daily");
+                    } catch (Exception e) {
+                        Log.e(TAG, "DailyIntentService exception on Daily Save Database - ", e);
+                    }
+                }
+
                 // prune old database records
                 //mPrefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
                 try {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
@@ -47,6 +47,12 @@ public class DatabaseUtil {
     }
 
     public static String saveSql(Context context) {
+        // TecMunky 6/23/17 overload saveSql function to call modified function
+        return DatabaseUtil.saveSql(context, "export");
+    }
+
+    public static String saveSql(Context context, String prefix) {
+        // TecMunky 6/23/17 modify function with added prefix string variable
 
         FileInputStream srcStream = null;
         BufferedInputStream biStream = null;
@@ -64,7 +70,10 @@ public class DatabaseUtil {
 
             final StringBuilder sb = new StringBuilder();
             sb.append(dir);
-            sb.append("/export");
+            //sb.append("/export");
+            // TecMunky 6/23/17 replace "/export" with "/" and prefix
+            sb.append("/");
+            sb.append(prefix);
             sb.append(DateFormat.format("yyyyMMdd-kkmmss", System.currentTimeMillis()));
             sb.append(".zip");
             zipFilename = sb.toString();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
@@ -87,7 +87,7 @@ public class DatabaseUtil {
 
                     foStream = new FileOutputStream(zipOutputFile);
                     zipOutputStream = new ZipOutputStream(new BufferedOutputStream(foStream));
-                    zipOutputStream.putNextEntry(new ZipEntry("export" + DateFormat.format("yyyyMMdd-kkmmss", System.currentTimeMillis()) + ".sqlite"));
+                    zipOutputStream.putNextEntry(new ZipEntry(prefix + DateFormat.format("yyyyMMdd-kkmmss", System.currentTimeMillis()) + ".sqlite"));
 
                     byte buffer[] = new byte[BUFFER_SIZE];
                     int count;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -611,6 +611,8 @@
     <string name="disable_log_transmitter_battery_warning">Disable the warning for low transmitter battery state on the home screen. (Only relevant for DIY receivers.)</string>
     <string name="engineering_mode">Engineering mode</string>
     <string name="allow_unsafe_settings">Allows changing the most unsafe settings which could break everything!</string>
+    <string name="daily_save_db">Save Database Daily</string>
+    <string name="allow_daily_db_save">Allows the Daily Intent Service to save the database before purging</string>
     <string name="options_for_extra_line">Options for the extra line</string>
     <string name="todays_average_value">Today\'s average value.</string>
     <string name="ac1_estimation_dcct">A1c estimation in DCCT format (%)</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -583,6 +583,11 @@
                 android:key="engineering_mode"
                 android:summary="@string/allow_unsafe_settings"
                 android:title="@string/engineering_mode" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="save_db_ondemand"
+                android:summary="@string/allow_daily_db_save"
+                android:title="@string/daily_save_db" />
             <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
                 android:key="xdrip_other_misc_extra_screen"
                 android:summary=""


### PR DESCRIPTION
This change adds a new setting under "less common settings" to "Save Database Daily", modifies the DailyIntentService to execute saveSql when enabled, and overloads the saveSql function in DatabaseUtils.java to allow the name of the zip file to be changed to "daily..." vs "export...". Note that the name of the exported database (in the zip file) is not changed, just the name of the zip file. The strings.xml file is also modified with the strings for the new settings option, while the prefs_advanced_settings.xml file is modified to add the new setting.