### PR TITLE
Fix layout of Missed Readings/Alert screens

### DIFF
--- a/app/src/main/res/layout/activity_edit_alert.xml
+++ b/app/src/main/res/layout/activity_edit_alert.xml
@@ -278,17 +278,20 @@
 
                     <LinearLayout
                         android:orientation="horizontal"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
+                        android:layout_width="fill_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center_vertical"
                         android:paddingTop="20dp">
 
                         <TextView
                             android:id="@+id/view_alert_override_silent"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:gravity="left"
                             android:text="@string/override_phone_silent_mode_colon"
                             android:textSize="15sp"
+                            android:gravity="left"
+                            android:layout_centerVertical="true"
+                            android:layout_weight="1"
                             />
 
                         <CheckBox
@@ -296,15 +299,19 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text=""
-                            android:textSize="15sp"/>
+                            android:textSize="15sp"
+                            android:gravity="right"
+                            android:layout_centerVertical="true"
+                            android:layout_weight="0" />
 
                     </LinearLayout>
 
                     <LinearLayout
                         android:orientation="horizontal"
-                        android:layout_width="wrap_content"
+                        android:layout_width="fill_parent"
                         android:layout_height="wrap_content"
-                        android:paddingTop="20dp">
+                        android:gravity="center_vertical"
+                        android:paddingTop="10dp">
 
                         <TextView
                             android:id="@+id/view_alert_vibrate"
@@ -313,6 +320,8 @@
                             android:gravity="left"
                             android:text="@string/vibrate_on_alert"
                             android:textSize="15sp"
+                            android:layout_alignParentLeft="true"
+                            android:layout_weight="1"
                             />
 
                         <CheckBox
@@ -320,15 +329,19 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text=""
-                            android:textSize="15sp"/>
+                            android:textSize="15sp"
+                            android:gravity="right"
+                            android:layout_alignParentRight="true"
+                            android:layout_weight="0" />
 
                     </LinearLayout>
-                    
+
                     <LinearLayout
                         android:orientation="horizontal"
-                        android:layout_width="wrap_content"
+                        android:layout_width="fill_parent"
                         android:layout_height="wrap_content"
-                        android:paddingTop="20dp">
+                        android:gravity="center_vertical"
+                        android:paddingTop="10dp">
 
                         <TextView
                             android:id="@+id/view_alert_disable"
@@ -337,6 +350,8 @@
                             android:gravity="left"
                             android:text="@string/disable_alert"
                             android:textSize="15sp"
+                            android:layout_alignParentLeft="true"
+                            android:layout_weight="1"
                             />
 
                         <CheckBox
@@ -344,7 +359,10 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text=""
-                            android:textSize="15sp"/>
+                            android:textSize="15sp"
+                            android:gravity="right"
+                            android:layout_alignParentRight="true"
+                            android:layout_weight="0" />
 
                     </LinearLayout>
                 </LinearLayout>

--- a/app/src/main/res/layout/activity_missed_readings.xml
+++ b/app/src/main/res/layout/activity_missed_readings.xml
@@ -29,31 +29,49 @@
                             android:layout_height="wrap_content"
                             android:text="Enable Missed Reading Alert"
                             android:textSize="15sp"
+                            android:padding="5dp"
                             android:layout_gravity="left"
-                            android:gravity="right" />
+                            android:layout_marginLeft="10dp"
+                            android:gravity="left" />
                         
                         <TextView
                             android:id="@+id/missed_reading_text_alert_time"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:gravity="left"
-                            android:text="Alert if no data recieved in x minutes:"
+                            android:text="Alert if no data recieved in:"
                             android:textSize="15sp"
                             android:layout_gravity="left"
-                            android:paddingRight="10dp" />
-                        
-                        <EditText
-                            android:layout_width="101dp"
+                            android:paddingLeft="15dp"
+                            android:paddingRight="10dp"
+                            android:paddingTop="10dp" />
+
+                        <LinearLayout
+                            android:layout_width="fill_parent"
                             android:layout_height="wrap_content"
