### PR TITLE
close confirmation on wear when confirmed on phone

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -989,7 +989,7 @@ public class Home extends ActivityWithMenu {
                 (btnInsulinDose.getVisibility() == View.INVISIBLE)) {
             hideAllTreatmentButtons(); // we clear values here also
             //send toast to wear - closes the confirmation activity on the watch
-            WatchUpdaterService.sendWearLocalToast("Treatment processed", Toast.LENGTH_LONG);
+            WatchUpdaterService.sendWearToast("Treatment processed", Toast.LENGTH_LONG);
             return true;
         } else {
             return false;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -988,6 +988,8 @@ public class Home extends ActivityWithMenu {
                 (btnCarbohydrates.getVisibility() == View.INVISIBLE) &&
                 (btnInsulinDose.getVisibility() == View.INVISIBLE)) {
             hideAllTreatmentButtons(); // we clear values here also
+            //send toast to wear - closes the confirmation activity on the watch
+            WatchUpdaterService.sendWearLocalToast("Treatment processed", Toast.LENGTH_LONG);
             return true;
         } else {
             return false;


### PR DESCRIPTION
On the phone insulin and carbs can be confirmed individually by clicking on them instead of clicking on the green plus. If all are confirmed this way, the dialog closes on the phone but did not on the watch.

By sending this message to the watch it will close.

@kskandispersonal, could you please take a look at this. Thanks.