### PR TITLE
Gvi filter

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -16,6 +16,7 @@ import com.eveningoutpost.dexdrip.ImportedLibraries.dexcom.Dex_Constants;
 import com.eveningoutpost.dexdrip.R;
 
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -134,32 +135,106 @@ public class FirstPageFragment extends Fragment {
                 TextView coefficientOfVariation = (TextView) localView.findViewById(R.id.textView_coefficient_of_variation);
                 updateText(localView, coefficientOfVariation, Math.round(1000d*stdev/mean)/10d + "%");
 
+
+                //calculate BGI / PGS
+                // https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/report_plugins/glucosedistribution.js#L150
                 List<BgReadingStats> bgListByTime = DBSearchUtil.getReadings(false);
-                double NormalReadingspct = inRange*100/total;
-                double glucoseFirst = bgListByTime.get(0).calculated_value;
+
+
+                // data cleaning pass 1 - add interpolated missing points
+                List<BgReadingStats> glucose_data = new ArrayList<>(bgListByTime.size());
+                for (int i=0; i<bgListByTime.size()-2; i++) {
+
+                    BgReadingStats entry = bgListByTime.get(i);
+                    BgReadingStats nextEntry = bgListByTime.get(i + 1);
+
+                    long timeDelta = nextEntry.timestamp - entry.timestamp;
+
+                    if (timeDelta < 9 * 60 * 1000 ||  timeDelta > 25 * 60 * 1000) {
+                        glucose_data.add(entry);
+                        continue;
+                    }
+                    int missingRecords = (int) (Math.floor(timeDelta / (5 * 60 * 990)) -1);
+                    long timePatch = (long) Math.floor(timeDelta / (missingRecords + 1));
+                    double bgDelta = (nextEntry.calculated_value - entry.calculated_value) / (missingRecords + 1);
+                    glucose_data.add(entry);
+
+                    for (int j = 1; j <= missingRecords; j++) {
+                        BgReadingStats newEntry = new BgReadingStats();
+                        newEntry.calculated_value = entry.calculated_value + bgDelta * j;
+                        newEntry.timestamp = (entry.timestamp + j * timePatch);
+                        glucose_data.add(newEntry);
+                    }
+                }
+
+                // data cleaning pass 2 - replace single jumpy measures with interpolated values
+                List<BgReadingStats> glucose_data2 = new ArrayList<>(glucose_data.size());
+                BgReadingStats prevEntry = null;
+                if(glucose_data.size() > 0) {
+                    glucose_data2.add(glucose_data.get(0));
+                    prevEntry = glucose_data.get(0);
+                }
+
+                for (int i = 1; i < glucose_data.size()-2; i++) {
+                    BgReadingStats entry = glucose_data.get(i);
+                    BgReadingStats nextEntry = glucose_data.get(i+1);
+                    long timeDelta = nextEntry.timestamp - entry.timestamp;
+                    long timeDelta2 = entry.timestamp - prevEntry.timestamp;
+                    long maxGap = (5 * 60 * 1000) + 20000;
+                    if (timeDelta > maxGap || timeDelta2 > maxGap ) {
+                        glucose_data2.add(entry);
+                        prevEntry = entry;
+                        continue;
+                    }
+                    double delta1 = entry.calculated_value - prevEntry.calculated_value;
+                    double delta2 = nextEntry.calculated_value - entry.calculated_value;
+                    if (delta1 <= 8 && delta2 <= 8) {
+                        glucose_data2.add(entry);
+                        prevEntry = entry;
+                        continue;
+                    }
+
+                    if ((delta1 > 0 && delta2 <0) || (delta1 < 0 && delta2 > 0)) {
+                        double d = (nextEntry.calculated_value - prevEntry.calculated_value) / 2;
+                        BgReadingStats newEntry = new BgReadingStats();
+                        newEntry.calculated_value = prevEntry.calculated_value + d;
+                        newEntry.timestamp = entry.timestamp;
+
+                        glucose_data2.add(newEntry);
+                        prevEntry = newEntry;
+                        continue;
+
+                    }
+                    glucose_data2.add(entry);
+                    prevEntry = entry;
+                }
+                glucose_data = glucose_data2;
+
+                double normalReadingspct= inRange*100/total; //TODO calculate from cleaned data?
+                double glucoseFirst = glucose_data.get(0).calculated_value;
                 double glucoseLast = glucoseFirst;
                 double glucoseTotal =  glucoseLast;
-                double GVITotal = 0;
+                double gviTotal = 0;
                 int usedRecords = 1;
-                for (int i=1; i<bgListByTime.size();i++) {
-                    BgReadingStats bgr = bgListByTime.get(i);
+                for (int i=1; i<glucose_data.size();i++) {
+                    BgReadingStats bgr = glucose_data.get(i);
                     double delta = bgr.calculated_value - glucoseLast;
-                    GVITotal += Math.sqrt(25 + Math.pow(delta, 2));
+                    gviTotal += Math.sqrt(25 + Math.pow(delta, 2));
                     usedRecords += 1;
                     glucoseLast = bgr.calculated_value;
                     glucoseTotal +=  glucoseLast;
                 }
-                double GVIDelta = Math.abs(glucoseLast - glucoseFirst);//Math.floor(glucose_data[0].bgValue,glucose_data[glucose_data.length-1].bgValue);
-                double GVIIdeal = Math.sqrt(Math.pow(usedRecords*5,2) + Math.pow(GVIDelta,2));
-                double GVI = (GVITotal / GVIIdeal * 100) / 100;
-                Log.d("DrawStats", "GVI=" + GVI + " GVIIdeal=" + GVIIdeal + " GVITotal=" + GVITotal + " GVIDelta=" + GVIDelta + " usedRecords=" + usedRecords);
+                double gviDelta = Math.abs(glucoseLast - glucoseFirst);//Math.floor(glucose_data[0].bgValue,glucose_data[glucose_data.length-1].bgValue);
+                double gviIdeal = Math.sqrt(Math.pow(usedRecords*5,2) + Math.pow(gviDelta,2));
+                double gvi = (gviTotal / gviIdeal * 100) / 100;
+                Log.d("DrawStats", "GVI=" + gvi + " GVIIdeal=" + gviIdeal + " GVITotal=" + gviTotal + " GVIDelta=" + gviDelta + " usedRecords=" + usedRecords);
                 double glucoseMean = Math.floor(glucoseTotal / usedRecords);
-                double tirMultiplier = NormalReadingspct / 100.0;
-                double PGS = (GVI * glucoseMean * (1-tirMultiplier) * 100) / 100;
-                Log.d("DrawStats", "NormalReadingspct=" + NormalReadingspct + " glucoseMean=" + glucoseMean + " tirMultiplier=" + tirMultiplier + " PGS=" + PGS);
+                double tirMultiplier = normalReadingspct / 100.0;
+                double PGS = (gvi * glucoseMean * (1-tirMultiplier) * 100) / 100;
+                Log.d("DrawStats", "NormalReadingspct=" + normalReadingspct + " glucoseMean=" + glucoseMean + " tirMultiplier=" + tirMultiplier + " PGS=" + PGS);
                 TextView gviView = (TextView) localView.findViewById(R.id.textView_gvi);
                 DecimalFormat df = new DecimalFormat("#.00");
-                updateText(localView, gviView,  df.format(GVI) + "  PGS:  " + df.format(PGS));
+                updateText(localView, gviView,  df.format(gvi) + "  PGS:  " + df.format(PGS));
 
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -139,7 +139,8 @@ public class FirstPageFragment extends Fragment {
 
                 //calculate BGI / PGS
                 // https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/report_plugins/glucosedistribution.js#L150
-                List<BgReadingStats> bgListByTime = DBSearchUtil.getReadings(false);
+                List<BgReadingStats> bgListByTime = DBSearchUtil.getFilteredReadingsWithFallback(false);
+
                 bgListByTime = pass1DataCleaning(bgListByTime);
                 bgListByTime = pass2DataCleaning(bgListByTime);
 


### PR DESCRIPTION
1) Use the 1st pass filter that fills the gaps like in the Nightscout report
2) Use the 2nd pass filter that eliminates single outliers with deltas > 8 (jump up AND down the next)
3) Use filtered data as micro-noise can artificially lengthen the trace

@kskandis (or @kskandispersonal ?) could you please take a look at this? Thanks! 