### PR TITLE
Implement notification channels for Android O

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
@@ -11,6 +11,7 @@ import com.eveningoutpost.dexdrip.Models.TransmitterData;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.Services.Ob1G5CollectionService;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
+import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.utils.PowerStateReceiver;
 import com.eveningoutpost.dexdrip.xdrip;
@@ -542,7 +543,8 @@ public class Ob1G5StateMachine {
             if (batteryInfoRxMessage.voltagea < LOW_BATTERY_WARNING_LEVEL) {
                 if (JoH.pratelimit("g5-low-battery-warning", 40000)) {
                     final boolean loud = !PowerStateReceiver.is_power_connected();
-                    JoH.showNotification("G5 Battery Low", "G5 Transmitter battery has dropped to: " + batteryInfoRxMessage.voltagea + " it may fail soon", null, 770, loud, loud, false);
+                    JoH.showNotification("G5 Battery Low", "G5 Transmitter battery has dropped to: " + batteryInfoRxMessage.voltagea + " it may fail soon",
+                            null, 770, NotificationChannels.LOW_TRANSMITTER_BATTERY_CHANNEL, loud, loud, null, null, null);
                 }
             }
             PersistentStore.setLong(G5_BATTERY_LEVEL_MARKER + transmitterId, batteryInfoRxMessage.voltagea);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -81,6 +81,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Experience;
 import com.eveningoutpost.dexdrip.UtilityModels.Intents;
 import com.eveningoutpost.dexdrip.UtilityModels.JamorhamShowcaseDrawer;
 import com.eveningoutpost.dexdrip.UtilityModels.NightscoutUploader;
+import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
 import com.eveningoutpost.dexdrip.UtilityModels.Notifications;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.PrefsViewImpl;
@@ -255,10 +256,13 @@ public class Home extends ActivityWithMenu {
 
     private static String statusIOB = "";
     private static String statusBWP = "";
+    private NotificationChannels notifChannels;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         mActivity = this;
+        // Builds notification channels if supported
+        notifChannels = new NotificationChannels(mActivity);
 
         if (!xdrip.checkAppContext(getApplicationContext())) {
             toast("Unusual internal context problem - please report");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -81,7 +81,6 @@ import com.eveningoutpost.dexdrip.UtilityModels.Experience;
 import com.eveningoutpost.dexdrip.UtilityModels.Intents;
 import com.eveningoutpost.dexdrip.UtilityModels.JamorhamShowcaseDrawer;
 import com.eveningoutpost.dexdrip.UtilityModels.NightscoutUploader;
-import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
 import com.eveningoutpost.dexdrip.UtilityModels.Notifications;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.PrefsViewImpl;
@@ -256,13 +255,10 @@ public class Home extends ActivityWithMenu {
 
     private static String statusIOB = "";
     private static String statusBWP = "";
-    private NotificationChannels notifChannels;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         mActivity = this;
-        // Builds notification channels if supported
-        notifChannels = new NotificationChannels(mActivity);
 
         if (!xdrip.checkAppContext(getApplicationContext())) {
             toast("Unusual internal context problem - please report");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -38,6 +38,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.PowerManager;
 import android.provider.Settings;
+import android.support.v4.app.NotificationCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.view.ContextThemeWrapper;
@@ -1016,11 +1017,15 @@ public class JoH {
     }
 
     public static void showNotification(String title, String content, PendingIntent intent, int notificationId, boolean sound, boolean vibrate, PendingIntent deleteIntent, Uri sound_uri) {
-        showNotification(title, content, intent, notificationId, sound, vibrate, deleteIntent, sound_uri, null);
+        showNotification(title, content, intent, notificationId, null, sound, vibrate, deleteIntent, sound_uri, null);
     }
 
     public static void showNotification(String title, String content, PendingIntent intent, int notificationId, boolean sound, boolean vibrate, PendingIntent deleteIntent, Uri sound_uri, String bigmsg) {
-        final Notification.Builder mBuilder = notificationBuilder(title, content, intent);
+        showNotification(title, content, intent, notificationId, null, sound, vibrate, deleteIntent, sound_uri, bigmsg);
+    }
+
+    public static void showNotification(String title, String content, PendingIntent intent, int notificationId, String channelId, boolean sound, boolean vibrate, PendingIntent deleteIntent, Uri sound_uri, String bigmsg) {
+        final NotificationCompat.Builder mBuilder = notificationBuilder(title, content, intent, channelId);
         final long[] vibratePattern = {0, 1000, 300, 1000, 300, 1000};
         if (vibrate) mBuilder.setVibrate(vibratePattern);
         if (deleteIntent != null) mBuilder.setDeleteIntent(deleteIntent);
@@ -1031,7 +1036,7 @@ public class JoH {
         }
 
         if (bigmsg != null) {
-            mBuilder.setStyle(new Notification.BigTextStyle().bigText(bigmsg));
+            mBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(bigmsg));
         }
 
         final NotificationManager mNotifyMgr = (NotificationManager) xdrip.getAppContext().getSystemService(Context.NOTIFICATION_SERVICE);
@@ -1040,8 +1045,8 @@ public class JoH {
         mNotifyMgr.notify(notificationId, mBuilder.build());
     }
 
-    private static Notification.Builder notificationBuilder(String title, String content, PendingIntent intent) {
-        return new Notification.Builder(xdrip.getAppContext())
+    private static NotificationCompat.Builder notificationBuilder(String title, String content, PendingIntent intent, String channelId) {
+        return new NotificationCompat.Builder(xdrip.getAppContext(), channelId)
                 .setSmallIcon(R.drawable.ic_action_communication_invert_colors_on)
                 .setContentTitle(title)
                 .setContentText(content)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ParakeetHelper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ParakeetHelper.java
@@ -9,10 +9,12 @@ import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.preference.PreferenceManager;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.widget.Toast;
 
 import com.eveningoutpost.dexdrip.Models.JoH;
+import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
 import com.eveningoutpost.dexdrip.UtilityModels.Notifications;
 import com.eveningoutpost.dexdrip.utils.PowerStateReceiver;
 import com.eveningoutpost.dexdrip.utils.Preferences;
@@ -163,7 +165,7 @@ public class ParakeetHelper {
                     PendingIntent.FLAG_ONE_SHOT);
 
             Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-            Notification.Builder notificationBuilder =  new Notification.Builder(xdrip.getAppContext())
+            NotificationCompat.Builder notificationBuilder =  new NotificationCompat.Builder(xdrip.getAppContext(), NotificationChannels.PARAKEET_STATUS_CHANNEL)
                     .setSmallIcon(R.drawable.ic_launcher)
                     .setLargeIcon(BitmapFactory.decodeResource(xdrip.getAppContext().getResources(), R.drawable.jamorham_parakeet_marker))
                     .setContentTitle(title)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
@@ -55,6 +55,7 @@ import com.eveningoutpost.dexdrip.Models.Reminder;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.JamorhamShowcaseDrawer;
+import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.ShotStateStore;
 import com.eveningoutpost.dexdrip.profileeditor.DatePickerFragment;
@@ -974,7 +975,8 @@ public class Reminders extends ActivityWithRecycler implements SensorEventListen
                 final PendingIntent deleteIntent = PendingIntent.getActivity(xdrip.getAppContext(), NOTIFICATION_ID + 1, notificationDeleteIntent, 0);
                 final PendingIntent pendingIntent = PendingIntent.getActivity(xdrip.getAppContext(), NOTIFICATION_ID, notificationIntent, 0);
 
-                JoH.showNotification(reminder.getTitle(), "Reminder due " + JoH.hourMinuteString(reminder.next_due), pendingIntent, NOTIFICATION_ID, true, true, deleteIntent, JoH.isOngoingCall() ? null : (reminder.sound_uri != null) ? Uri.parse(reminder.sound_uri) : Uri.parse(JoH.getResourceURI(R.raw.reminder_default_notification)));
+                JoH.showNotification(reminder.getTitle(), "Reminder due " + JoH.hourMinuteString(reminder.next_due),
+                        pendingIntent, NOTIFICATION_ID, NotificationChannels.REMINDER_CHANNEL, true, true, deleteIntent, JoH.isOngoingCall() ? null : (reminder.sound_uri != null) ? Uri.parse(reminder.sound_uri) : Uri.parse(JoH.getResourceURI(R.raw.reminder_default_notification)), null);
                 UserError.Log.ueh("Reminder Alert", reminder.getTitle() + " due: " + JoH.dateTimeText(reminder.next_due) + ((reminder.snoozed_till > reminder.next_due) ? " snoozed till: " + JoH.dateTimeText(reminder.snoozed_till) : ""));
                 reminder.notified();
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5CollectionService.java
@@ -63,6 +63,7 @@ import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.ForegroundServiceStarter;
+import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.StatusItem;
 import com.eveningoutpost.dexdrip.utils.BgToSpeech;
@@ -1614,7 +1615,8 @@ public class G5CollectionService extends G5BaseService {
             if (batteryInfoRxMessage.voltagea < LOW_BATTERY_WARNING_LEVEL) {
                 if (JoH.pratelimit("g5-low-battery-warning", 40000)) {
                     final boolean loud = !PowerStateReceiver.is_power_connected();
-                    JoH.showNotification("G5 Battery Low", "G5 Transmitter battery has dropped to: " + batteryInfoRxMessage.voltagea + " it may fail soon", null, 770, loud, loud, false);
+                    JoH.showNotification("G5 Battery Low", "G5 Transmitter battery has dropped to: " + batteryInfoRxMessage.voltagea + " it may fail soon",
+                            null, 770, NotificationChannels.LOW_TRANSMITTER_BATTERY_CHANNEL, loud, loud, null, null, null);
                 }
             }
             PersistentStore.setLong(G5_BATTERY_LEVEL_MARKER + transmitterId, batteryInfoRxMessage.voltagea);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -417,7 +417,7 @@ public class AlertPlayer {
 
         boolean localOnly = (Home.get_forced_wear() && PersistentStore.getBoolean("bg_notifications_watch"));
         Log.d(TAG, "NotificationCompat.Builder localOnly=" + localOnly);
-        NotificationCompat.Builder  builder = new NotificationCompat.Builder(ctx)//KS Notification
+        NotificationCompat.Builder  builder = new NotificationCompat.Builder(ctx, NotificationChannels.BG_ALERT_CHANNEL)//KS Notification
             .setSmallIcon(R.drawable.ic_action_communication_invert_colors_on)
             .setContentTitle(title)
             .setContentText(content)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -655,7 +655,8 @@ public class NightscoutUploader {
                     notification_shown = true;
                     JoH.showNotification("Nightscout Failure", "REST-API upload to Nightscout has failed " + last_exception_count
                                     + " times. With message: " + last_exception + " " + ((last_success_time > 0) ? "Last succeeded: " + JoH.dateTimeText(last_success_time) : ""),
-                            MegaStatus.getStatusPendingIntent("Uploaders"), Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID, true, true, null, null, msg);
+
+                            MegaStatus.getStatusPendingIntent("Uploaders"), Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID, NotificationChannels.NIGHTSCOUT_UPLOADER_CHANNEL, true, true, null, null, msg);
                 }
             } else {
                 Log.e(TAG, "Cannot alert for nightscout failures as preference setting is disabled");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NotificationChannels.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NotificationChannels.java
@@ -26,6 +26,9 @@ public class NotificationChannels extends ContextWrapper {
     public static final String LOW_BRIDGE_BATTERY_CHANNEL = "lowBridgeBattery";
     public static final String LOW_TRANSMITTER_BATTERY_CHANNEL = "lowTransmitterBattery";
     public static final String NIGHTSCOUT_UPLOADER_CHANNEL = "nightscoutUploaderChannel";
+    public static final String PARAKEET_STATUS_CHANNEL = "parakeetStatusChannel";
+    public static final String REMINDER_CHANNEL = "reminderChannel";
+    public static final String BG_ALERT_CHANNEL = "bgAlertChannel";
 
     @TargetApi(Build.VERSION_CODES.O)
     public NotificationChannels(Context ctx) {
@@ -48,6 +51,18 @@ public class NotificationChannels extends ContextWrapper {
         notifChannels.add(new NotificationChannel(
                 NIGHTSCOUT_UPLOADER_CHANNEL,
                 "Nightscout Uploader",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                PARAKEET_STATUS_CHANNEL,
+                "Parakeet Status",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                REMINDER_CHANNEL,
+                "Reminders",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                BG_ALERT_CHANNEL,
+                "Blood Glucose Alert",
                 NotificationManager.IMPORTANCE_DEFAULT));
 
         getNotifManager().createNotificationChannels(notifChannels);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NotificationChannels.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NotificationChannels.java
@@ -23,6 +23,10 @@ public class NotificationChannels extends ContextWrapper {
     public static final String TAG = NotificationChannels.class.getSimpleName();
     private NotificationManager notifManager;
 
+    public static final String LOW_BRIDGE_BATTERY_CHANNEL = "lowBridgeBattery";
+    public static final String LOW_TRANSMITTER_BATTERY_CHANNEL = "lowTransmitterBattery";
+    public static final String NIGHTSCOUT_UPLOADER_CHANNEL = "nightscoutUploaderChannel";
+
     @TargetApi(Build.VERSION_CODES.O)
     public NotificationChannels(Context ctx) {
         super(ctx);
@@ -33,6 +37,19 @@ public class NotificationChannels extends ContextWrapper {
         }
 
         List<NotificationChannel> notifChannels = new ArrayList<>();
+        notifChannels.add(new NotificationChannel(
+                LOW_BRIDGE_BATTERY_CHANNEL,
+                "Low bridge battery",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                LOW_TRANSMITTER_BATTERY_CHANNEL,
+                "Low transmitter battery",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                NIGHTSCOUT_UPLOADER_CHANNEL,
+                "Nightscout Uploader",
+                NotificationManager.IMPORTANCE_DEFAULT));
+
         getNotifManager().createNotificationChannels(notifChannels);
         Log.d(TAG, "Notification channels created.");
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NotificationChannels.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NotificationChannels.java
@@ -1,0 +1,46 @@
+package com.eveningoutpost.dexdrip.UtilityModels;
+
+import android.annotation.TargetApi;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.os.Build;
+import android.support.v4.app.NotificationCompatSideChannelService;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by jwoglom on 10/15/2017.
+ *
+ * Contains setup for creation of notification channels, and constants for
+ * channelId values used when creating notifications.
+ */
+
+public class NotificationChannels extends ContextWrapper {
+    public static final String TAG = NotificationChannels.class.getSimpleName();
+    private NotificationManager notifManager;
+
+    @TargetApi(Build.VERSION_CODES.O)
+    public NotificationChannels(Context ctx) {
+        super(ctx);
+
+        if (Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
+            Log.d(TAG, "Notification channels not available on this sdk version. ("+Build.VERSION.SDK_INT+")");
+            return;
+        }
+
+        List<NotificationChannel> notifChannels = new ArrayList<>();
+        getNotifManager().createNotificationChannels(notifChannels);
+        Log.d(TAG, "Notification channels created.");
+    }
+
+    private NotificationManager getNotifManager() {
+        if (notifManager == null) {
+            notifManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        }
+        return notifManager;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NotificationChannels.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NotificationChannels.java
@@ -29,6 +29,13 @@ public class NotificationChannels extends ContextWrapper {
     public static final String PARAKEET_STATUS_CHANNEL = "parakeetStatusChannel";
     public static final String REMINDER_CHANNEL = "reminderChannel";
     public static final String BG_ALERT_CHANNEL = "bgAlertChannel";
+    public static final String BG_MISSED_ALERT_CHANNEL = "bgMissedAlertChannel";
+    public static final String BG_RISE_DROP_CHANNEL = "bgRiseDropChannel";
+    public static final String BG_PREDICTED_LOW_CHANNEL = "bgPredictedLowChannel";
+    public static final String BG_PERSISTENT_HIGH_CHANNEL = "bgPersistentHighChannel";
+    public static final String CALIBRATION_CHANNEL = "calibrationChannel";
+    public static final String ONGOING_CHANNEL = "ongoingChannel";
+
 
     @TargetApi(Build.VERSION_CODES.O)
     public NotificationChannels(Context ctx) {
@@ -63,6 +70,30 @@ public class NotificationChannels extends ContextWrapper {
         notifChannels.add(new NotificationChannel(
                 BG_ALERT_CHANNEL,
                 "Blood Glucose Alert",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                BG_MISSED_ALERT_CHANNEL,
+                "BG Missed Readings",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                BG_RISE_DROP_CHANNEL,
+                "BG Rise/Drop",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                BG_PREDICTED_LOW_CHANNEL,
+                "BG Predicted Low",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                BG_PERSISTENT_HIGH_CHANNEL,
+                "BG Persistent High",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                CALIBRATION_CHANNEL,
+                "Calibration",
+                NotificationManager.IMPORTANCE_DEFAULT));
+        notifChannels.add(new NotificationChannel(
+                ONGOING_CHANNEL,
+                "Ongoing",
                 NotificationManager.IMPORTANCE_DEFAULT));
 
         getNotifManager().createNotificationChannels(notifChannels);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBattery.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.UserError;
+import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
 import com.eveningoutpost.dexdrip.xdrip;
 
 import static com.eveningoutpost.dexdrip.Models.JoH.cancelNotification;
@@ -48,7 +49,8 @@ public class CheckBridgeBattery {
                     notification_showing = true;
                     lowbattery = true;
                     final PendingIntent pendingIntent = android.app.PendingIntent.getActivity(xdrip.getAppContext(), 0, new Intent(xdrip.getAppContext(), Home.class), android.app.PendingIntent.FLAG_UPDATE_CURRENT);
-                    showNotification("Low bridge battery", "Bridge battery dropped to: " + this_level + "%", pendingIntent, NOTIFICATION_ITEM, true, true, false);
+                    showNotification("Low bridge battery", "Bridge battery dropped to: " + this_level + "%",
+                            pendingIntent, NOTIFICATION_ITEM, NotificationChannels.LOW_BRIDGE_BATTERY_CHANNEL, true, true, null, null, null);
                 }
             } else {
                 if (notification_showing) {
@@ -78,7 +80,8 @@ public class CheckBridgeBattery {
                 if (JoH.pratelimit("parakeet-battery-warning", repeat_seconds)) {
                     parakeet_notification_showing = true;
                     final PendingIntent pendingIntent = android.app.PendingIntent.getActivity(xdrip.getAppContext(), 0, new Intent(xdrip.getAppContext(), Home.class), android.app.PendingIntent.FLAG_UPDATE_CURRENT);
-                    showNotification("Low Parakeet battery", "Parakeet battery dropped to: " + this_level + "%", pendingIntent, PARAKEET_NOTIFICATION_ITEM, true, true, false);
+                    showNotification("Low Parakeet battery", "Parakeet battery dropped to: " + this_level + "%",
+                            pendingIntent, PARAKEET_NOTIFICATION_ITEM, NotificationChannels.LOW_BRIDGE_BATTERY_CHANNEL, true, true, null, null, null);
                 }
             } else {
                 if (parakeet_notification_showing) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
@@ -17,6 +17,7 @@ import com.eveningoutpost.dexdrip.Services.BluetoothGlucoseMeter;
 import com.eveningoutpost.dexdrip.Services.PlusSyncService;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.IdempotentMigrations;
+import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
 import com.eveningoutpost.dexdrip.UtilityModels.PlusAsyncExecutor;
 import com.eveningoutpost.dexdrip.calibrations.PluggableCalibration;
 
@@ -35,6 +36,7 @@ public class xdrip extends Application {
     private static boolean fabricInited = false;
     private static boolean bfInited = false;
     private static Locale LOCALE;
+    private static NotificationChannels notifChannels;
     public static PlusAsyncExecutor executor;
     public static boolean useBF = false;
 
@@ -61,6 +63,8 @@ public class xdrip extends Application {
 
         checkForcedEnglish(xdrip.context);
 
+        // Builds notification channels if supported
+        notifChannels = new NotificationChannels(this);
 
         JoH.ratelimit("policy-never", 3600); // don't on first load
         new IdempotentMigrations(getApplicationContext()).performAll();


### PR DESCRIPTION
This change:
* creates a NotificationChannels class (that extends ContextWrapper) which creates notification channels for Android O+. Per Google documentation and examples, android ignores creation requests for channels if they already exist, so always attempting to create them (by call in the Home activity) is the right way to go.
* changes notification methods in the JoH helper class to use NotificationCompat.Builder, with an argument for the notification channel ID in these methods.
* updates most, but not all, notification-related calls that use JoH.showNotification to provide a NotificationChannels.XX_CHANNEL constant (created in NotificationChannels.java) as the channelId. There were a couple oddly-specific error cases that generate notifications which I did not create a notification channel for. 
* updates all other uses of Notification.Builder to use NotificationCompat.Builder, except for in GcmListenerSvc. It looked to me like updating this class to be channel-aware would require passing channelId's in bundled GCM objects which are picked up here, and I don't actually know how this class is used so I just left it alone.

The user-visible changes as a result of adding notification channels is that sound, vibration, do not disturb, and importance preferences can be set for different categories of notifications. Additionally, until at least one notification channel is created for an application running under Android O, vibration and importance preferences on all notifications for that app cannot be changed, which was functionality supported for all notifications by a single app in Android N.

This change has been tested on a Nexus 5X running Oreo, as well as on an emulated Nougat device to ensure notifications are still generated and the app doesn't crash when running on an earlier SDK version than 26, which introduces notification channels.

![xdrip-channels-1](https://user-images.githubusercontent.com/192620/31593724-6ae4a92c-b1fe-11e7-81d1-0049d9384495.png)
![xdrip-channels-2](https://user-images.githubusercontent.com/192620/31593728-6d97b31c-b1fe-11e7-8e68-fb5ae09cd631.png)
![xdrip-channels-3](https://user-images.githubusercontent.com/192620/31593729-6f5e44d6-b1fe-11e7-8367-736212b18506.png)
![xdrip-channels-4](https://user-images.githubusercontent.com/192620/31593730-70ac2420-b1fe-11e7-8a19-1c6cbe1ddb82.png)