-                            android:inputType="number"
-                            android:ems="10"
-                            android:id="@+id/missed_reading_bg_minutes"
-                            android:autoText="false"
-                            android:text=""
-                            android:singleLine="true"
-                            android:textAlignment="center"
-                            android:textSize="15sp"
-                            android:layout_alignParentStart="true" />
+                            android:paddingTop="0dp"
+                            android:paddingLeft="15dp">
+
+                            <EditText
+                                android:id="@+id/missed_reading_bg_minutes"
+                                android:layout_width="101dp"
+                                android:layout_height="wrap_content"
+                                android:autoText="false"
+                                android:ems="10"
+                                android:inputType="number"
+                                android:singleLine="true"
+                                android:text=""
+                                android:textAlignment="center"
+                                android:textSize="15sp" />
+
+                            <TextView
+                                android:id="@+id/missed_reading_bg_minutes_label"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="bottom"
+                                android:paddingBottom="5dp"
+                                android:text="minutes" />
+                        </LinearLayout>
                         
                         <TextView
                             android:id="@+id/missed_reading_text_select_time"
@@ -63,68 +81,21 @@
                             android:text="Select time for alert:"
                             android:textSize="15sp"
                             android:layout_gravity="left"
-                            android:paddingRight="10dp" />
+                            android:paddingLeft="15dp"
+                            android:paddingRight="10dp"
+                            android:paddingTop="10dp"
+                            android:paddingBottom="5dp"/>
                         
                         <CheckBox
                             android:id="@+id/missed_reading_all_day"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="all day"
+                            android:text="All Day"
                             android:textSize="15sp"
-                            android:layout_gravity="center"
-                            android:gravity="right" />
-                        
-                        <TextView
-                            android:id="@+id/missed_reading_bg_snooze_text"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:gravity="left"
-                            android:text="Number of minutes before raising the same alert after snooze"
-                            android:textSize="15sp"
+                            android:padding="5dp"
                             android:layout_gravity="left"
-                            android:paddingRight="10dp" />
-
-                        <EditText
-                            android:layout_width="101dp"
-                            android:layout_height="wrap_content"
-                            android:inputType="number"
-                            android:ems="10"
-                            android:id="@+id/missed_reading_bg_snooze"
-                            android:autoText="false"
-                            android:text=""
-                            android:singleLine="true"
-                            android:textAlignment="center"
-                            android:textSize="15sp"
-                            android:layout_alignParentStart="true" />
-                        <CheckBox
-                            android:id="@+id/missed_reading_enable_alerts_reraise"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Reraise alerts before snooze time"
-                            android:textSize="15sp"
-                            android:layout_gravity="center"
-                            android:gravity="right" />
-                        <TextView
-                            android:id="@+id/missed_reading_reraise_sec_text"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:gravity="left"
-                            android:text="Alert Reraise time (in SECONDS)"
-                            android:textSize="15sp"
-                            android:layout_gravity="left"
-                            android:paddingRight="10dp" />
-                        <EditText
-                            android:layout_width="101dp"
-                            android:layout_height="wrap_content"
-                            android:inputType="number"
-                            android:ems="10"
-                            android:id="@+id/missed_reading_reraise_sec"
-                            android:autoText="false"
-                            android:text=""
-                            android:singleLine="true"
-                            android:textAlignment="center"
-                            android:textSize="15sp"
-                            android:layout_alignParentStart="true" />
+                            android:layout_marginLeft="10dp"
+                            android:gravity="left"  />
 
                     </LinearLayout>
 
@@ -188,7 +159,107 @@
                             android:id="@+id/missed_reading_instructions_end"/>
 
                     </LinearLayout>
