### PR TITLE
Remove the need to enter calibrations for the OOP algorithm.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2186,7 +2186,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         }
         if (isWifiWixel || isWifiBluetoothWixel || collector.equals(DexCollectionType.Mock)) {
             updateCurrentBgInfoForWifiWixel(notificationText);
-        } else if (is_follower || collector.equals(DexCollectionType.NSEmulator) ||DexCollectionType.isLibreOOPAlgorithm()) {
+        } else if (is_follower || collector.equals(DexCollectionType.NSEmulator) ||DexCollectionType.isLibreOOPAlgorithm(collector)) {
             displayCurrentInfo();
             getApplicationContext().startService(new Intent(getApplicationContext(), Notifications.class));
         } else if (!alreadyDisplayedBgInfoCommon && DexCollectionType.getDexCollectionType() == DexCollectionType.LibreAlarm) {
@@ -2374,7 +2374,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             showUncalibratedSlope();
             return;
         }
-        if(DexCollectionType.isLibreOOPAlgorithm()) {
+        if(DexCollectionType.isLibreOOPAlgorithm(null)) {
         	// Rest of this function deals with initial calibration. Since we currently don't have a way to calibrate,
         	// And even once we will have, there is probably no need to force a calibration at start of sensor use.
         	return;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2179,18 +2179,18 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             updateCurrentBgInfoForBtShare(notificationText);
         }
         if (isG5Share) {
-            updateCurrentBgInfoCommon(notificationText);
+            updateCurrentBgInfoCommon(collector, notificationText);
         }
         if (isBTWixel || isDexbridgeWixel || isWifiBluetoothWixel) {
-            updateCurrentBgInfoForBtBasedWixel(notificationText);
+            updateCurrentBgInfoForBtBasedWixel(collector, notificationText);
         }
         if (isWifiWixel || isWifiBluetoothWixel || collector.equals(DexCollectionType.Mock)) {
-            updateCurrentBgInfoForWifiWixel(notificationText);
+            updateCurrentBgInfoForWifiWixel(collector, notificationText);
         } else if (is_follower || collector.equals(DexCollectionType.NSEmulator) ||DexCollectionType.isLibreOOPAlgorithm(collector)) {
             displayCurrentInfo();
             getApplicationContext().startService(new Intent(getApplicationContext(), Notifications.class));
         } else if (!alreadyDisplayedBgInfoCommon && DexCollectionType.getDexCollectionType() == DexCollectionType.LibreAlarm) {
-            updateCurrentBgInfoCommon(notificationText);
+            updateCurrentBgInfoCommon(collector, notificationText);
         }
         if (collector.equals(DexCollectionType.Disabled)) {
             notificationText.append("\n DATA SOURCE DISABLED");
@@ -2289,17 +2289,17 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
     }
 
 
-    private void updateCurrentBgInfoForWifiWixel(TextView notificationText) {
+    private void updateCurrentBgInfoForWifiWixel(DexCollectionType collector, TextView notificationText) {
         if (!WixelReader.IsConfigured(getApplicationContext())) {
             notificationText.setText(R.string.first_configure_ip_address);
             return;
         }
 
-        updateCurrentBgInfoCommon(notificationText);
+        updateCurrentBgInfoCommon(collector, notificationText);
 
     }
 
-    private void updateCurrentBgInfoForBtBasedWixel(TextView notificationText) {
+    private void updateCurrentBgInfoForBtBasedWixel(DexCollectionType collector, TextView notificationText) {
         if ((android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN_MR2)) {
             notificationText.setText(R.string.unfortunately_andoird_version_no_blueooth_low_energy);
             return;
@@ -2309,10 +2309,10 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             notificationText.setText(R.string.first_use_menu_to_scan);
             return;
         }
-        updateCurrentBgInfoCommon(notificationText);
+        updateCurrentBgInfoCommon(collector, notificationText);
     }
 
-    private void updateCurrentBgInfoCommon(TextView notificationText) {
+    private void updateCurrentBgInfoCommon(DexCollectionType collector, TextView notificationText) {
         if (alreadyDisplayedBgInfoCommon) return; // with bluetooth and wifi, skip second time
         alreadyDisplayedBgInfoCommon = true;
 
@@ -2374,7 +2374,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             showUncalibratedSlope();
             return;
         }
-        if(DexCollectionType.isLibreOOPAlgorithm(null)) {
+        if(DexCollectionType.isLibreOOPAlgorithm(collector)) {
         	// Rest of this function deals with initial calibration. Since we currently don't have a way to calibrate,
         	// And even once we will have, there is probably no need to force a calibration at start of sensor use.
         	return;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2186,7 +2186,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         }
         if (isWifiWixel || isWifiBluetoothWixel || collector.equals(DexCollectionType.Mock)) {
             updateCurrentBgInfoForWifiWixel(notificationText);
-        } else if (is_follower || collector.equals(DexCollectionType.NSEmulator)) {
+        } else if (is_follower || collector.equals(DexCollectionType.NSEmulator) ||DexCollectionType.isLibreOOPAlgorithm()) {
             displayCurrentInfo();
             getApplicationContext().startService(new Intent(getApplicationContext(), Notifications.class));
         } else if (!alreadyDisplayedBgInfoCommon && DexCollectionType.getDexCollectionType() == DexCollectionType.LibreAlarm) {
@@ -2374,7 +2374,11 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             showUncalibratedSlope();
             return;
         }
-
+        if(DexCollectionType.isLibreOOPAlgorithm()) {
+        	// Rest of this function deals with initial calibration. Since we currently don't have a way to calibrate,
+        	// And even once we will have, there is probably no need to force a calibration at start of sensor use.
+        	return;
+        }
         if (BgReading.latest(3).size() > 2) {
             // TODO potential to calibrate off stale data here
             final List<Calibration> calibrations = Calibration.latestValid(2);
@@ -2511,7 +2515,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
     private void displayCurrentInfo() {
         DecimalFormat df = new DecimalFormat("#");
         df.setMaximumFractionDigits(0);
-
+        
         final boolean isDexbridge = CollectionServiceStarter.isDexBridgeOrWifiandDexBridge();
         // final boolean hasBtWixel = DexCollectionType.hasBtWixel();
         final boolean isLimitter = CollectionServiceStarter.isLimitter();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
@@ -130,6 +130,11 @@ public enum DexCollectionType {
     public static boolean hasFiltered() {
         return does_have_filtered || usesFiltered.contains(getDexCollectionType());
     }
+    
+    public static boolean isLibreOOPAlgorithm() {
+        return DexCollectionType.getDexCollectionType() == DexCollectionType.LimiTTer && 
+               Home.getPreferencesBooleanDefaultFalse("external_blukon_algorithm"); 
+    }
 
     public static Class<?> getCollectorServiceClass() {
         switch (getDexCollectionType()) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
@@ -131,8 +131,11 @@ public enum DexCollectionType {
         return does_have_filtered || usesFiltered.contains(getDexCollectionType());
     }
     
-    public static boolean isLibreOOPAlgorithm() {
-        return DexCollectionType.getDexCollectionType() == DexCollectionType.LimiTTer && 
+    public static boolean isLibreOOPAlgorithm(DexCollectionType collector) {
+    	if(collector == null) {
+    		collector = DexCollectionType.getDexCollectionType();
+    	}
+        return collector == DexCollectionType.LimiTTer && 
                Home.getPreferencesBooleanDefaultFalse("external_blukon_algorithm"); 
     }
 


### PR DESCRIPTION
Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>

Background:
Currently it is not possible to pass the oop algorithm through the calibration mechanism.
In the future, I want to allow both the option to calibrate and the option not to calibrate.
In the near future I want to allow people to scan directly using the phone, and also use the OOP algorithm. 
(and again that might be with calibrations and without calibrations.)

In this PR I remove the need for calibration. This is based on running without calibrations such as the ns emulator (and a follower, that does have calibrations now).
This is one way to solve the problem. Another way is to create a "fake" calibration and let the code work with it. This option is closer to other options that xDrip has.

What do people think?