### PR TITLE
Tzachi oop phone scan 2

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreOOPAlgorithm.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreOOPAlgorithm.java
@@ -1,0 +1,34 @@
+package com.eveningoutpost.dexdrip.Models;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.eveningoutpost.dexdrip.xdrip;
+import com.eveningoutpost.dexdrip.ImportedLibraries.usbserial.util.HexDump;
+import com.eveningoutpost.dexdrip.Models.UserError.Log;
+import com.eveningoutpost.dexdrip.UtilityModels.Intents;
+
+import java.util.Arrays;
+
+public class LibreOOPAlgorithm {
+	private static final String TAG = "LibreOOPAlgorithm";
+	
+    static public void SendData(byte[] fullData) {
+    	Log.i(TAG, "Sending full data to OOP Algorithm data-len = " + fullData.length);
+    	
+    	fullData = java.util.Arrays.copyOfRange(fullData, 0, 0x158);
+    	Log.i(TAG, "Data that will be sent is " + HexDump.dumpHexString(fullData));
+    	
+    	
+    	
+    	Intent intent = new Intent(Intents.XDRIP_PLUS_LIBRE_DATA);
+        Bundle bundle = new Bundle();
+        bundle.putByteArray(Intents.LIBRE_DATA_BUFFER, fullData);
+        bundle.putLong(Intents.LIBRE_DATA_TIMESTAMP, JoH.tsl());
+        intent.putExtras(bundle);
+        intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
+        xdrip.getAppContext().sendBroadcast(intent);
+    }
+    
+    
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
@@ -110,6 +110,7 @@ public class NSEmulatorReceiver extends BroadcastReceiver {
                                                         // sanity checking???
                                                         // fake up some extra data
                                                         faux_bgr.put("raw_data", json_object.getDouble("sgv"));
+                                                        faux_bgr.put("age_adjusted_raw_value", json_object.getDouble("sgv"));
                                                         faux_bgr.put("filtered_data", json_object.getDouble("sgv"));
                                                         faux_bgr.put("uuid", UUID.randomUUID().toString());
                                                          


### PR DESCRIPTION
Read first 43 blocks of sensor, and send it to oop algorithm if needed.

In this change, number of blocks being read was increased to 43 (actually in multiblock it will read even 45 blocks).
Since original buffer was already 360, there was no need to increase buffer size.
From my experiments on a dead sensor, data that is read is always the same. Still need to verify it on real sensors of course.

To make code simple, the same number of blocks is always read. If anyone sees a problem with it, please let me know.

All comments are welcomed.