### PR TITLE
noise ultrasensitive mode

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
@@ -203,10 +203,7 @@ public class BestGlucose {
         }
 
         // TODO Noise uses plugin in bggraphbuilder
-        if ((BgGraphBuilder.last_noise > BgGraphBuilder.NOISE_TRIGGER)
-                && (BgGraphBuilder.best_bg_estimate > 0)
-                && (BgGraphBuilder.last_bg_estimate > 0)
-                && (prefs.getBoolean("bg_compensate_noise", false))) {
+        if (compensateNoise()) {
             estimate = BgGraphBuilder.best_bg_estimate; // this maybe needs scaling based on noise intensity
             estimated_delta = BgGraphBuilder.best_bg_estimate - BgGraphBuilder.last_bg_estimate;
             // TODO handle ratio when period is not dexcom period?
@@ -280,6 +277,17 @@ public class BestGlucose {
         if (d)
             Log.d(TAG, "dg result: " + dg.unitized + " previous: " + BgGraphBuilder.unitized_string(previous_estimate, doMgdl));
         return dg;
+    }
+
+    protected static boolean compensateNoise() {
+        return (BgGraphBuilder.last_noise > BgGraphBuilder.NOISE_TRIGGER
+                || (BgGraphBuilder.last_noise > BgGraphBuilder.NOISE_TRIGGER_ULTRASENSITIVE
+                        && Home.getPreferencesBooleanDefaultFalse("engineering_mode")
+                        && Home.getPreferencesBooleanDefaultFalse("bg_compensate_noise_ultrasensitive")
+                ))
+                && (BgGraphBuilder.best_bg_estimate > 0)
+                && (BgGraphBuilder.last_bg_estimate > 0)
+                && (prefs.getBoolean("bg_compensate_noise", false));
     }
 
     public static String unitizedDeltaString(boolean showUnit, boolean highGranularity, boolean doMgdl, double value1, long timestamp1, double value2, long timestamp2) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2594,10 +2594,7 @@ public class Home extends ActivityWithMenu {
                 }
 
                 // TODO this should be partially already be covered by dg - recheck
-                if ((BgGraphBuilder.last_noise > BgGraphBuilder.NOISE_TRIGGER)
-                        && (BgGraphBuilder.best_bg_estimate > 0)
-                        && (BgGraphBuilder.last_bg_estimate > 0)
-                        && (prefs.getBoolean("bg_compensate_noise", false))) {
+                if (BestGlucose.compensateNoise()) {
                     estimate = BgGraphBuilder.best_bg_estimate; // this maybe needs scaling based on noise intensity
                     estimated_delta = BgGraphBuilder.best_bg_estimate - BgGraphBuilder.last_bg_estimate;
                     slope_arrow = BgReading.slopeToArrowSymbol(estimated_delta / (BgGraphBuilder.DEXCOM_PERIOD / 60000)); // delta by minute
@@ -2652,11 +2649,7 @@ public class Home extends ActivityWithMenu {
 
             //display_delta = bgGraphBuilder.unitizedDeltaString(true, true, is_follower);
             display_delta = dg.unitized_delta;
-            // TODO reduce duplication of logic
-            if ((BgGraphBuilder.last_noise > BgGraphBuilder.NOISE_TRIGGER)
-                    && (BgGraphBuilder.best_bg_estimate > 0)
-                    && (BgGraphBuilder.last_bg_estimate > 0)
-                    && (prefs.getBoolean("bg_compensate_noise", false))) {
+            if (BestGlucose.compensateNoise()) {
                 //final double estimated_delta = BgGraphBuilder.best_bg_estimate - BgGraphBuilder.last_bg_estimate;
                 display_delta = bgGraphBuilder.unitizedDeltaStringRaw(true, true, estimated_delta);
                 addDisplayDelta();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -103,6 +103,7 @@ public class BgGraphBuilder {
     public static final int FUZZER = (1000 * 30 * 5); // 2.5 mins?
     public final static long DEXCOM_PERIOD = 300000;
     public final static double NOISE_TRIGGER = 10;
+    public final static double NOISE_TRIGGER_ULTRASENSITIVE = 1;
     public final static double NOISE_TOO_HIGH_FOR_PREDICT = 60;
     public final static double NOISE_HIGH = 200;
     public final static double NOISE_FORGIVE = 100;
@@ -284,6 +285,7 @@ public class BgGraphBuilder {
         if (thisnoise > NOISE_HIGH) return "Extreme";
         if (thisnoise > NOISE_TOO_HIGH_FOR_PREDICT) return "Very High";
         if (thisnoise > NOISE_TRIGGER) return "High";
+        if (thisnoise > NOISE_TRIGGER_ULTRASENSITIVE && Home.getPreferencesBooleanDefaultFalse("engineering_mode") && Home.getPreferencesBooleanDefaultFalse("bg_compensate_noise_ultrasensitive")) return "Some";
         return "Low";
     }
 
@@ -1226,7 +1228,11 @@ public class BgGraphBuilder {
                 }
 
                 final boolean show_noise_working_line;
-                if ((last_noise > NOISE_TRIGGER) && prefs.getBoolean("bg_compensate_noise", false)) {
+                if (last_noise > NOISE_TRIGGER ||
+                        (last_noise > BgGraphBuilder.NOISE_TRIGGER_ULTRASENSITIVE
+                                && Home.getPreferencesBooleanDefaultFalse("engineering_mode")
+                                && Home.getPreferencesBooleanDefaultFalse("bg_compensate_noise_ultrasensitive")
+                        )) {
                     show_noise_working_line = true;
                 } else {
                     show_noise_working_line = prefs.getBoolean("show_noise_workings", false);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -758,6 +758,8 @@ public class Preferences extends PreferenceActivity {
             final Preference old_school_calibration_mode = findPreference("old_school_calibration_mode");
             final Preference extraTagsForLogs = findPreference("extra_tags_for_logging");
             final Preference enableBF = findPreference("enable_bugfender");
+            final PreferenceCategory displayCategory = (PreferenceCategory) findPreference("xdrip_plus_display_category");
+
 
             findPreference("bluetooth_meter_enabled").setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
@@ -978,6 +980,15 @@ public class Preferences extends PreferenceActivity {
             }
 
             final boolean engineering_mode = this.prefs.getBoolean("engineering_mode",false);
+
+            if (!engineering_mode) {
+                try {
+                    displayCategory.removePreference(findPreference("bg_compensate_noise_ultrasensitive"));
+                } catch (Exception e) {
+                    //
+                }
+            }
+
 
             if (!engineering_mode) {
                 try {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
@@ -102,10 +102,7 @@ public class xDripWidget extends AppWidgetProvider {
 
                 if (dg == null) {
                     // if not using best glucose helper
-                    if ((BgGraphBuilder.last_noise > BgGraphBuilder.NOISE_TRIGGER)
-                            && (BgGraphBuilder.best_bg_estimate > 0)
-                            && (BgGraphBuilder.last_bg_estimate > 0)
-                            && (PreferenceManager.getDefaultSharedPreferences(context).getBoolean("bg_compensate_noise", false))) {
+                    if (BestGlucose.compensateNoise()) {
                         estimate = BgGraphBuilder.best_bg_estimate; // this needs scaling based on noise intensity
                         estimated_delta = BgGraphBuilder.best_bg_estimate - BgGraphBuilder.last_bg_estimate;
                         slope_arrow = BgReading.slopeToArrowSymbol(estimated_delta / (BgGraphBuilder.DEXCOM_PERIOD / 60000)); // delta by minute

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -813,4 +813,5 @@
     <string name="repeat_sound">Repeat sound</string>
     <string name="enable_telemetry">Enable Telemetry</string>
     <string name="send_data_to_developers">Send data to developers about success rates of different devices</string>
+    <string name="try_to_work_around_noisy_readings_ultrasensitive">Start to work around noisy readings even on very low noise levels (engineering mode ony)</string>
 </resources>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -273,6 +273,14 @@
                 android:switchTextOff="@string/short_off_text_for_switches"
                 android:switchTextOn="@string/short_on_text_for_switches"
                 android:title="\u26A0 Smooth sensor noise" />
+            <SwitchPreference
+                android:defaultValue="false"
+                android:key="bg_compensate_noise_ultrasensitive"
+                android:dependency="bg_compensate_noise"
+                android:summary="@string/try_to_work_around_noisy_readings_ultrasensitive"
+                android:switchTextOff="@string/short_off_text_for_switches"
+                android:switchTextOn="@string/short_on_text_for_switches"
+                android:title="\u26A0 Smooth sensor noise ultrasensitive" />
             <CheckBoxPreference
                 android:defaultValue="true"
                 android:key="show_showcase"


### PR DESCRIPTION
Provide engineering mode feature to allow noise compensation to occur even with very low noise levels. (Ultra-sensitive threshold)

The purpose of this is to give the option to smooth glucose data effectively for occasional sensors which show noise during initial bedding in stage.