### PR TITLE
Fix to display sensor and treatment data on phone on each sync.

### DIFF
--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
@@ -288,6 +288,16 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                                         sendMessagePayload(node, "WEARABLE_RESEND_PATH", path, payload);
                                     default://SYNC_ALL_DATA
                                         Log.d(TAG, "doInBackground SYNC_ALL_DATA");
+                                        if (sync_step_counter) {
+                                            datamap = getWearStepSensorData(send_step_count, last_send_previous_step_sensor, 0);
+                                            if (datamap != null) {
+                                                sendMessagePayload(node, "SYNC_STEP_SENSOR_PATH", SYNC_STEP_SENSOR_PATH, datamap.toByteArray());
+                                            }
+                                        }
+                                        datamap = getWearTreatmentsData(send_treatments_count, last_send_previous_treatments, 0);
+                                        if (datamap != null) {
+                                            sendMessagePayload(node, "SYNC_TREATMENTS_PATH", SYNC_TREATMENTS_PATH, datamap.toByteArray());
+                                        }
                                         if (enable_wearG5) {//KS
                                             datamap = getWearTransmitterData(send_bg_count, last_send_previous, 0);//KS 36 data for last 3 hours; 288 for 1 day
                                             if (datamap != null) {
@@ -300,16 +310,6 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                                                 byte[] compressPayload = JoH.compressBytesToBytesGzip((datamap.toByteArray()));
                                                 sendMessagePayload(node, "SYNC_LOGS_PATH", SYNC_LOGS_PATH, compressPayload);
                                             }
-                                        }
-                                        if (sync_step_counter) {
-                                            datamap = getWearStepSensorData(send_step_count, last_send_previous_step_sensor, 0);
-                                            if (datamap != null) {
-                                                sendMessagePayload(node, "SYNC_STEP_SENSOR_PATH", SYNC_STEP_SENSOR_PATH, datamap.toByteArray());
-                                            }
-                                        }
-                                        datamap = getWearTreatmentsData(send_treatments_count, last_send_previous_treatments, 0);
-                                        if (datamap != null) {
-                                            sendMessagePayload(node, "SYNC_TREATMENTS_PATH", SYNC_TREATMENTS_PATH, datamap.toByteArray());
                                         }
                                         //sendMessagePayload(node, "WEARABLE_RESEND_PATH", path, payload);
                                         if (PersistentStore.getBoolean(G5_BATTERY_WEARABLE_SEND)) {


### PR DESCRIPTION
This issue was observed by wannago.  Moved Steps and Treatments data sync BEFORE BGs sync so the phone screen refresh, triggered by BG refresh, will show all new data.