### PR TITLE
Tzachi xdrip uploader

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
@@ -13,6 +13,7 @@ import com.eveningoutpost.dexdrip.Services.Ob1G5CollectionService;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
+import com.eveningoutpost.dexdrip.UtilityModels.UploaderQueue;
 import com.eveningoutpost.dexdrip.utils.PowerStateReceiver;
 import com.eveningoutpost.dexdrip.xdrip;
 import com.polidea.rxandroidble.RxBleConnection;
@@ -467,6 +468,7 @@ public class Ob1G5StateMachine {
             return;
         } else {
             UserError.Log.d(TAG, "Created transmitter data " + transmitterData.uuid + " " + JoH.dateTimeText(transmitterData.timestamp));
+            UploaderQueue.newTransmitterDataEntry("create", transmitterData);
             // TODO timeInMillisecondsOfLastSuccessfulSensorRead = captureTime;
         }
         Sensor sensor = Sensor.currentSensor();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/TransmitterData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/TransmitterData.java
@@ -214,6 +214,13 @@ public class TransmitterData extends Model {
             return null;
         }
     }
+    
+    public static TransmitterData byid(long id) {
+        return new Select()
+                .from(TransmitterData.class)
+                .where("_ID = ?", id)
+                .executeSingle();
+    }
 
     public static void updateTransmitterBatteryFromSync(final int battery_level) {
         try {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DailyIntentService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DailyIntentService.java
@@ -62,12 +62,6 @@ public class DailyIntentService extends IntentService {
                     Log.e(TAG, "DailyIntentService exception on UserError ", e);
                 }
                 try {
-                    BgSendQueue.cleanQueue(); // no longer used
-
-                } catch (Exception e) {
-                    Log.d(TAG, "DailyIntentService exception on BgSendQueue "+ e);
-                }
-                try {
                     CalibrationSendQueue.cleanQueue();
                 } catch (Exception e) {
                     Log.e(TAG, "DailyIntentService exception on CalibrationSendQueue ", e);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -58,6 +58,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.ForegroundServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.HM10Attributes;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.StatusItem;
+import com.eveningoutpost.dexdrip.UtilityModels.UploaderQueue;
 import com.eveningoutpost.dexdrip.UtilityModels.XbridgePlus;
 import com.eveningoutpost.dexdrip.utils.CheckBridgeBattery;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
@@ -1046,7 +1047,9 @@ public class DexCollectionService extends Service {
                         poll_backoff = 0;
                         retry_backoff = 0;
                         Log.v(TAG, "setSerialDataToTransmitterRawData: Creating TransmitterData at " + timestamp);
-                        processNewTransmitterData(TransmitterData.create(buffer, len, timestamp), timestamp);
+                        TransmitterData transmitterData = TransmitterData.create(buffer, len, timestamp);
+                        UploaderQueue.newEntry("create", transmitterData);
+                        processNewTransmitterData(transmitterData, timestamp);
                         if (Home.get_master())
                             GcmActivity.sendBridgeBattery(Home.getPreferencesInt("bridge_battery", -1));
                         CheckBridgeBattery.checkBridgeBattery();
@@ -1058,7 +1061,9 @@ public class DexCollectionService extends Service {
                     sendBtMessage(new byte[]{0x6C});
                 }
             } else {
-                processNewTransmitterData(TransmitterData.create(buffer, len, timestamp), timestamp);
+            	TransmitterData transmitterData = TransmitterData.create(buffer, len, timestamp);
+            	UploaderQueue.newEntry("create", transmitterData);
+                processNewTransmitterData(transmitterData, timestamp);
             }
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -1048,7 +1048,7 @@ public class DexCollectionService extends Service {
                         retry_backoff = 0;
                         Log.v(TAG, "setSerialDataToTransmitterRawData: Creating TransmitterData at " + timestamp);
                         TransmitterData transmitterData = TransmitterData.create(buffer, len, timestamp);
-                        UploaderQueue.newEntry("create", transmitterData);
+                        UploaderQueue.newTransmitterDataEntry("create", transmitterData);
                         processNewTransmitterData(transmitterData, timestamp);
                         if (Home.get_master())
                             GcmActivity.sendBridgeBattery(Home.getPreferencesInt("bridge_battery", -1));
@@ -1062,7 +1062,7 @@ public class DexCollectionService extends Service {
                 }
             } else {
             	TransmitterData transmitterData = TransmitterData.create(buffer, len, timestamp);
-            	UploaderQueue.newEntry("create", transmitterData);
+            	UploaderQueue.newTransmitterDataEntry("create", transmitterData);
                 processNewTransmitterData(transmitterData, timestamp);
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -56,44 +56,6 @@ public class BgSendQueue extends Model {
     @Column(name = "operation_type")
     public String operation_type;
 
-    /*
-        public static List<BgSendQueue> queue() {
-            return new Select()
-                    .from(BgSendQueue.class)
-                    .where("success = ?", false)
-                    .orderBy("_ID asc")
-                    .limit(20)
-                    .execute();
-        }
-    */
-    public static List<BgSendQueue> mongoQueue() {
-        return new Select()
-                .from(BgSendQueue.class)
-                .where("mongo_success = ?", false)
-                .where("operation_type = ?", "create")
-                .orderBy("_ID desc")
-                .limit(30)
-                .execute();
-    }
-
-    public static List<BgSendQueue> cleanQueue() {
-        return new Delete()
-                .from(BgSendQueue.class)
-                .where("mongo_success = ?", true)
-                .where("operation_type = ?", "create")
-                .execute();
-    }
-
-    private static void addToQueue(BgReading bgReading, String operation_type) {
-        BgSendQueue bgSendQueue = new BgSendQueue();
-        bgSendQueue.operation_type = operation_type;
-        bgSendQueue.bgReading = bgReading;
-        bgSendQueue.success = false;
-        bgSendQueue.mongo_success = false;
-        bgSendQueue.save();
-        Log.d("BGQueue", "New value added to queue!");
-    }
-
     public static void handleNewBgReading(BgReading bgReading, String operation_type, Context context) {
         handleNewBgReading(bgReading, operation_type, context, false);
     }
@@ -270,11 +232,6 @@ public class BgSendQueue extends Model {
         }
     }
 
-    public void markMongoSuccess() {
-        this.mongo_success = true;
-        save();
-    }
-
     public static int getBatteryLevel(Context context) {
         final Intent batteryIntent = context.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
         try {
@@ -288,4 +245,5 @@ public class BgSendQueue extends Model {
             return 50;
         }
     }
+    
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -1098,8 +1098,9 @@ public class NightscoutUploader {
                             testData.put("TransmissionId",-1);
                             testData.put("TransmitterId", "TransmitterId");
                             testData.put("ReceivedSignalStrength",-1);
-                            
-                            tdCollection.insert(testData, WriteConcern.UNACKNOWLEDGED);
+                            // Use upcerts for loading the data.
+                            BasicDBObject query = new BasicDBObject("CaptureDateTime", transmitterData.timestamp).append("RawValue", transmitterData.raw_data);
+                            tdCollection.update(query, testData, true, false,  WriteConcern.UNACKNOWLEDGED);
                         }
 
                         // TODO: quick port from original code, revisit before release

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/UploaderQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/UploaderQueue.java
@@ -186,6 +186,13 @@ public class UploaderQueue extends Model {
         return result;
     }
 
+    public static void newTransmitterDataEntry(String action, Model obj) {
+    	if(Home.getPreferencesBooleanDefaultFalse("mongo_load_transmitter_data")) {
+    		return;
+    	}
+    	newEntry(action, obj);
+    }
+    
     // TODO remove duplicated functionality, replace with generic multi-purpose method
     public static UploaderQueue newEntryForWatch(String action, Model obj) {
         UserError.Log.d(TAG, "new entry called for watch");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/UploaderQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/UploaderQueue.java
@@ -17,6 +17,7 @@ import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.BloodTest;
 import com.eveningoutpost.dexdrip.Models.Calibration;
 import com.eveningoutpost.dexdrip.Models.JoH;
+import com.eveningoutpost.dexdrip.Models.TransmitterData;
 import com.eveningoutpost.dexdrip.Models.Treatments;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.google.gson.Gson;
@@ -143,7 +144,7 @@ public class UploaderQueue extends Model {
     //////////////////////////////////////////
 
     public static UploaderQueue newEntry(String action, Model obj) {
-        UserError.Log.d(TAG, "new entry called");
+        Log.d(TAG, "new entry called");
         final UploaderQueue result = new UploaderQueue();
         result.bitfield_wanted = DEFAULT_UPLOAD_CIRCUITS
                 | (Home.getPreferencesBooleanDefaultFalse("cloud_storage_mongodb_enable") ? MONGO_DIRECT : 0)
@@ -162,6 +163,8 @@ public class UploaderQueue extends Model {
             result.reference_uuid = obj instanceof Calibration ? ((Calibration) obj).uuid : null;
         if (result.reference_uuid == null)
             result.reference_uuid = obj instanceof BloodTest ? ((BloodTest) obj).uuid : null;
+        if (result.reference_uuid == null)
+            result.reference_uuid = obj instanceof TransmitterData ? ((TransmitterData) obj).uuid : null;
 
         if (result.reference_uuid == null) {
             Log.d(TAG, "reference_uuid was null so refusing to create new entry");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/UploaderQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/UploaderQueue.java
@@ -187,7 +187,7 @@ public class UploaderQueue extends Model {
     }
 
     public static void newTransmitterDataEntry(String action, Model obj) {
-    	if(Home.getPreferencesBooleanDefaultFalse("mongo_load_transmitter_data")) {
+    	if(!Home.getPreferencesBooleanDefaultFalse("mongo_load_transmitter_data")) {
     		return;
     	}
     	newEntry(action, obj);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -692,6 +692,8 @@
     <string name="mongo_db_uri">Mongo DB Uri</string>
     <string name="skip_local_lan">For local servers with 192.168.x.x addresses, skip uploads when there is no local network connectivity.</string>
     <string name="skip_lan_uploads">Skip LAN uploads</string>
+    <string name="mongo_load_transmitter_data_title">Upload G4/G5 transmitters data</string>
+    <string name="mongo_load_transmitter_data_summary">Allow More than one xDrip to connect to BT devices and store the data that they receive in the cloud. This should allow all house coverage for G5, or 2 parents using the same BT device transperantly.</string>
     <string name="influxdb_sync">Enable InfluxDB sync</string>
     <string name="influxdb_uri">InfluxDB Uri</string>
     <string name="influxdb_database_name">InfluxDB Database Name</string>

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -53,6 +53,12 @@
                     android:key="skip_lan_uploads_when_no_lan"
                     android:summary="@string/skip_local_lan"
                     android:title="@string/skip_lan_uploads" />
+                
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="mongo_load_transmitter_data"
+                    android:summary="@string/mongo_load_transmitter_data_summary"
+                    android:title="@string/mongo_load_transmitter_data_title" />
 
             </PreferenceScreen>
 


### PR DESCRIPTION
With this change, xDrip will connect to the BT device and send the data that it collects to mongo DB. The data can be processed by another xDrip using wifi. This works for G4 and G5 devices.
Other data sources can be added later.

This should allow all house coverage for G5 or two parents to use one BT device transparently.
Basic testing on g4 worked correctly, and I'm starting a more serious testing phase. (I will not test G5 that I don't have, but change is trivial there).

Still need to implement rest uploads.

All comments are welcomed. 

