### PR TITLE
Add ZTE Axon 7 as supported G5 receiving phone.

### DIFF
--- a/Documentation/Phones_For_G5.md
+++ b/Documentation/Phones_For_G5.md
@@ -47,6 +47,7 @@ Doogee X5S | 5.1 | OB1
 Melrose S9 | 4.4.2 | OB1
 Samsung A3 2017 | 6.0.1 | OB1
 ZTE Axon 7 Mini | 7.1.1 | OB1
+ZTE Axon 7 | 7.1.2 | OB1
 
 ## Tips
 


### PR DESCRIPTION
96-98% capture rate, both with and without OB1 impl.