### PR TITLE
Masterplexus blueReader adding better Battery (percent and rest days) and restart

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/BluetoothScan.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BluetoothScan.java
@@ -389,6 +389,10 @@ public class BluetoothScan extends ListActivityWithMenu {
             } else if (device.getName().toLowerCase().contains("bluereader")) {
                 if (!CollectionServiceStarter.isLimitter()) {
                     prefs.edit().putString("dex_collection_method", "LimiTTer").apply();
+                    //prepare storrage for Firmwareinfo
+                    if (!prefs.getString("blueReader_Version","empty").startsWith("empty")) {
+                        prefs.edit().putString("blueReader_Version","empty").apply();
+                    }
                 }
                 returnToHome();
             } else if (device.getName().toLowerCase().contains("sweetreader")) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1884,7 +1884,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
 
         //Transmitter Battery Level
         final Sensor sensor = Sensor.currentSensor();
-        if (sensor != null && sensor.latest_battery_level != 0 && sensor.latest_battery_level <= Dex_Constants.TRANSMITTER_BATTERY_LOW && !prefs.getBoolean("disable_battery_warning", false)) {
+        if (sensor != null && sensor.latest_battery_level != 0 && !DexCollectionService.getBestLimitterHardwareName().equalsIgnoreCase("BlueReader") && sensor.latest_battery_level <= Dex_Constants.TRANSMITTER_BATTERY_LOW && !prefs.getBoolean("disable_battery_warning", false)) {
             Drawable background = new Drawable() {
 
                 @Override
@@ -2531,7 +2531,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                     if (limitterName.equals(DexCollectionService.LIMITTER_NAME)) {
                         dexbridgeBattery.setText(getString(R.string.limitter_battery) + ": " + bridgeBattery + "%");
                     } else {
-                        dexbridgeBattery.setText(limitterName + " " + getString(R.string.battery) + ": " + bridgeBattery + "%");
+                        dexbridgeBattery.setText(limitterName + " " + getString(R.string.battery) + ": " + bridgeBattery + "% (" + prefs.getString( "bridge_battery_days", "0") + "days)");
                     }
                 } else {
                     dexbridgeBattery.setText("Bridge battery" + ": " + bridgeBattery + ((bridgeBattery < 200) ? "%" : "mV"));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/TransmitterData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/TransmitterData.java
@@ -51,6 +51,7 @@ public class TransmitterData extends Model {
     public static synchronized TransmitterData create(byte[] buffer, int len, Long timestamp) {
         if (len < 6) { return null; }
         final TransmitterData transmitterData = new TransmitterData();
+        StringBuilder data_string = new StringBuilder(); //move it outside of try to access it in error
         try {
             if ((buffer[0] == 0x11 || buffer[0] == 0x15) && buffer[1] == 0x00) {
                 //this is a dexbridge packet.  Process accordingly.
@@ -71,7 +72,7 @@ public class TransmitterData extends Model {
                 Log.i(TAG, "Created transmitterData record with Raw value of " + transmitterData.raw_data + " and Filtered value of " + transmitterData.filtered_data + " at " + timestamp + " with timestamp " + transmitterData.timestamp);
             } else { //this is NOT a dexbridge packet.  Process accordingly.
                 Log.i(TAG, "create Processing a BTWixel or IPWixel packet");
-                StringBuilder data_string = new StringBuilder();
+
                 for (int i = 0; i < len; ++i) {
                     data_string.append((char) buffer[i]);
                 }
@@ -129,9 +130,9 @@ public class TransmitterData extends Model {
             transmitterData.uuid = UUID.randomUUID().toString();
             transmitterData.save();
             return transmitterData;
-        }catch(Exception e)
-        {
+        }catch(Exception e) {
             Log.e(TAG, "Got exception processing fields in protocol: " + e);
+            Log.e(TAG, "data: " + data_string.toString()); //output of additional Data to understand may the error.
         }
         return null;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -227,7 +227,6 @@ public class NFCReaderX {
                 if (!NFCReaderX.useNFC()) return;
                 if (succeeded) {
                     final String tagId = bytesToHexString(tag.getId());
-                    Log.w("LibreRawData",bytesToHexString(data)); //todo hierDW
                     mResult = parseData(0, tagId, data);
                     new Thread() {
                         @Override

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -23,6 +23,7 @@ import android.view.View;
 import com.eveningoutpost.dexdrip.ImportedLibraries.usbserial.util.HexDump;
 import com.eveningoutpost.dexdrip.Models.GlucoseData;
 import com.eveningoutpost.dexdrip.Models.JoH;
+import com.eveningoutpost.dexdrip.Models.LibreBlock;
 import com.eveningoutpost.dexdrip.Models.PredictionData;
 import com.eveningoutpost.dexdrip.Models.ReadingData;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
@@ -30,7 +31,6 @@ import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -227,6 +227,10 @@ public class NFCReaderX {
                 if (!NFCReaderX.useNFC()) return;
                 if (succeeded) {
                     final String tagId = bytesToHexString(tag.getId());
+
+                    // Save raw block record (we start from block 0)
+                    LibreBlock.createAndSave(tagId, data, 0);
+
                     mResult = parseData(0, tagId, data);
                     new Thread() {
                         @Override

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -227,7 +227,7 @@ public class NFCReaderX {
                 if (!NFCReaderX.useNFC()) return;
                 if (succeeded) {
                     final String tagId = bytesToHexString(tag.getId());
-
+                    Log.w("LibreRawData",bytesToHexString(data)); //todo hierDW
                     mResult = parseData(0, tagId, data);
                     new Thread() {
                         @Override

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -1055,7 +1055,7 @@ public class DexCollectionService extends Service {
             } else if (new String(buffer) != null && (new String(buffer).startsWith("IDR") || new String(buffer).startsWith("TRANS_FAILED") || new String(buffer).startsWith("HYBERNATE SUCCESS") || new String(buffer).startsWith("not ready for") || new String(buffer).startsWith("NFC_DISABLED") )) {
                 if (static_use_nrf) {
                     Log.e(TAG, "blueReader-message: " + new String(buffer));
-                    if (new String(buffer).startsWith("TRANS_FAILED") || new String(buffer).startsWith("not ready for") ) {
+                    if (new String(buffer).startsWith("not ready for") ) { //delete the trans_failed, because its normal only if the bluereader could not read the sensor.
                         Log.e(TAG, "Found blueReader in a ugly State, send hibernate to reset!");
                         sendBtMessage(new byte[]{0x68}); //send hard hibernate, because bluereader is in a ugly state
                     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -1052,6 +1052,14 @@ public class DexCollectionService extends Service {
                         CheckBridgeBattery.checkBridgeBattery();
                     }
                 }
+            } else if (new String(buffer) != null && (new String(buffer).startsWith("TRANS_FAILED") || new String(buffer).startsWith("HYBERNATE SUCCESS") || new String(buffer).startsWith("not ready for") || new String(buffer).startsWith("NFC_DISABLED") )) {
+                if (static_use_nrf) {
+                    Log.e(TAG, "blueReader-message: " + new String(buffer));
+                    if (new String(buffer).startsWith("TRANS_FAILED") || new String(buffer).startsWith("not ready for") ) {
+                        Log.e(TAG, "Found blueReader in a ugly State, send hibernate to reset!");
+                        sendBtMessage(new byte[]{0x68}); //send hard hibernate, because bluereader is in a ugly state
+                    }
+                }
             } else if (buffer.length > 10 && new String(buffer) != null && new String(buffer).startsWith("battery: ")) {
                 //bluereader intermidiate support
                 if (BgReading.last() == null || BgReading.last().timestamp + (4 * 60 * 1000) < System.currentTimeMillis()) {
@@ -1065,10 +1073,6 @@ public class DexCollectionService extends Service {
 
     private synchronized void processNewTransmitterData(TransmitterData transmitterData, long timestamp) {
         if (transmitterData == null) {
-            if (static_use_nrf) {
-                Log.e(TAG, "Found blueReader in a ugly State,send Reset");
-                sendBtMessage(new byte[]{0x79}); //send hard reset, because bluereader is in a ugly state
-            }
             return;
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -1052,18 +1052,31 @@ public class DexCollectionService extends Service {
                         CheckBridgeBattery.checkBridgeBattery();
                     }
                 }
-            } else if (new String(buffer) != null && (new String(buffer).startsWith("TRANS_FAILED") || new String(buffer).startsWith("HYBERNATE SUCCESS") || new String(buffer).startsWith("not ready for") || new String(buffer).startsWith("NFC_DISABLED") )) {
+            } else if (new String(buffer) != null && (new String(buffer).startsWith("IDR") || new String(buffer).startsWith("TRANS_FAILED") || new String(buffer).startsWith("HYBERNATE SUCCESS") || new String(buffer).startsWith("not ready for") || new String(buffer).startsWith("NFC_DISABLED") )) {
                 if (static_use_nrf) {
                     Log.e(TAG, "blueReader-message: " + new String(buffer));
                     if (new String(buffer).startsWith("TRANS_FAILED") || new String(buffer).startsWith("not ready for") ) {
                         Log.e(TAG, "Found blueReader in a ugly State, send hibernate to reset!");
                         sendBtMessage(new byte[]{0x68}); //send hard hibernate, because bluereader is in a ugly state
                     }
+                    if (new String(buffer).startsWith("IDR")){
+                        prefs.edit().putString("blueReader_Version",new String(buffer)).apply();
+                        ByteBuffer ackMessage = ByteBuffer.allocate(3);
+                    }
                 }
             } else if (buffer.length > 10 && new String(buffer) != null && new String(buffer).startsWith("battery: ")) {
                 //bluereader intermidiate support
                 if (BgReading.last() == null || BgReading.last().timestamp + (4 * 60 * 1000) < System.currentTimeMillis()) {
                     sendBtMessage(new byte[]{0x6C});
+                }
+                //command to get Firmware
+                if(prefs.getString("blueReader_Version","empty").contains("empty")) {
+                    prefs.edit().putString("blueReader_Version","empty-started").apply(); //just only one time request the firmware, so change the emptyvalue
+                    ByteBuffer ackMessage = ByteBuffer.allocate(3);
+                    ackMessage.put(0, (byte) 0x49);
+                    ackMessage.put(1, (byte) 0x44);
+                    ackMessage.put(2, (byte) 0x4E);
+                    sendBtMessage(ackMessage); //send "IDN" for Firmwarerequest
                 }
             } else {
                 processNewTransmitterData(TransmitterData.create(buffer, len, timestamp), timestamp);
@@ -1101,6 +1114,11 @@ public class DexCollectionService extends Service {
             if (transmitterData.sensor_battery_level > prefs.getInt("blueReader_Full_Battery", 3800)) {
                 prefs.edit().putInt("blueReader_Full_Battery", transmitterData.sensor_battery_level).apply();
                 Log.w(TAG, "blueReader_Full_Battery set to: " + transmitterData.sensor_battery_level) ;
+            }
+            if (transmitterData.sensor_battery_level < 3300) {
+                sendBtMessage(new byte[]{0x6B}); //send powerdown to bluereader (k)
+                Log.e(TAG, "Send blueReader ower-off, due to low Battery!");
+                Home.toaststatic("Send blueReader ower-off, due to low Battery!");
             }
         } else {
             //sensor.latest_battery_level = (sensor.latest_battery_level != 0) ? Math.min(sensor.latest_battery_level, transmitterData.sensor_battery_level) : transmitterData.sensor_battery_level;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
@@ -263,10 +263,10 @@ public class SystemStatusFragment extends Fragment {
         } else {
             transmitter_status_view.setText("" + td.sensor_battery_level);
             GcmActivity.requestSensorBatteryUpdate(); // always ask
-            if (prefs.getString("btDevice","").equals("blueReader")) {
-                if (td.sensor_battery_level <= 3200) {
+            if (getBestLimitterHardwareName().equals("BlueReader")) {
+                if (td.sensor_battery_level <= 3300) {
                     transmitter_status_view.append(" - very low");
-                } else if (td.sensor_battery_level <= 3400) {
+                } else if (td.sensor_battery_level <= 3650) {
                     transmitter_status_view.append(" - low");
                 } else {
                     transmitter_status_view.append(" - ok");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
@@ -430,6 +430,9 @@ public class SystemStatusFragment extends Fragment {
     private void setNotes() {
         try {
 
+            if(!prefs.getString("blueReader_Version","empty").startsWith("empty")) {
+                notes.append("\n- blueReader Firmware: " + prefs.getString("blueReader_Version","empty"));
+            }
             if ((mBluetoothManager == null) || ((android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) && (mBluetoothManager.getAdapter() == null))) {
                 notes.append("\n- This device does not seem to support bluetooth");
             } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.eveningoutpost.dexdrip.Home.startWatchUpdaterService;
+import static com.eveningoutpost.dexdrip.Services.DexCollectionService.getBestLimitterHardwareName;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.DexcomG5;
 
 
@@ -262,13 +263,27 @@ public class SystemStatusFragment extends Fragment {
         } else {
             transmitter_status_view.setText("" + td.sensor_battery_level);
             GcmActivity.requestSensorBatteryUpdate(); // always ask
-            if (td.sensor_battery_level <= Dex_Constants.TRANSMITTER_BATTERY_EMPTY) {
-                transmitter_status_view.append(" - very low");
-            } else if (td.sensor_battery_level <= Dex_Constants.TRANSMITTER_BATTERY_LOW) {
-                transmitter_status_view.append(" - low");
-                transmitter_status_view.append("\n(experimental interpretation)");
+            if (prefs.getString("btDevice","").equals("blueReader")) {
+                if (td.sensor_battery_level <= 3200) {
+                    transmitter_status_view.append(" - very low");
+                } else if (td.sensor_battery_level <= 3400) {
+                    transmitter_status_view.append(" - low");
+                } else {
+                    transmitter_status_view.append(" - ok");
+                }
+                transmitter_status_view.append(" (" + ((td.sensor_battery_level - 3300) * 100 / (prefs.getInt("blueReader_Full_Battery", 3800) - 3300)) + "%)");
+                transmitter_status_view.append(" rest days approx " + prefs.getString( "bridge_battery_days", "0"));
+                //set for BlueReader Battery the other way... todo bring it at the right updateplace
+                PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext()).edit().putInt("bridge_battery", (td.sensor_battery_level - 3300) * 100 / (prefs.getInt("blueReader_Full_Battery", 3800) - 3300)).apply();
             } else {
-                transmitter_status_view.append(" - ok");
+                if (td.sensor_battery_level <= Dex_Constants.TRANSMITTER_BATTERY_EMPTY) {
+                    transmitter_status_view.append(" - very low");
+                } else if (td.sensor_battery_level <= Dex_Constants.TRANSMITTER_BATTERY_LOW) {
+                    transmitter_status_view.append(" - low");
+                } else {
+                    transmitter_status_view.append(" - ok");
+                }
+
             }
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SendFeedBack.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SendFeedBack.java
@@ -3,11 +3,9 @@ package com.eveningoutpost.dexdrip.UtilityModels;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Environment;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.text.InputType;
-import android.text.format.DateFormat;
 import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
@@ -17,7 +15,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.eveningoutpost.dexdrip.Models.JoH;
-import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.R;
 import com.squareup.okhttp.FormEncodingBuilder;
 import com.squareup.okhttp.Interceptor;
@@ -27,22 +24,13 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.util.concurrent.TimeUnit;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
-
-import static com.eveningoutpost.dexdrip.utils.FileUtils.getExternalDir;
-import static com.eveningoutpost.dexdrip.utils.FileUtils.makeSureDirectoryExists;
 
 public class SendFeedBack extends AppCompatActivity {
 
@@ -88,55 +76,6 @@ public class SendFeedBack extends AppCompatActivity {
                     type_of_message = "Log Push";
                     myrating.setVisibility(View.GONE);
                     ratingtext.setVisibility(View.GONE);
-
-                    //zeitlich begrenzt
-                    FileOutputStream foStream = null;
-                    PrintStream printStream = null;
-                    ZipOutputStream zipOutputStream =null;
-                    String zipFilename = null;
-
-
-                    try {
-
-                        final String dir = getExternalDir();
-                        makeSureDirectoryExists(dir);
-
-                        final StringBuilder sb = new StringBuilder();
-                        sb.append(dir);
-                        sb.append("/exportlog");
-                        sb.append(DateFormat.format("yyyyMMdd-kkmmss", System.currentTimeMillis()));
-                        sb.append(".zip");
-                        zipFilename = sb.toString();
-                        final File sd = Environment.getExternalStorageDirectory();
-                        if (sd.canWrite()) {
-                            final File zipOutputFile = new File(zipFilename);
-
-                            foStream = new FileOutputStream(zipOutputFile);
-                            zipOutputStream = new ZipOutputStream(new BufferedOutputStream(foStream));
-                            zipOutputStream.putNextEntry(new ZipEntry("exportlog" + DateFormat.format("yyyyMMdd-kkmmss", System.currentTimeMillis()) + ".txt"));
-                            printStream = new PrintStream(zipOutputStream);
-
-                            //add Treatment and BGlucose Header
-                            printStream.println(log_data);
-                            printStream.flush();
-
-
-                        } else {
-                            UserError.Log.d(TAG, "SD card not writable!");
-                        }
-
-                    } catch (IOException e) {
-                        UserError.Log.e(TAG, "Exception while writing DB", e);
-                    } finally {
-                        if (printStream != null) {
-                            printStream.close();
-                        }
-                        if (zipOutputStream != null) try {
-                            zipOutputStream.close();
-                        } catch (IOException e1) {
-                            UserError.Log.e(TAG, "Something went wrong closing: ", e1);
-                        }
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SendFeedBack.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SendFeedBack.java
@@ -3,9 +3,11 @@ package com.eveningoutpost.dexdrip.UtilityModels;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Environment;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.text.InputType;
+import android.text.format.DateFormat;
 import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
@@ -15,6 +17,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.eveningoutpost.dexdrip.Models.JoH;
+import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.R;
 import com.squareup.okhttp.FormEncodingBuilder;
 import com.squareup.okhttp.Interceptor;
@@ -24,13 +27,22 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
+
+import static com.eveningoutpost.dexdrip.utils.FileUtils.getExternalDir;
+import static com.eveningoutpost.dexdrip.utils.FileUtils.makeSureDirectoryExists;
 
 public class SendFeedBack extends AppCompatActivity {
 
@@ -76,6 +88,55 @@ public class SendFeedBack extends AppCompatActivity {
                     type_of_message = "Log Push";
                     myrating.setVisibility(View.GONE);
                     ratingtext.setVisibility(View.GONE);
+
+                    //zeitlich begrenzt
+                    FileOutputStream foStream = null;
+                    PrintStream printStream = null;
+                    ZipOutputStream zipOutputStream =null;
+                    String zipFilename = null;
+
+
+                    try {
+
+                        final String dir = getExternalDir();
+                        makeSureDirectoryExists(dir);
+
+                        final StringBuilder sb = new StringBuilder();
+                        sb.append(dir);
+                        sb.append("/exportlog");
+                        sb.append(DateFormat.format("yyyyMMdd-kkmmss", System.currentTimeMillis()));
+                        sb.append(".zip");
+                        zipFilename = sb.toString();
+                        final File sd = Environment.getExternalStorageDirectory();
+                        if (sd.canWrite()) {
+                            final File zipOutputFile = new File(zipFilename);
+
+                            foStream = new FileOutputStream(zipOutputFile);
+                            zipOutputStream = new ZipOutputStream(new BufferedOutputStream(foStream));
+                            zipOutputStream.putNextEntry(new ZipEntry("exportlog" + DateFormat.format("yyyyMMdd-kkmmss", System.currentTimeMillis()) + ".txt"));
+                            printStream = new PrintStream(zipOutputStream);
+
+                            //add Treatment and BGlucose Header
+                            printStream.println(log_data);
+                            printStream.flush();
+
+
+                        } else {
+                            UserError.Log.d(TAG, "SD card not writable!");
+                        }
+
+                    } catch (IOException e) {
+                        UserError.Log.e(TAG, "Exception while writing DB", e);
+                    } finally {
+                        if (printStream != null) {
+                            printStream.close();
+                        }
+                        if (zipOutputStream != null) try {
+                            zipOutputStream.close();
+                        } catch (IOException e1) {
+                            UserError.Log.e(TAG, "Something went wrong closing: ", e1);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adding Battery Stuff for blueReader:
- percentage of Battery
- Rest days of Battery
- hide Low/-Bat-message in Home with nrf-flag, as it was misinterpretated for blueReader (may rework later)

Further:
- add log output of errors specific for bluereader in DexCollector and TransmitterData
- add Restart/reset of blueReader when in ugly state (clearly to check in addition, may need also a hibernate-send, and Collectionservice needs then also may a restart)

Surely the coding is not as its best, so every comment is welcome ;)