-                
+
+                    <LinearLayout
+                        android:orientation="vertical"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="20dp">
+                        <TextView
+                            android:id="@+id/missed_reading_bg_snooze_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="left"
+                            android:text="Wait before raising the same alert after snooze:"
+                            android:textSize="15sp"
+                            android:layout_gravity="left"
+                            android:paddingRight="10dp"
+                            android:paddingLeft="15dp" />
+
+                        <LinearLayout
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingTop="0dp"
+                            android:paddingLeft="15dp">
+
+                            <EditText
+                                android:id="@+id/missed_reading_bg_snooze"
+                                android:layout_width="101dp"
+                                android:layout_height="wrap_content"
+                                android:inputType="number"
+                                android:ems="10"
+                                android:autoText="false"
+                                android:text=""
+                                android:singleLine="true"
+                                android:textAlignment="center"
+                                android:textSize="15sp"
+                                android:layout_alignParentStart="true" />
+
+                            <TextView
+                                android:id="@+id/missed_reading_bg_snooze_label"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="bottom"
+                                android:paddingBottom="5dp"
+                                android:text="minutes" />
+                        </LinearLayout>
+
+                        <CheckBox
+                            android:id="@+id/missed_reading_enable_alerts_reraise"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Reraise alerts before snooze time"
+                            android:textSize="15sp"
+                            android:padding="5dp"
+                            android:layout_gravity="left"
+                            android:layout_marginLeft="10dp"
+                            android:gravity="left" />
+
+
+
+                        <TextView
+                            android:id="@+id/missed_reading_reraise_sec_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="left"
+                            android:text="Alert Reraise time:"
+                            android:textSize="15sp"
+                            android:layout_gravity="left"
+                            android:paddingLeft="15dp"
+                            android:paddingRight="10dp"
+                            android:paddingTop="10dp" />
+
+                        <LinearLayout
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingTop="0dp"
+                            android:paddingLeft="15dp">
+
+                            <EditText
+                                android:id="@+id/missed_reading_reraise_sec"
+                                android:layout_width="101dp"
+                                android:layout_height="wrap_content"
+                                android:inputType="number"
+                                android:ems="10"
+                                android:autoText="false"
+                                android:text=""
+                                android:singleLine="true"
+                                android:textAlignment="center"
+                                android:textSize="15sp"
+                                android:layout_alignParentStart="true" />
+
+                            <TextView
+                                android:id="@+id/missed_Reading_reraise_sec_label"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="bottom"
+                                android:paddingBottom="5dp"
+                                android:text="seconds" />
+                        </LinearLayout>
+
+
+                    </LinearLayout>
+
             </LinearLayout>
         </ScrollView>
 

--- a/app/src/main/res/layout/activity_missed_readings.xml
+++ b/app/src/main/res/layout/activity_missed_readings.xml
@@ -27,7 +27,7 @@
                             android:id="@+id/missed_reading_enable_alert"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="enable alert"
+                            android:text="Enable Missed Reading Alert"
                             android:textSize="15sp"
                             android:layout_gravity="left"
                             android:gravity="right" />
@@ -37,7 +37,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:gravity="left"
-                            android:text="Alert if no data receieved in x minutes:"
+                            android:text="Alert if no data recieved in x minutes:"
                             android:textSize="15sp"
                             android:layout_gravity="left"
                             android:paddingRight="10dp" />

--- a/app/src/main/res/layout/activity_missed_readings.xml
+++ b/app/src/main/res/layout/activity_missed_readings.xml
@@ -39,7 +39,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:gravity="left"
-                            android:text="Alert if no data recieved in:"
+                            android:text="Alert if no data received in:"
                             android:textSize="15sp"
                             android:layout_gravity="left"
                             android:paddingLeft="15dp"


### PR DESCRIPTION
Slightly modifies the layouts of the Missed Readings and Edit/Create Alert settings pages to be more consistent. 

Missed Readings layout screenshot: 
![image](https://user-images.githubusercontent.com/192620/35364068-3311487a-013b-11e8-9768-580ba3b3024f.png)


Edit Alert layout screenshot: 
![image](https://user-images.githubusercontent.com/192620/35364098-4e05b6de-013b-11e8-892a-399285865969.png)
