### PR TITLE
Update for Tomato and Bluetooth handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -286,6 +286,10 @@ dependencies {
     // add this for webview testing support
     //androidTestImplementation 'com.android.support.test.espresso:espresso-web:3.0.1'
 
+    // you will want to install the android studio lombok plugin
+    compileOnly 'org.projectlombok:lombok:1.16.18'
+    //compileOnly 'javax.annotation:javax.annotation-api:1.3.1'
+    annotationProcessor "org.projectlombok:lombok:1.16.18"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -42,22 +42,23 @@ import android.preference.PreferenceManager;
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.ImportedLibraries.usbserial.util.HexDump;
-import com.eveningoutpost.dexdrip.Models.JoH;
-import com.eveningoutpost.dexdrip.Models.UserError;
-import com.eveningoutpost.dexdrip.Models.UserError.Log;
-
 import com.eveningoutpost.dexdrip.Models.ActiveBluetoothDevice;
 import com.eveningoutpost.dexdrip.Models.BgReading;
-import com.eveningoutpost.dexdrip.Models.TransmitterData;
+import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.Sensor;
-import com.eveningoutpost.dexdrip.Models.blueReader;
 import com.eveningoutpost.dexdrip.Models.Tomato;
+import com.eveningoutpost.dexdrip.Models.TransmitterData;
+import com.eveningoutpost.dexdrip.Models.UserError;
+import com.eveningoutpost.dexdrip.Models.UserError.Log;
+import com.eveningoutpost.dexdrip.Models.blueReader;
 import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.UtilityModels.Blukon;
+import com.eveningoutpost.dexdrip.UtilityModels.BridgeResponse;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.ForegroundServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.HM10Attributes;
+import com.eveningoutpost.dexdrip.UtilityModels.Inevitable;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.StatusItem;
@@ -81,31 +82,9 @@ import static com.eveningoutpost.dexdrip.UtilityModels.BgGraphBuilder.DEXCOM_PER
 
 @TargetApi(Build.VERSION_CODES.KITKAT)
 public class DexCollectionService extends Service {
+    public static final String LIMITTER_NAME = "LimiTTer";
     private final static String TAG = DexCollectionService.class.getSimpleName();
     private static final boolean d = false;
-    private SharedPreferences prefs;
-
-    private static PendingIntent serviceIntent;
-    private static PendingIntent serviceFailoverIntent;
-    public DexCollectionService dexCollectionService;
-
-    private BluetoothAdapter mBluetoothAdapter;
-    private BluetoothGatt mBluetoothGatt;
-    private String mDeviceAddress;
-    private ForegroundServiceStarter foregroundServiceStarter;
-    private int mConnectionState = BluetoothProfile.STATE_DISCONNECTING;
-    private static int mStaticState = BluetoothProfile.STATE_DISCONNECTING;
-    private static int mStaticStateWatch = 0; // default unknown
-    private static byte[] immediateSend;
-    private static String bondedState;
-    private static int bondingTries = 0;
-    private BluetoothDevice device;
-    private BluetoothGattCharacteristic mCharacteristic;
-    // Experimental support for rfduino from Tomasz Stachowicz
-    private BluetoothGattCharacteristic mCharacteristicSend;
-    long lastPacketTime;
-    private byte[] lastdata = null;
-    private final Object mLock = new Object();
     //private Context mContext;
     private static final int STATE_DISCONNECTED = BluetoothProfile.STATE_DISCONNECTED;
     private static final int STATE_DISCONNECTING = BluetoothProfile.STATE_DISCONNECTING;
@@ -116,21 +95,30 @@ public class DexCollectionService extends Service {
     private static final long POLLING_PERIOD = (Constants.MINUTE_IN_MS * 5) - Constants.SECOND_IN_MS;
     private static final long RETRY_PERIOD = DEXCOM_PERIOD - (Constants.SECOND_IN_MS * 35);
     private static final long TOLERABLE_JITTER = 10000;
-
-    public static double last_time_seen = 0;
+    private static long last_time_seen = 0;
     public static String lastState = "Not running";
+    public static String lastError = null;
     public static TransmitterData last_transmitter_Data;
+    //WATCH:
+    public static String lastStateWatch = "Not running";
+    private static PendingIntent serviceIntent;
+    private static PendingIntent serviceFailoverIntent;
+    private static volatile BluetoothGatt mBluetoothGatt;
+    private volatile static int mStaticState = BluetoothProfile.STATE_DISCONNECTING;
+    private static int mStaticStateWatch = 0; // default unknown
+    private static byte[] immediateSend;
+    private static String bondedState;
+    private static int bondingTries = 0;
     private static int last_battery_level = -1;
     private static long retry_time = 0;
     private static long failover_time = 0;
     private static long poll_backoff = 0;
     private static long retry_backoff = 0;
+    private static long last_connect_request = 0;
     private static long descriptor_time = 0;
     private static int watchdog_count = 0;
     private static long max_wakeup_jitter = 0;
-    private static DISCOVERED servicesDiscovered = DISCOVERED.NULL;
-
-
+    private static volatile DISCOVERED servicesDiscovered = DISCOVERED.NULL;
     private static boolean static_use_transmiter_pl_bluetooth = false;
     private static boolean static_use_rfduino_bluetooth = false;
     private static boolean static_use_polling = false;
@@ -138,9 +126,6 @@ public class DexCollectionService extends Service {
     private static boolean static_use_nrf = false;
     private static String static_last_hexdump;
     private static String static_last_sent_hexdump;
-
-    //WATCH:
-    public static String lastStateWatch = "Not running";
     private static TransmitterData last_transmitter_DataWatch;
     private static int last_battery_level_watch = -1;
     private static long last_poll_sent = 0;
@@ -148,156 +133,41 @@ public class DexCollectionService extends Service {
     private static long failover_time_watch = 0;
     private static String static_last_hexdump_watch;
     private static String static_last_sent_hexdump_watch;
-
+    public final UUID CCCD = UUID.fromString(HM10Attributes.CLIENT_CHARACTERISTIC_CONFIG);
+    public final UUID nrfDataService = UUID.fromString(HM10Attributes.NRF_UART_SERVICE);
+    public final UUID nrfDataRXCharacteristic = UUID.fromString(HM10Attributes.NRF_UART_TX);
+    public final UUID nrfDataTXCharacteristic = UUID.fromString(HM10Attributes.NRF_UART_RX);
+    private final Object mLock = new Object();
     // Experimental support for "Transmiter PL" from Marek Macner @FPV-UAV
     private final boolean use_transmiter_pl_bluetooth = Pref.getBooleanDefaultFalse("use_transmiter_pl_bluetooth");
     private final boolean use_rfduino_bluetooth = Pref.getBooleanDefaultFalse("use_rfduino_bluetooth");
-  //  private final boolean use_polling = Home.getBooleanDefaultFalse(PREF_DEX_COLLECTION_POLLING) && DexCollectionType.hasLibre();
+    //  private final boolean use_polling = Home.getBooleanDefaultFalse(PREF_DEX_COLLECTION_POLLING) && DexCollectionType.hasLibre();
     private final boolean use_polling = Pref.getBooleanDefaultFalse(PREF_DEX_COLLECTION_POLLING);
     private final UUID xDripDataService = use_transmiter_pl_bluetooth ? UUID.fromString(HM10Attributes.TRANSMITER_PL_SERVICE) : UUID.fromString(HM10Attributes.HM_10_SERVICE);
     private final UUID xDripDataCharacteristic = use_transmiter_pl_bluetooth ? UUID.fromString(HM10Attributes.TRANSMITER_PL_RX_TX) : UUID.fromString(HM10Attributes.HM_RX_TX);
     // Experimental support for rfduino from Tomasz Stachowicz
     private final UUID xDripDataCharacteristicSend = use_rfduino_bluetooth ? UUID.fromString(HM10Attributes.HM_TX) : UUID.fromString(HM10Attributes.HM_RX_TX);
-
     private final String DEFAULT_BT_PIN = getDefaultPin();
-
-    public final UUID CCCD = UUID.fromString(HM10Attributes.CLIENT_CHARACTERISTIC_CONFIG);
-    public final UUID nrfDataService = UUID.fromString(HM10Attributes.NRF_UART_SERVICE);
-    public final UUID nrfDataRXCharacteristic = UUID.fromString(HM10Attributes.NRF_UART_TX);
-    public final UUID nrfDataTXCharacteristic = UUID.fromString(HM10Attributes.NRF_UART_RX);
-
     private final UUID blukonDataService = UUID.fromString(HM10Attributes.BLUKON_SERVICE);
-
-    private enum DISCOVERED {
-        NULL,
-        PENDING,
-        COMPLETE
-    }
-
-    private static String getDefaultPin() {
-        final String bk_pin = Blukon.getPin();
-        return bk_pin != null ? bk_pin : HM10Attributes.HM_DEFAULT_BT_PIN;
-    }
-
-    @Override
-    public IBinder onBind(Intent intent) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public void onCreate() {
-        foregroundServiceStarter = new ForegroundServiceStarter(getApplicationContext(), this);
-        foregroundServiceStarter.start();
-        //mContext = getApplicationContext();
-        dexCollectionService = this;
-        prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-        listenForChangeInSettings();
-        //bgToSpeech = BgToSpeech.setupTTS(mContext); //keep reference to not being garbage collected
-        if(CollectionServiceStarter.isDexBridgeOrWifiandDexBridge()){
-            Log.i(TAG,"onCreate: resetting bridge_battery preference to 0");
-            prefs.edit().putInt("bridge_battery",0).apply();
-            //if (Home.get_master()) GcmActivity.sendBridgeBattery(prefs.getInt("bridge_battery",-1));
+    public DexCollectionService dexCollectionService;
+    long lastPacketTime;
+    private SharedPreferences prefs;
+    private BluetoothAdapter mBluetoothAdapter;
+    private String mDeviceAddress;
+    private final BroadcastReceiver mPairingRequestRecevier = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            Log.d(TAG, "Received pairing request");
+            JoH.doPairingRequest(context, this, intent, mDeviceAddress, DEFAULT_BT_PIN);
         }
-
-        final IntentFilter pairingRequestFilter = new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST);
-        pairingRequestFilter.setPriority(IntentFilter.SYSTEM_HIGH_PRIORITY - 1);
-        registerReceiver(mPairingRequestRecevier, pairingRequestFilter);
-        Log.i(TAG, "onCreate: STARTING SERVICE: pin code: " + DEFAULT_BT_PIN);
-    }
-
-    @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        final PowerManager.WakeLock wl = JoH.getWakeLock("dexcollect-service", 120000);
-        if (retry_time > 0 && failover_time > 0) {
-            final long requested_wake_time = Math.min(retry_time, failover_time);
-            final long wakeup_jitter = JoH.msSince(requested_wake_time);
-            Log.d(TAG, "Wake up jitter: " + JoH.niceTimeScalar(wakeup_jitter));
-            JoH.persistentBuggySamsungCheck();
-            if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && (JoH.isSamsung())) {
-                UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
-                JoH.setBuggySamsungEnabled();
-                max_wakeup_jitter = 0;
-            } else {
-                max_wakeup_jitter = Math.max(max_wakeup_jitter, wakeup_jitter);
-            }
-        }
-        retry_time = 0;
-        failover_time = 0;
-        static_use_rfduino_bluetooth = use_rfduino_bluetooth;
-        static_use_transmiter_pl_bluetooth = use_transmiter_pl_bluetooth;
-        static_use_polling = use_polling;
-        status("Started");
-        if (shouldServiceRun()) {
-            setFailoverTimer();
-        } else {
-            status("Stopping");
-            stopSelf();
-            JoH.releaseWakeLock(wl);
-            return START_NOT_STICKY;
-        }
-        lastdata = null;
-        checkConnection();
-        watchdog();
-        JoH.releaseWakeLock(wl);
-        return START_STICKY;
-    }
-
-
-    private static boolean shouldServiceRun() {
-        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) return false;
-        final boolean result = (DexCollectionType.hasXbridgeWixel() || DexCollectionType.hasBtWixel())
-                && ((!Home.get_forced_wear() && (((UiModeManager) xdrip.getAppContext().getSystemService(UI_MODE_SERVICE)).getCurrentModeType() != Configuration.UI_MODE_TYPE_WATCH))
-                || PersistentStore.getBoolean(CollectionServiceStarter.pref_run_wear_collector));
-        if (d) Log.d(TAG, "shouldServiceRun() returning: " + result);
-        return result;
-    }
-
-
-    @Override
-    public void onDestroy() {
-        status("Shutdown");
-        super.onDestroy();
-        Log.d(TAG, "onDestroy entered");
-        close();
-        foregroundServiceStarter.stop();
-
-        try {
-            unregisterReceiver(mPairingRequestRecevier);
-        } catch (Exception e) {
-            android.util.Log.e(TAG, "Error unregistering pairing receiver: " + e);
-        }
-
-        if (shouldServiceRun()) {//Android killed service
-            setRetryTimer();
-            status("Stopped, attempting restart");
-        }
-        else {//onDestroy triggered by CollectionServiceStart.stopBtService
-            Log.d(TAG, "onDestroy stop Alarm serviceIntent");
-            JoH.cancelAlarm(this,serviceIntent);
-            Log.d(TAG, "onDestroy stop Alarm serviceFailoverIntent");
-            JoH.cancelAlarm(this,serviceFailoverIntent);
-            status("Service full stop");
-            retry_time = 0;
-            failover_time = 0;
-        }
-        //BgToSpeech.tearDownTTS();
-
-        retry_backoff = 0;
-        poll_backoff = 0;
-        servicesDiscovered = DISCOVERED.NULL;
-        bondingTries = 0;
-
-        Log.i(TAG, "SERVICE STOPPED");
-    }
-
-    // remember needs proguard exclusion due to access by reflection
-    public static boolean isCollecting() {
-       if (static_use_blukon) {
-           return Blukon.isCollecting();
-       }
-       return false;
-    }
-
+    };
+    private ForegroundServiceStarter foregroundServiceStarter;
+    private volatile int mConnectionState = BluetoothProfile.STATE_DISCONNECTING;
+    private BluetoothDevice device;
+    private BluetoothGattCharacteristic mCharacteristic;
+    // Experimental support for rfduino from Tomasz Stachowicz
+    private BluetoothGattCharacteristic mCharacteristicSend;
+    private byte[] lastdata = null;
     public SharedPreferences.OnSharedPreferenceChangeListener prefListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
         public void onSharedPreferenceChanged(SharedPreferences prefs, String key) {
             if (key.compareTo("run_service_in_foreground") == 0) {
@@ -311,200 +181,13 @@ public class DexCollectionService extends Service {
                     Log.d(TAG, "Removing from foreground");
                 }
             }
-            if(key.equals("dex_collection_method") || key.equals("dex_txid")){
+            if (key.equals("dex_collection_method") || key.equals("dex_txid")) {
                 //if the input method or ID changed, accept any new package once even if they seem duplicates
                 Log.d(TAG, "collection method or txID changed - setting lastdata to null");
                 lastdata = null;
             }
         }
     };
-
-    public void listenForChangeInSettings() {
-        prefs.registerOnSharedPreferenceChangeListener(prefListener);
-    }
-
-    public void setRetryTimer() {
-        mStaticState = mConnectionState;
-        if (shouldServiceRun()) {
-            //final long retry_in = (Constants.SECOND_IN_MS * 25);
-            final long retry_in = whenToRetryNext();
-            Log.d(TAG, "setRetryTimer: Restarting in: " + (retry_in / Constants.SECOND_IN_MS) + " seconds");
-            serviceIntent = PendingIntent.getService(this, Constants.DEX_COLLECTION_SERVICE_RETRY_ID, new Intent(this, this.getClass()), 0);
-            retry_time = JoH.wakeUpIntent(this, retry_in, serviceIntent);
-        } else {
-            Log.d(TAG, "Not setting retry timer as service should not be running");
-        }
-    }
-
-    public synchronized void setFailoverTimer() {
-        if (shouldServiceRun()) {
-            final long retry_in = use_polling ? whenToPollNext() : (Constants.MINUTE_IN_MS * 6);
-            Log.d(TAG, "setFailoverTimer: Fallover Restarting in: " + (retry_in / (Constants.MINUTE_IN_MS)) + " minutes");
-            serviceFailoverIntent = PendingIntent.getService(this, Constants.DEX_COLLECTION_SERVICE_FAILOVER_ID, new Intent(this, this.getClass()), 0);
-            failover_time = JoH.wakeUpIntent(this, retry_in, serviceFailoverIntent);
-            retry_time = 0; // only one alarm will run
-        } else {
-            stopSelf();
-        }
-    }
-
-    private long whenToRetryNext() {
-        final long poll_time = Math.max((Constants.SECOND_IN_MS * 10) + retry_backoff, RETRY_PERIOD - JoH.msSince(lastPacketTime));
-        if (retry_backoff < (Constants.MINUTE_IN_MS)) {
-            retry_backoff += Constants.SECOND_IN_MS;
-        }
-        Log.d(TAG, "Scheduling next retry in: " + JoH.niceTimeScalar(poll_time) + " @ " + JoH.dateTimeText(poll_time + JoH.tsl()) + " period diff: " + (RETRY_PERIOD - JoH.msSince(lastPacketTime)));
-        return poll_time;
-    }
-
-    private long whenToPollNext() {
-        final long poll_time = Math.max((Constants.SECOND_IN_MS * 5) + poll_backoff, POLLING_PERIOD - JoH.msSince(lastPacketTime));
-        if (poll_backoff < (Constants.MINUTE_IN_MS * 6)) {
-            poll_backoff += Constants.SECOND_IN_MS;
-        }
-        Log.d(TAG, "Scheduling next poll in: " + JoH.niceTimeScalar(poll_time) + " @ " + JoH.dateTimeText(poll_time + JoH.tsl()) + " period diff: " + (POLLING_PERIOD - JoH.msSince(lastPacketTime)));
-        return poll_time;
-    }
-
-    private static void status(String msg) {
-        lastState = msg + " " + JoH.hourMinuteString();
-    }
-
-    synchronized void checkConnection() {
-        status("Attempting connection");
-        final BluetoothManager bluetoothManager = (BluetoothManager) getSystemService(Context.BLUETOOTH_SERVICE);
-        if (bluetoothManager == null) {
-            status("No bluetooth manager");
-            setRetryTimer();
-            return;
-        }
-
-        mBluetoothAdapter = bluetoothManager.getAdapter();
-        if (mBluetoothAdapter == null) {
-            status("No bluetooth adapter");
-            setRetryTimer();
-            return;
-        }
-
-        if (!mBluetoothAdapter.isEnabled()) {
-            if (Pref.getBoolean("automatically_turn_bluetooth_on",true)) {
-                Log.i(TAG, "Turning bluetooth on as appears disabled");
-                status("Turning bluetooth on");
-                JoH.setBluetoothEnabled(getApplicationContext(), true);
-            } else {
-                Log.d(TAG,"Not automatically turning on bluetooth due to preferences");
-            }
-        }
-
-        if (device != null) {
-            mConnectionState = STATE_DISCONNECTED;
-            for (BluetoothDevice bluetoothDevice : bluetoothManager.getConnectedDevices(BluetoothProfile.GATT)) {
-                if (bluetoothDevice.getAddress().compareTo(device.getAddress()) == 0) {
-                    mConnectionState = STATE_CONNECTED;
-                }
-            }
-        }
-
-        Log.i(TAG, "checkConnection: Connection state: " + getStateStr(mConnectionState));
-        if (mConnectionState == STATE_DISCONNECTED || mConnectionState == STATE_DISCONNECTING) {
-            final ActiveBluetoothDevice btDevice = ActiveBluetoothDevice.first();
-            if (btDevice != null) {
-                final String deviceAddress = btDevice.address;
-                mDeviceAddress = deviceAddress;
-                try {
-                    if (mBluetoothAdapter.isEnabled() && mBluetoothAdapter.getRemoteDevice(deviceAddress) != null) {
-                        status("Connecting" + (Home.get_engineering_mode() ? ": "+deviceAddress : ""));
-                        connect(deviceAddress);
-                        mStaticState = mConnectionState;
-                        return;
-                    }
-                } catch (IllegalArgumentException e) {
-                    Log.e(TAG, "IllegalArgumentException: " + e);
-                }
-            }
-        } else if (mConnectionState == STATE_CONNECTED) { //WOOO, we are good to go, nothing to do here!
-            status("Last Connected");
-            Log.i(TAG, "checkConnection: Looks like we are already connected, ready to receive");
-            mStaticState = mConnectionState;
-            if (use_polling && (JoH.msSince(lastPacketTime) >= POLLING_PERIOD)) {
-                pollForData();
-            }
-            return;
-        }
-        setRetryTimer();
-    }
-
-    private synchronized void checkImmediateSend() {
-        if (immediateSend != null) {
-            Log.d(TAG, "Sending immediate data: " + JoH.bytesToHex(immediateSend));
-            sendBtMessage(immediateSend);
-            immediateSend = null;
-        }
-    }
-
-    private synchronized void pollForData() {
-        if (JoH.ratelimit("poll-for-data", 5)) {
-            new Thread() {
-                @Override
-                public void run() {
-                    Log.d(TAG, "Polling for data");
-                    int wait_counter = 0;
-                    while (servicesDiscovered != DISCOVERED.COMPLETE && wait_counter < 10) {
-                        Log.d(TAG, "Waiting for service discovery: " + servicesDiscovered + " count: " + wait_counter);
-                        try {
-                            Thread.sleep(200); // delay for wakeup readiness
-                        } catch (InterruptedException e) {
-                            //
-                        }
-                        wait_counter++;
-                    }
-                    if (servicesDiscovered == DISCOVERED.NULL) {
-                        Log.e(TAG, "Failed to discover services!");
-                        try {
-                            if (JoH.ratelimit("rediscover-services", 30)) {
-                                Log.d(TAG, "Refresh result: " + JoH.refreshDeviceCache(TAG, mBluetoothGatt));
-                                mBluetoothGatt.discoverServices();
-                            }
-                        } catch (Exception e) {
-                            Log.d(TAG, "Exception discovering services: " + e);
-                        }
-                    }
-                    last_poll_sent = JoH.tsl();
-                    if ((JoH.msSince(lastPacketTime) > Home.stale_data_millis()) && (JoH.ratelimit("poll-request-part-b", 15))) {
-                        Log.e(TAG, "Stale data so requesting backfill");
-                        sendBtMessage(XbridgePlus.sendLast15BRequestPacket());
-                    } else {
-                        sendBtMessage(XbridgePlus.sendDataRequestPacket());
-                    }
-                }
-            }.start();
-        }
-    }
-
-    private static String getStateStr(int mConnectionState) {
-        mStaticState = mConnectionState;
-        switch (mConnectionState){
-            case STATE_CONNECTED:
-                return "CONNECTED";
-            case STATE_CONNECTING:
-                return "CONNECTING";
-            case STATE_DISCONNECTED:
-                return "DISCONNECTED";
-            case STATE_DISCONNECTING:
-                return "DISCONNECTING";
-            default:
-                return "UNKNOWN STATE!";
-        }
-    }
-
-    private final BroadcastReceiver mPairingRequestRecevier = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            Log.d(TAG,"Received pairing request");
-            JoH.doPairingRequest(context, this, intent, mDeviceAddress, DEFAULT_BT_PIN) ;
-        }
-    };
-
     private final BluetoothGattCallback mGattCallback = new BluetoothGattCallback() {
         @Override
         public synchronized void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
@@ -563,14 +246,15 @@ public class DexCollectionService extends Service {
                 UserError.Log.wtf(TAG, "Caught exception in Gatt callback " + e);
                 UserError.Log.wtf(TAG, e);
             } finally {
+                mStaticState = mConnectionState;
                 JoH.releaseWakeLock(wl);
             }
-            mStaticState = mConnectionState;
+
         }
 
         @Override
         public synchronized void onServicesDiscovered(BluetoothGatt gatt, int status) {
-            Log.d(TAG,"Services discovered start");
+            Log.d(TAG, "Services discovered start");
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.d(TAG, "onServicesDiscovered received: " + status);
                 return;
@@ -602,14 +286,12 @@ public class DexCollectionService extends Service {
                     listAvailableServices(mBluetoothGatt);
                 }
                 // try next
-            }
-            else
-            {
+            } else {
                 final BluetoothGattCharacteristic gattCharacteristic = gattService.getCharacteristic(xDripDataCharacteristic);
                 if (gattCharacteristic == null) {
                     Log.w(TAG, "onServicesDiscovered: characteristic " + xDripDataCharacteristic + " not found");
                     JoH.releaseWakeLock(wl);
-                    Log.d(TAG,"onServicesDiscovered: returning due to null xDrip characteristic");
+                    Log.d(TAG, "onServicesDiscovered: returning due to null xDrip characteristic");
                     return;
                 }
 
@@ -666,13 +348,12 @@ public class DexCollectionService extends Service {
             }
             else*/
 
-            if (nrfGattService != null)
-            {
-               final BluetoothGattCharacteristic nrfGattCharacteristic = nrfGattService.getCharacteristic(nrfDataRXCharacteristic);
+            if (nrfGattService != null) {
+                final BluetoothGattCharacteristic nrfGattCharacteristic = nrfGattService.getCharacteristic(nrfDataRXCharacteristic);
                 if (nrfGattCharacteristic == null) {
                     Log.w(TAG, "onServicesDiscovered: characteristic " + nrfGattCharacteristic + " not found");
                     JoH.releaseWakeLock(wl);
-                    Log.d(TAG,"onServicesDiscovered: returning due to null nrf characteristic");
+                    Log.d(TAG, "onServicesDiscovered: returning due to null nrf characteristic");
                     return;
                 } else {
                     static_use_nrf = true;
@@ -698,17 +379,18 @@ public class DexCollectionService extends Service {
                         JoH.releaseWakeLock(wl);
                         return;
                     }
-                    if(blueReader.isblueReader()) {
-                        status("Enabled blueReader" );
-                        Log.d(TAG,"blueReader initialized and Version requested");
+                    if (blueReader.isblueReader()) {
+                        status("Enabled blueReader");
+                        Log.d(TAG, "blueReader initialized and Version requested");
                         sendBtMessage(blueReader.initialize());
-                    } else if(Tomato.isTomato()) {
-                        status("Enabled tomato" );
-                        Log.d(TAG,"tomato initialized and data requested");
+                    } else if (Tomato.isTomato()) {
+                        status("Enabled tomato");
+                        Log.d(TAG, "tomato initialized and data requested");
                         ArrayList<ByteBuffer> buffers = Tomato.initialize();
-                        for (ByteBuffer buffer : buffers ) {
+                        for (ByteBuffer buffer : buffers) {
                             sendBtMessage(buffer);
                         }
+                        servicesDiscovered = DISCOVERED.NULL; // reset this state
                     }
                 }
             }
@@ -744,7 +426,7 @@ public class DexCollectionService extends Service {
                 Blukon.initialize();
 
             }
-            
+
             // TODO is this duplicated in some situations?
             try {
                 final BluetoothGattDescriptor descriptor = mCharacteristic.getDescriptor(CCCD);
@@ -785,7 +467,7 @@ public class DexCollectionService extends Service {
 
         @Override
         public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
-            onCharacteristicChanged(gatt,characteristic);
+            onCharacteristicChanged(gatt, characteristic);
         }
 
         @Override
@@ -794,24 +476,31 @@ public class DexCollectionService extends Service {
             final PowerManager.WakeLock wakeLock1 = JoH.getWakeLock("DexCollectionService", 60000);
             try {
                 final byte[] data = characteristic.getValue();
-                final String hexdump = HexDump.dumpHexString(data);
-                if (!hexdump.contains("0x00000000 00      ")) {
-                    static_last_hexdump = hexdump;
-                }
-                Log.i(TAG, "onCharacteristicChanged entered " + hexdump);
+
                 if (data != null && data.length > 0) {
                     setSerialDataToTransmitterRawData(data, data.length);
+
+                    final String hexdump = HexDump.dumpHexString(data);
+                    //if (!hexdump.contains("0x00000000 00      ")) {
+                    if (data.length > 1 || data[0] != 0x00) {
+                        static_last_hexdump = hexdump;
+                    }
+                    if (d) Log.i(TAG, "onCharacteristicChanged entered " + hexdump);
+
                 }
                 lastdata = data;
-                setFailoverTimer(); // restart the countdown
-                // intentionally left hanging wakelock for 5 seconds after we receive something
-                final PowerManager.WakeLock wakeLock2 = JoH.getWakeLock("DexCollectionLinger", 5000);
+
+                Inevitable.task("dex-set-failover", 1000, () -> {
+                    setFailoverTimer(); // restart the countdown
+                    // intentionally left hanging wakelock for 5 seconds after we receive something
+                    final PowerManager.WakeLock wakeLock2 = JoH.getWakeLock("DexCollectionLinger", 5000);
+                });
+
             } finally {
-                if (Pref.getBoolean("bluetooth_frequent_reset",false))
-                {
-                    Log.e(TAG,"Resetting bluetooth due to constant reset option being set!");
-                    JoH.restartBluetooth(getApplicationContext(),5000);
-                }
+               /* if (Pref.getBoolean("bluetooth_frequent_reset", false)) {
+                    Log.e(TAG, "Resetting bluetooth due to constant reset option being set!");
+                    JoH.restartBluetooth(getApplicationContext(), 5000);
+                }*/
                 JoH.releaseWakeLock(wakeLock1);
             }
         }
@@ -827,6 +516,549 @@ public class DexCollectionService extends Service {
             descriptor_time = 0;
         }
     };
+
+    private static String getDefaultPin() {
+        final String bk_pin = Blukon.getPin();
+        return bk_pin != null ? bk_pin : HM10Attributes.HM_DEFAULT_BT_PIN;
+    }
+
+    private static boolean shouldServiceRun() {
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) return false;
+        final boolean result = (DexCollectionType.hasXbridgeWixel() || DexCollectionType.hasBtWixel())
+                && ((!Home.get_forced_wear() && (((UiModeManager) xdrip.getAppContext().getSystemService(UI_MODE_SERVICE)).getCurrentModeType() != Configuration.UI_MODE_TYPE_WATCH))
+                || PersistentStore.getBoolean(CollectionServiceStarter.pref_run_wear_collector));
+        if (d) Log.d(TAG, "shouldServiceRun() returning: " + result);
+        return result;
+    }
+
+    // remember needs proguard exclusion due to access by reflection
+    public static boolean isCollecting() {
+        if (static_use_blukon) {
+            return Blukon.isCollecting();
+        }
+        return false;
+    }
+
+    private static void status(String msg) {
+        lastState = msg + " " + JoH.hourMinuteString();
+    }
+
+    private static void error(String msg) {
+        lastError = msg + " " + JoH.hourMinuteString();
+    }
+
+    private static String getStateStr(int mConnectionState) {
+        mStaticState = mConnectionState;
+        switch (mConnectionState) {
+            case STATE_CONNECTED:
+                return "CONNECTED";
+            case STATE_CONNECTING:
+                return "CONNECTING";
+            case STATE_DISCONNECTED:
+                return "DISCONNECTED";
+            case STATE_DISCONNECTING:
+                return "DISCONNECTING";
+            default:
+                return "UNKNOWN STATE!";
+        }
+    }
+
+    private static Integer convertSrc(final String Src) {
+        Integer res = 0;
+        String tmpSrc = Src.toUpperCase();
+        res |= getSrcValue(tmpSrc.charAt(0)) << 20;
+        res |= getSrcValue(tmpSrc.charAt(1)) << 15;
+        res |= getSrcValue(tmpSrc.charAt(2)) << 10;
+        res |= getSrcValue(tmpSrc.charAt(3)) << 5;
+        res |= getSrcValue(tmpSrc.charAt(4));
+        return res;
+    }
+
+    private static int getSrcValue(char ch) {
+        int i;
+        char[] cTable = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'W', 'X', 'Y'};
+        for (i = 0; i < cTable.length; i++) {
+            if (cTable[i] == ch) break;
+        }
+        return i;
+    }
+
+    // Status for Watchface
+    public static boolean isRunning() {
+        return lastState.equals("Not Running") || lastState.startsWith("Stopping", 0) ? false : true;
+    }
+
+    public static DataMap getWatchStatus() {
+        DataMap dataMap = new DataMap();
+        dataMap.putString("lastState", lastState);
+        if (last_transmitter_Data != null)
+            dataMap.putLong("timestamp", last_transmitter_Data.timestamp);
+        dataMap.putInt("mStaticState", mStaticState);
+        dataMap.putInt("last_battery_level", last_battery_level);
+        dataMap.putLong("retry_time", retry_time);
+        dataMap.putLong("failover_time", failover_time);
+        dataMap.putString("static_last_hexdump", static_last_hexdump);
+        dataMap.putString("static_last_sent_hexdump", static_last_sent_hexdump);
+        return dataMap;
+    }
+
+    public static void setWatchStatus(DataMap dataMap) {
+        lastStateWatch = dataMap.getString("lastState", "");
+        last_transmitter_DataWatch = new TransmitterData();
+        last_transmitter_DataWatch.timestamp = dataMap.getLong("timestamp", 0);
+        mStaticStateWatch = dataMap.getInt("mStaticState", 0);
+        last_battery_level_watch = dataMap.getInt("last_battery_level", -1);
+        retry_time_watch = dataMap.getLong("retry_time", 0);
+        failover_time_watch = dataMap.getLong("failover_time", 0);
+        static_last_hexdump_watch = dataMap.getString("static_last_hexdump", "");
+        static_last_sent_hexdump_watch = dataMap.getString("static_last_sent_hexdump", "");
+    }
+
+    public static String getBestLimitterHardwareName() {
+        if (static_use_nrf && blueReader.isblueReader()) {
+            return "BlueReader";
+        } else if (static_use_nrf && Tomato.isTomato()) {
+            return xdrip.getAppContext().getString(R.string.tomato);
+        } else if (static_use_blukon) {
+            return xdrip.getAppContext().getString(R.string.blukon);
+        } else if (static_use_transmiter_pl_bluetooth) {
+            return "Transmiter PL";
+        } else if (static_use_rfduino_bluetooth) {
+            return "Rfduino";
+        } else return LIMITTER_NAME;
+    }
+
+    // data for MegaStatus
+    public static List<StatusItem> megaStatus() {
+        final List<StatusItem> l = new ArrayList<>();
+
+        final boolean forced_wear = Home.get_forced_wear();
+
+        l.add(new StatusItem("Phone Service State", lastState + (forced_wear ? " (Watch Forced)" : "")));
+
+        if (lastError != null) {
+            l.add(new StatusItem("Last Error", lastError, StatusItem.Highlight.NOTICE, "long-press", () -> lastError = null));
+        }
+
+        l.add(new StatusItem("Bluetooth Device", JoH.ucFirst(getStateStr(mStaticState))));
+
+        if (mStaticState == STATE_CONNECTING) {
+            final long connecting_ms = JoH.msSince(last_connect_request);
+            l.add(new StatusItem("Connecting for", JoH.niceTimeScalar(connecting_ms)));
+        }
+
+        if (static_use_polling) {
+            l.add(new StatusItem("Polling mode", ((last_poll_sent > 0) ? "Last poll: " + JoH.niceTimeSince(last_poll_sent) + " ago" : "Enabled")));
+        }
+
+        if (static_use_transmiter_pl_bluetooth) {
+            l.add(new StatusItem("Hardware", "Transmiter PL"));
+        }
+
+        if (static_use_rfduino_bluetooth) {
+            l.add(new StatusItem("Hardware", "Rfduino"));
+        }
+
+        if (static_use_blukon) {
+            l.add(new StatusItem("Hardware", xdrip.getAppContext().getString(R.string.blukon)));
+        }
+
+        if (static_use_nrf && blueReader.isblueReader()) {
+            l.add(new StatusItem("Hardware", "BlueReader"));
+        }
+
+        if (static_use_nrf && Tomato.isTomato()) {
+            l.add(new StatusItem("Hardware", xdrip.getAppContext().getString(R.string.tomato)));
+        }
+
+        // TODO add LimiTTer info
+
+        if (last_transmitter_Data != null) {
+            l.add(new StatusItem("Glucose data from", JoH.niceTimeSince(last_transmitter_Data.timestamp) + " ago"));
+        }
+        if (last_battery_level > -1) {
+            l.add(new StatusItem("Battery level", last_battery_level));
+        }
+
+        if (Pref.getBooleanDefaultFalse(PREF_DEX_COLLECTION_BONDING)) {
+            if (bondedState != null) {
+                l.add(new StatusItem("Bluetooth Pairing", (bondedState.length() > 0) ? "Bonded" : "Not bonded" + (bondingTries > 1 ? " (" + bondingTries + ")" : ""), (bondedState.length() > 0) ? StatusItem.Highlight.GOOD : StatusItem.Highlight.NOTICE, "long-press",
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                Pref.setBoolean(PREF_DEX_COLLECTION_BONDING, false);
+                                if (bondedState.length() > 0) {
+                                    JoH.static_toast_long("If you want to unbond use Android bluetooth system settings to Forget device");
+                                    bondedState = null;
+                                }
+                                new Thread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        CollectionServiceStarter.restartCollectionService(xdrip.getAppContext());
+                                    }
+                                }
+                                ).start();
+                            }
+                        }));
+            }
+        } else {
+            l.add(new StatusItem("Bluetooth Pairing", "Disabled, tap to enable", StatusItem.Highlight.NORMAL, "long-press",
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            Pref.setBoolean(PREF_DEX_COLLECTION_BONDING, true);
+                            JoH.static_toast_long("This probably only works on HM10/HM11 devices at the moment and takes a minute");
+                            new Thread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    CollectionServiceStarter.restartCollectionService(xdrip.getAppContext());
+                                }
+                            }
+                            ).start();
+                        }
+                    }));
+        }
+        if (max_wakeup_jitter > 2000) {
+            l.add(new StatusItem("Slowest wake up", JoH.niceTimeScalar(max_wakeup_jitter) + " late", max_wakeup_jitter > 61000 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
+        }
+        if (JoH.buggy_samsung) {
+            l.add(new StatusItem("Buggy Samsung", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : StatusItem.Highlight.BAD));
+        }
+        if (retry_time > 0)
+            l.add(new StatusItem("Next Retry", JoH.niceTimeTill(retry_time), JoH.msTill(retry_time) < -2 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
+        if (failover_time > 0)
+            l.add(new StatusItem("Next Wake up", JoH.niceTimeTill(failover_time), JoH.msTill(failover_time) < -2 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
+
+        if (Home.get_engineering_mode() && DexCollectionType.hasLibre()) {
+            l.add(new StatusItem("Request Data", "Test for xBridgePlus protocol", immediateSend == null ? StatusItem.Highlight.NORMAL : StatusItem.Highlight.NOTICE, "long-press", new Runnable() {
+                @Override
+                public void run() {
+                    immediateSend = XbridgePlus.sendDataRequestPacket();
+                    CollectionServiceStarter.restartCollectionService(xdrip.getAppContext()); // TODO quicker/cleaner restart
+                }
+            }));
+        }
+
+        if (Home.get_engineering_mode() && (static_last_hexdump != null)) {
+            l.add(new StatusItem("Received Data", filterHexdump(static_last_hexdump)));
+        }
+        if (Home.get_engineering_mode() && (static_last_sent_hexdump != null)) {
+            l.add(new StatusItem("Sent Data", filterHexdump(static_last_sent_hexdump)));
+        }
+
+        //WATCH
+        if (forced_wear) {
+            l.add(new StatusItem());
+            l.add(new StatusItem("Watch Service State", lastStateWatch));
+            l.add(new StatusItem("Bridge Device", JoH.ucFirst(getStateStr(mStaticStateWatch))));
+
+            // TODO add LimiTTer info
+
+            if ((last_transmitter_DataWatch != null) && (last_transmitter_DataWatch.timestamp > 0)) {
+                l.add(new StatusItem("Watch Glucose data", JoH.niceTimeSince(last_transmitter_DataWatch.timestamp) + " ago"));
+            }
+            if (last_battery_level_watch > -1) {
+                l.add(new StatusItem("Bridge Battery level", last_battery_level_watch));
+            }
+
+            if (retry_time_watch > 0)
+                l.add(new StatusItem("Watch Next Retry", JoH.niceTimeTill(retry_time_watch)));
+            if (failover_time_watch > 0)
+                l.add(new StatusItem("Watch Wake up", JoH.niceTimeTill(failover_time_watch)));
+
+            if (Home.get_engineering_mode() && (static_last_hexdump_watch != null) && (static_last_hexdump_watch.length() > 0)) {
+                l.add(new StatusItem("Watch Received Data", filterHexdump(static_last_hexdump_watch)));
+            }
+            if (Home.get_engineering_mode() && (static_last_sent_hexdump_watch != null) && (static_last_sent_hexdump_watch.length() > 0)) {
+                l.add(new StatusItem("Watch Sent Data", filterHexdump(static_last_sent_hexdump_watch)));
+            }
+        }
+
+        // blueReader
+        if (blueReader.isblueReader()) {
+            l.add(new StatusItem("blueReader Battery", Pref.getInt("bridge_battery", 0) + "%"));
+            l.add(new StatusItem("blueReader rest days", PersistentStore.getString("bridge_battery_days")));
+            l.add(new StatusItem("blueReader Firmware", PersistentStore.getString("blueReaderFirmware")));
+        }
+
+        if (Tomato.isTomato()) {
+            l.add(new StatusItem("Tomato Battery", PersistentStore.getString("Tomatobattery")));
+            l.add(new StatusItem("Tomato Hardware", PersistentStore.getString("TomatoHArdware")));
+            l.add(new StatusItem("Tomato Firmware", PersistentStore.getString("TomatoFirmware")));
+        }
+
+        return l;
+    }
+
+    private static String filterHexdump(String hex) {
+        return hex.replaceAll("[ ]+", " ").replaceAll("\n0x0000[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f] ", "\n").replaceFirst("^\n", "");
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void onCreate() {
+        foregroundServiceStarter = new ForegroundServiceStarter(getApplicationContext(), this);
+        foregroundServiceStarter.start();
+        //mContext = getApplicationContext();
+        dexCollectionService = this;
+        prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        listenForChangeInSettings();
+        //bgToSpeech = BgToSpeech.setupTTS(mContext); //keep reference to not being garbage collected
+        if (CollectionServiceStarter.isDexBridgeOrWifiandDexBridge()) {
+            Log.i(TAG, "onCreate: resetting bridge_battery preference to 0");
+            prefs.edit().putInt("bridge_battery", 0).apply();
+            //if (Home.get_master()) GcmActivity.sendBridgeBattery(prefs.getInt("bridge_battery",-1));
+        }
+
+        final IntentFilter pairingRequestFilter = new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST);
+        pairingRequestFilter.setPriority(IntentFilter.SYSTEM_HIGH_PRIORITY - 1);
+        registerReceiver(mPairingRequestRecevier, pairingRequestFilter);
+        Log.i(TAG, "onCreate: STARTING SERVICE: pin code: " + DEFAULT_BT_PIN);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        final PowerManager.WakeLock wl = JoH.getWakeLock("dexcollect-service", 120000);
+        if (retry_time > 0 && failover_time > 0) {
+            final long requested_wake_time = Math.min(retry_time, failover_time);
+            final long wakeup_jitter = JoH.msSince(requested_wake_time);
+            Log.d(TAG, "Wake up jitter: " + JoH.niceTimeScalar(wakeup_jitter));
+            JoH.persistentBuggySamsungCheck();
+            if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && (JoH.isSamsung())) {
+                UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
+                JoH.setBuggySamsungEnabled();
+                max_wakeup_jitter = 0;
+            } else {
+                max_wakeup_jitter = Math.max(max_wakeup_jitter, wakeup_jitter);
+            }
+        }
+        retry_time = 0;
+        failover_time = 0;
+        static_use_rfduino_bluetooth = use_rfduino_bluetooth;
+        static_use_transmiter_pl_bluetooth = use_transmiter_pl_bluetooth;
+        static_use_polling = use_polling;
+        status("Started");
+        if (shouldServiceRun()) {
+            setFailoverTimer();
+        } else {
+            status("Stopping");
+            stopSelf();
+            JoH.releaseWakeLock(wl);
+            return START_NOT_STICKY;
+        }
+        lastdata = null;
+        checkConnection();
+        watchdog();
+        JoH.releaseWakeLock(wl);
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        status("Shutdown");
+        super.onDestroy();
+        Log.d(TAG, "onDestroy entered");
+        close();
+        foregroundServiceStarter.stop();
+
+        try {
+            unregisterReceiver(mPairingRequestRecevier);
+        } catch (Exception e) {
+            android.util.Log.e(TAG, "Error unregistering pairing receiver: " + e);
+        }
+
+        if (shouldServiceRun()) {//Android killed service
+            setRetryTimer();
+            status("Stopped, attempting restart");
+        } else {//onDestroy triggered by CollectionServiceStart.stopBtService
+            Log.d(TAG, "onDestroy stop Alarm serviceIntent");
+            JoH.cancelAlarm(this, serviceIntent);
+            Log.d(TAG, "onDestroy stop Alarm serviceFailoverIntent");
+            JoH.cancelAlarm(this, serviceFailoverIntent);
+            status("Service full stop");
+            retry_time = 0;
+            failover_time = 0;
+        }
+        //BgToSpeech.tearDownTTS();
+
+        retry_backoff = 0;
+        poll_backoff = 0;
+        servicesDiscovered = DISCOVERED.NULL;
+        bondingTries = 0;
+
+        Log.i(TAG, "SERVICE STOPPED");
+    }
+
+    public void listenForChangeInSettings() {
+        prefs.registerOnSharedPreferenceChangeListener(prefListener);
+    }
+
+    public void setRetryTimer() {
+        mStaticState = mConnectionState;
+        if (shouldServiceRun()) {
+            //final long retry_in = (Constants.SECOND_IN_MS * 25);
+            final long retry_in = whenToRetryNext();
+            Log.d(TAG, "setRetryTimer: Restarting in: " + (retry_in / Constants.SECOND_IN_MS) + " seconds");
+            serviceIntent = PendingIntent.getService(this, Constants.DEX_COLLECTION_SERVICE_RETRY_ID, new Intent(this, this.getClass()), 0);
+            retry_time = JoH.wakeUpIntent(this, retry_in, serviceIntent);
+        } else {
+            Log.d(TAG, "Not setting retry timer as service should not be running");
+        }
+    }
+
+    public synchronized void setFailoverTimer() {
+        if (shouldServiceRun()) {
+            final long retry_in = use_polling ? whenToPollNext() : (Constants.MINUTE_IN_MS * 6);
+            Log.d(TAG, "setFailoverTimer: Fallover Restarting in: " + (retry_in / (Constants.MINUTE_IN_MS)) + " minutes");
+            serviceFailoverIntent = PendingIntent.getService(this, Constants.DEX_COLLECTION_SERVICE_FAILOVER_ID, new Intent(this, this.getClass()), 0);
+            failover_time = JoH.wakeUpIntent(this, retry_in, serviceFailoverIntent);
+            retry_time = 0; // only one alarm will run
+        } else {
+            stopSelf();
+        }
+    }
+
+    private long whenToRetryNext() {
+        final long poll_time = Math.max((Constants.SECOND_IN_MS * 10) + retry_backoff, RETRY_PERIOD - JoH.msSince(lastPacketTime));
+        if (retry_backoff < (Constants.MINUTE_IN_MS)) {
+            retry_backoff += Constants.SECOND_IN_MS;
+        }
+        Log.d(TAG, "Scheduling next retry in: " + JoH.niceTimeScalar(poll_time) + " @ " + JoH.dateTimeText(poll_time + JoH.tsl()) + " period diff: " + (RETRY_PERIOD - JoH.msSince(lastPacketTime)));
+        return poll_time;
+    }
+
+    private long whenToPollNext() {
+        final long poll_time = Math.max((Constants.SECOND_IN_MS * 5) + poll_backoff, POLLING_PERIOD - JoH.msSince(lastPacketTime));
+        if (poll_backoff < (Constants.MINUTE_IN_MS * 6)) {
+            poll_backoff += Constants.SECOND_IN_MS;
+        }
+        Log.d(TAG, "Scheduling next poll in: " + JoH.niceTimeScalar(poll_time) + " @ " + JoH.dateTimeText(poll_time + JoH.tsl()) + " period diff: " + (POLLING_PERIOD - JoH.msSince(lastPacketTime)));
+        return poll_time;
+    }
+
+    synchronized void checkConnection() {
+        status("Attempting connection");
+        final BluetoothManager bluetoothManager = (BluetoothManager) getSystemService(Context.BLUETOOTH_SERVICE);
+        if (bluetoothManager == null) {
+            status("No bluetooth manager");
+            setRetryTimer();
+            return;
+        }
+
+        mBluetoothAdapter = bluetoothManager.getAdapter();
+        if (mBluetoothAdapter == null) {
+            status("No bluetooth adapter");
+            setRetryTimer();
+            return;
+        }
+
+        if (!mBluetoothAdapter.isEnabled()) {
+            if (Pref.getBoolean("automatically_turn_bluetooth_on", true)) {
+                Log.i(TAG, "Turning bluetooth on as appears disabled");
+                status("Turning bluetooth on");
+                JoH.setBluetoothEnabled(getApplicationContext(), true);
+            } else {
+                Log.d(TAG, "Not automatically turning on bluetooth due to preferences");
+            }
+        }
+
+        if (device != null) {
+            //mConnectionState = STATE_DISCONNECTED;
+            for (BluetoothDevice bluetoothDevice : bluetoothManager.getConnectedDevices(BluetoothProfile.GATT)) {
+                if (bluetoothDevice.getAddress().compareTo(device.getAddress()) == 0) {
+                    mConnectionState = STATE_CONNECTED;
+                    break;
+                }
+            }
+        }
+
+        Log.i(TAG, "checkConnection: Connection state: " + getStateStr(mConnectionState));
+        if (mConnectionState == STATE_DISCONNECTED || mConnectionState == STATE_DISCONNECTING) {
+            final ActiveBluetoothDevice btDevice = ActiveBluetoothDevice.first();
+            if (btDevice != null) {
+                final String deviceAddress = btDevice.address;
+                mDeviceAddress = deviceAddress;
+                try {
+                    if (mBluetoothAdapter.isEnabled() && mBluetoothAdapter.getRemoteDevice(deviceAddress) != null) {
+                        status("Connecting" + (Home.get_engineering_mode() ? ": " + deviceAddress : ""));
+                        connect(deviceAddress);
+                        mStaticState = mConnectionState;
+                        return;
+                    }
+                } catch (IllegalArgumentException e) {
+                    Log.e(TAG, "IllegalArgumentException: " + e);
+                }
+            }
+        } else if (mConnectionState == STATE_CONNECTING) {
+            mStaticState = mConnectionState;
+            if (JoH.msSince(last_connect_request) > Constants.SECOND_IN_MS * 30) {
+                Log.i(TAG, "Connecting for too long, shutting down");
+                retry_backoff = 0;
+                close();
+            }
+        } else if (mConnectionState == STATE_CONNECTED) { //WOOO, we are good to go, nothing to do here!
+            status("Last Connected");
+            Log.i(TAG, "checkConnection: Looks like we are already connected, ready to receive");
+            mStaticState = mConnectionState;
+            if (use_polling && (JoH.msSince(lastPacketTime) >= POLLING_PERIOD)) {
+                pollForData();
+            }
+
+            return;
+        }
+        setRetryTimer();
+    }
+
+    private synchronized void checkImmediateSend() {
+        if (immediateSend != null) {
+            Log.d(TAG, "Sending immediate data: " + JoH.bytesToHex(immediateSend));
+            sendBtMessage(immediateSend);
+            immediateSend = null;
+        }
+    }
+
+    private synchronized void pollForData() {
+        if (JoH.ratelimit("poll-for-data", 5)) {
+            new Thread() {
+                @Override
+                public void run() {
+                    Log.d(TAG, "Polling for data");
+                    int wait_counter = 0;
+                    while (servicesDiscovered != DISCOVERED.COMPLETE && wait_counter < 10) {
+                        Log.d(TAG, "Waiting for service discovery: " + servicesDiscovered + " count: " + wait_counter);
+                        try {
+                            Thread.sleep(200); // delay for wakeup readiness
+                        } catch (InterruptedException e) {
+                            //
+                        }
+                        wait_counter++;
+                    }
+                    if (servicesDiscovered == DISCOVERED.NULL) {
+                        Log.e(TAG, "Failed to discover services!");
+                        try {
+                            if (JoH.ratelimit("rediscover-services", 30)) {
+                                Log.d(TAG, "Refresh result: " + JoH.refreshDeviceCache(TAG, mBluetoothGatt));
+                                mBluetoothGatt.discoverServices();
+                            }
+                        } catch (Exception e) {
+                            Log.d(TAG, "Exception discovering services: " + e);
+                        }
+                    }
+                    last_poll_sent = JoH.tsl();
+                    if ((JoH.msSince(lastPacketTime) > Home.stale_data_millis()) && (JoH.ratelimit("poll-request-part-b", 15))) {
+                        Log.e(TAG, "Stale data so requesting backfill");
+                        sendBtMessage(XbridgePlus.sendLast15BRequestPacket());
+                    } else {
+                        sendBtMessage(XbridgePlus.sendDataRequestPacket());
+                    }
+                }
+            }.start();
+        }
+    }
 
     /**
      * Displays all services and characteristics for debugging purposes.
@@ -920,26 +1152,6 @@ public class DexCollectionService extends Service {
         return result;
     }
 
-    private static Integer convertSrc(final String Src) {
-        Integer res = 0;
-        String tmpSrc = Src.toUpperCase();
-        res |= getSrcValue(tmpSrc.charAt(0)) << 20;
-        res |= getSrcValue(tmpSrc.charAt(1)) << 15;
-        res |= getSrcValue(tmpSrc.charAt(2)) << 10;
-        res |= getSrcValue(tmpSrc.charAt(3)) << 5;
-        res |= getSrcValue(tmpSrc.charAt(4));
-        return res;
-    }
-
-    private static int getSrcValue(char ch) {
-        int i;
-        char[] cTable = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'W', 'X', 'Y'};
-        for (i = 0; i < cTable.length; i++) {
-            if (cTable[i] == ch) break;
-        }
-        return i;
-    }
-
     public synchronized boolean connect(final String address) {
         Log.i(TAG, "connect: going to connect to device at address: " + address);
         if (mBluetoothAdapter == null || address == null) {
@@ -967,20 +1179,26 @@ public class DexCollectionService extends Service {
         }
         Log.i(TAG, "connect: Trying to create a new connection.");
         setRetryTimer();
-        mBluetoothGatt = device.connectGatt(getApplicationContext(), true, mGattCallback);
+        mBluetoothGatt = device.connectGatt(getApplicationContext(), false, mGattCallback);
         mConnectionState = STATE_CONNECTING;
+        last_connect_request = JoH.tsl();
         return true;
     }
 
-    public void close() {
+    public synchronized void close() {
         Log.i(TAG, "close: Closing Connection - setting state DISCONNECTED");
         if (mBluetoothGatt == null) {
-            return;
-        }
-        try {
-            mBluetoothGatt.close();
-        } catch (NullPointerException e) {
-            Log.wtf(TAG, "Concurrency related null pointer in close");
+            Log.i(TAG, "not closing as bluetooth gatt is null");
+            //  return;
+        } else {
+            // TODO gatt refresh??
+
+            try {
+                mBluetoothGatt.close();
+            } catch (NullPointerException e) {
+                Log.wtf(TAG, "Concurrency related null pointer in close");
+            }
+
         }
 
         setRetryTimer();
@@ -988,11 +1206,19 @@ public class DexCollectionService extends Service {
         mCharacteristic = null;
         mConnectionState = STATE_DISCONNECTED;
         servicesDiscovered = DISCOVERED.NULL;
+        last_connect_request = 0;
+    }
+
+    private void sendReply(BridgeResponse reply) {
+        for (ByteBuffer byteBuffer : reply.send) {
+            Log.d(TAG, "Sending reply message");
+            sendBtMessage(byteBuffer);
+        }
     }
 
     public synchronized void setSerialDataToTransmitterRawData(byte[] buffer, int len) {
-        long timestamp = new Date().getTime();
-        last_time_seen = JoH.ts();
+
+        last_time_seen = JoH.tsl();
         watchdog_count = 0;
         if (static_use_blukon && Blukon.checkBlukonPacket(buffer)) {
             final byte[] reply = Blukon.decodeBlukonPacket(buffer);
@@ -1000,19 +1226,24 @@ public class DexCollectionService extends Service {
                 Log.d(TAG, "Sending reply message from Blukon decoder");
                 sendBtMessage(reply);
             }
-        } else  if (blueReader.isblueReader()) {
+        } else if (blueReader.isblueReader()) {
             final byte[] reply = blueReader.decodeblueReaderPacket(buffer, len);
             if (reply != null) {
                 Log.d(TAG, "Sending reply message from blueReader decoder");
                 sendBtMessage(reply);
             }
-        } else  if (Tomato.isTomato()) {
-            ArrayList<ByteBuffer> buffers = Tomato.decodeTomatoPacket(buffer, len);
-            for (ByteBuffer byteBuffer : buffers ) {
-                Log.d(TAG, "Sending reply message from tomato decoder");
-                sendBtMessage(byteBuffer);
+        } else if (Tomato.isTomato()) {
+            final BridgeResponse reply = Tomato.decodeTomatoPacket(buffer, len);
+            if (reply.shouldDelay()) {
+                Inevitable.task("send-tomato-reply", reply.getDelay(), () -> sendReply(reply));
+            } else {
+                sendReply(reply);
             }
-            
+            if (reply.hasError()) {
+                JoH.static_toast_long(reply.getError_message());
+                error(reply.getError_message());
+            }
+
         } else if (XbridgePlus.isXbridgeExtensionPacket(buffer)) {
             // handle xBridge+ protocol packets
             final byte[] reply = XbridgePlus.decodeXbridgeExtensionPacket(buffer);
@@ -1021,7 +1252,7 @@ public class DexCollectionService extends Service {
                 sendBtMessage(reply);
             }
         } else {
-
+            long timestamp = new Date().getTime();
             if (((buffer.length > 0) && (buffer[0] == 0x07 || buffer[0] == 0x11 || buffer[0] == 0x15)) || CollectionServiceStarter.isDexBridgeOrWifiandDexBridge()) {
                 if ((buffer.length == 1) && (buffer[0] == 0x00)) {
                     return; // null packet
@@ -1089,7 +1320,7 @@ public class DexCollectionService extends Service {
                         CheckBridgeBattery.checkBridgeBattery();
                     }
                 }
-            }  else {
+            } else {
                 processNewTransmitterData(TransmitterData.create(buffer, len, timestamp), timestamp);
             }
         }
@@ -1110,7 +1341,6 @@ public class DexCollectionService extends Service {
             Log.wtf(TAG, "Ignoring probably erroneous Transmiter_PL data: " + transmitterData.raw_data);
             return;
         }
-
 
 
         //sensor.latest_battery_level = (sensor.latest_battery_level != 0) ? Math.min(sensor.latest_battery_level, transmitterData.sensor_battery_level) : transmitterData.sensor_battery_level;
@@ -1148,17 +1378,17 @@ public class DexCollectionService extends Service {
 
     private void watchdog() {
         if (last_time_seen == 0) return;
-        if (prefs.getBoolean("bluetooth_watchdog",false)) {
-            if ((JoH.ts() - last_time_seen) > 1200000) {
+        if (prefs.getBoolean("bluetooth_watchdog", false)) {
+            if ((JoH.msSince(last_time_seen)) > 1200000) {
                 if (!JoH.isOngoingCall()) {
                     Log.e(TAG, "Watchdog triggered, attempting to reset bluetooth");
                     status("Watchdog triggered");
                     JoH.restartBluetooth(getApplicationContext());
-                    last_time_seen = JoH.ts();
+                    last_time_seen = JoH.tsl();
                     watchdog_count++;
-                    if (watchdog_count>5) last_time_seen=0;
+                    if (watchdog_count > 5) last_time_seen = 0;
                 } else {
-                    Log.e(TAG,"Delaying watchdog reset as phone call is ongoing.");
+                    Log.e(TAG, "Delaying watchdog reset as phone call is ongoing.");
                 }
             }
         }
@@ -1175,202 +1405,9 @@ public class DexCollectionService extends Service {
         }
     }
 
-    // Status for Watchface
-    public static boolean isRunning() {
-        return lastState.equals("Not Running") || lastState.startsWith("Stopping", 0) ? false : true;
-    }
-
-    public static void setWatchStatus(DataMap dataMap) {
-        lastStateWatch = dataMap.getString("lastState", "");
-        last_transmitter_DataWatch = new TransmitterData();
-        last_transmitter_DataWatch.timestamp = dataMap.getLong("timestamp", 0);
-        mStaticStateWatch = dataMap.getInt("mStaticState", 0);
-        last_battery_level_watch = dataMap.getInt("last_battery_level", -1);
-        retry_time_watch = dataMap.getLong("retry_time", 0);
-        failover_time_watch = dataMap.getLong("failover_time", 0);
-        static_last_hexdump_watch = dataMap.getString("static_last_hexdump", "");
-        static_last_sent_hexdump_watch = dataMap.getString("static_last_sent_hexdump", "");
-    }
-
-    public static DataMap getWatchStatus() {
-        DataMap dataMap = new DataMap();
-        dataMap.putString("lastState", lastState);
-        if (last_transmitter_Data != null) dataMap.putLong("timestamp", last_transmitter_Data.timestamp);
-        dataMap.putInt("mStaticState", mStaticState);
-        dataMap.putInt("last_battery_level", last_battery_level);
-        dataMap.putLong("retry_time", retry_time);
-        dataMap.putLong("failover_time", failover_time);
-        dataMap.putString("static_last_hexdump", static_last_hexdump);
-        dataMap.putString("static_last_sent_hexdump", static_last_sent_hexdump);
-        return dataMap;
-    }
-
-    public static final String LIMITTER_NAME = "LimiTTer";
-    public static String getBestLimitterHardwareName() {
-        if (static_use_nrf && blueReader.isblueReader()) {
-            return "BlueReader";
-        } else if (static_use_nrf && Tomato.isTomato()) {
-            return xdrip.getAppContext().getString(R.string.tomato);
-        }
-        else if (static_use_blukon) {
-            return xdrip.getAppContext().getString(R.string.blukon);
-        } else if (static_use_transmiter_pl_bluetooth) {
-            return "Transmiter PL";
-        } else if (static_use_rfduino_bluetooth) {
-            return "Rfduino";
-        } else return LIMITTER_NAME;
-    }
-
-    // data for MegaStatus
-    public static List<StatusItem> megaStatus() {
-        final List<StatusItem> l = new ArrayList<>();
-
-        final boolean forced_wear = Home.get_forced_wear();
-
-        l.add(new StatusItem("Phone Service State", lastState + (forced_wear ? " (Watch Forced)" : "")));
-        l.add(new StatusItem("Bluetooth Device", JoH.ucFirst(getStateStr(mStaticState))));
-
-        if (static_use_polling) {
-            l.add(new StatusItem("Polling mode", ((last_poll_sent > 0) ? "Last poll: " + JoH.niceTimeSince(last_poll_sent) + " ago" : "Enabled")));
-        }
-
-        if (static_use_transmiter_pl_bluetooth) {
-            l.add(new StatusItem("Hardware", "Transmiter PL"));
-        }
-
-        if (static_use_rfduino_bluetooth) {
-            l.add(new StatusItem("Hardware", "Rfduino"));
-        }
-
-        if (static_use_blukon) {
-            l.add(new StatusItem("Hardware", xdrip.getAppContext().getString(R.string.blukon)));
-        }
-
-        if (static_use_nrf && blueReader.isblueReader()) {
-            l.add(new StatusItem("Hardware", "BlueReader"));
-        }
-
-        if (static_use_nrf && Tomato.isTomato()) {
-            l.add(new StatusItem("Hardware", xdrip.getAppContext().getString(R.string.tomato)));
-        }
-        
-        // TODO add LimiTTer info
-
-        if (last_transmitter_Data != null) {
-            l.add(new StatusItem("Glucose data from", JoH.niceTimeSince(last_transmitter_Data.timestamp) + " ago"));
-        }
-        if (last_battery_level > -1) {
-            l.add(new StatusItem("Battery level", last_battery_level));
-        }
-
-        if (Pref.getBooleanDefaultFalse(PREF_DEX_COLLECTION_BONDING)) {
-            if (bondedState != null) {
-                l.add(new StatusItem("Bluetooth Pairing", (bondedState.length() > 0) ? "Bonded" : "Not bonded" + (bondingTries > 1 ? " (" + bondingTries + ")" : ""), (bondedState.length() > 0) ? StatusItem.Highlight.GOOD : StatusItem.Highlight.NOTICE, "long-press",
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                Pref.setBoolean(PREF_DEX_COLLECTION_BONDING, false);
-                                if (bondedState.length() > 0) {
-                                    JoH.static_toast_long("If you want to unbond use Android bluetooth system settings to Forget device");
-                                    bondedState = null;
-                                }
-                                new Thread(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        CollectionServiceStarter.restartCollectionService(xdrip.getAppContext());
-                                    }
-                                }
-                                ).start();
-                            }
-                        }));
-            }
-        } else {
-            l.add(new StatusItem("Bluetooth Pairing", "Disabled, tap to enable", StatusItem.Highlight.NORMAL, "long-press",
-                    new Runnable() {
-                        @Override
-                        public void run() {
-                            Pref.setBoolean(PREF_DEX_COLLECTION_BONDING, true);
-                            JoH.static_toast_long("This probably only works on HM10/HM11 devices at the moment and takes a minute");
-                            new Thread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    CollectionServiceStarter.restartCollectionService(xdrip.getAppContext());
-                                }
-                            }
-                            ).start();
-                        }
-                    }));
-        }
-        if (max_wakeup_jitter > 2000) {
-            l.add(new StatusItem("Slowest wake up", JoH.niceTimeScalar(max_wakeup_jitter) + " late", max_wakeup_jitter > 61000 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
-        }
-        if (JoH.buggy_samsung) {
-            l.add(new StatusItem("Buggy Samsung", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : StatusItem.Highlight.BAD));
-        }
-        if (retry_time > 0) l.add(new StatusItem("Next Retry", JoH.niceTimeTill(retry_time), JoH.msTill(retry_time)< -2 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
-        if (failover_time > 0)
-            l.add(new StatusItem("Next Wake up", JoH.niceTimeTill(failover_time), JoH.msTill(failover_time) < -2 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
-
-        if (Home.get_engineering_mode() && DexCollectionType.hasLibre()) {
-            l.add(new StatusItem("Request Data", "Test for xBridgePlus protocol", immediateSend == null ? StatusItem.Highlight.NORMAL : StatusItem.Highlight.NOTICE, "long-press", new Runnable() {
-                @Override
-                public void run() {
-                    immediateSend = XbridgePlus.sendDataRequestPacket();
-                    CollectionServiceStarter.restartCollectionService(xdrip.getAppContext()); // TODO quicker/cleaner restart
-                }
-            }));
-        }
-
-        if (Home.get_engineering_mode() && (static_last_hexdump != null)) {
-            l.add(new StatusItem("Received Data", filterHexdump(static_last_hexdump)));
-        }
-        if (Home.get_engineering_mode() && (static_last_sent_hexdump != null)) {
-            l.add(new StatusItem("Sent Data", filterHexdump(static_last_sent_hexdump)));
-        }
-
-        //WATCH
-        if (forced_wear) {
-            l.add(new StatusItem());
-            l.add(new StatusItem("Watch Service State", lastStateWatch));
-            l.add(new StatusItem("Bridge Device", JoH.ucFirst(getStateStr(mStaticStateWatch))));
-
-            // TODO add LimiTTer info
-
-            if ((last_transmitter_DataWatch != null) && (last_transmitter_DataWatch.timestamp > 0)) {
-                l.add(new StatusItem("Watch Glucose data", JoH.niceTimeSince(last_transmitter_DataWatch.timestamp) + " ago"));
-            }
-            if (last_battery_level_watch > -1) {
-                l.add(new StatusItem("Bridge Battery level", last_battery_level_watch));
-            }
-
-            if (retry_time_watch > 0) l.add(new StatusItem("Watch Next Retry", JoH.niceTimeTill(retry_time_watch)));
-            if (failover_time_watch > 0)
-                l.add(new StatusItem("Watch Wake up", JoH.niceTimeTill(failover_time_watch)));
-
-            if (Home.get_engineering_mode() && (static_last_hexdump_watch != null) && (static_last_hexdump_watch.length()>0)) {
-                l.add(new StatusItem("Watch Received Data", filterHexdump(static_last_hexdump_watch)));
-            }
-            if (Home.get_engineering_mode() && (static_last_sent_hexdump_watch != null) && (static_last_sent_hexdump_watch.length()>0)) {
-                l.add(new StatusItem("Watch Sent Data", filterHexdump(static_last_sent_hexdump_watch)));
-            }
-        }
-
-        // blueReader
-        if (blueReader.isblueReader()) {
-            l.add(new StatusItem("blueReader Battery", Pref.getInt("bridge_battery", 0) + "%"));
-            l.add(new StatusItem("blueReader rest days", PersistentStore.getString("bridge_battery_days")));
-            l.add(new StatusItem("blueReader Firmware",  PersistentStore.getString("blueReaderFirmware")));
-        }
-        
-        if (Tomato.isTomato()) {
-            l.add(new StatusItem("tomato battery",  PersistentStore.getString("Tomatobattery")));
-            l.add(new StatusItem("tomato Hardware",  PersistentStore.getString("TomatoHArdware")));
-            l.add(new StatusItem("tomato Firmware",  PersistentStore.getString("TomatoFirmware")));
-        }
-
-        return l;
-    }
-    private static String filterHexdump(String hex) {
-        return hex.replaceAll("[ ]+"," ").replaceAll("\n0x0000[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f] ","\n").replaceFirst("^\n","");
+    private enum DISCOVERED {
+        NULL,
+        PENDING,
+        COMPLETE
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BridgeResponse.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BridgeResponse.java
@@ -1,0 +1,32 @@
+package com.eveningoutpost.dexdrip.UtilityModels;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+
+import lombok.Data;
+
+/**
+ * Created by jamorham on 16/03/2018.
+ */
+
+@Data
+public class BridgeResponse {
+
+    public final LinkedList<ByteBuffer> send;
+    String error_message;
+    long delay;
+
+    public BridgeResponse() {
+        send = new LinkedList<>();
+    }
+
+    public boolean hasError() {
+        return error_message != null;
+    }
+
+    public boolean shouldDelay() {
+        return delay > 0;
+    }
+}
+
+


### PR DESCRIPTION
This is some experimental code that I've been running the last 24 hours. The idea is to improve the capture rate with Tomato.

Unfortunately studio for some reason reorganized the code and I didn't realize at the time so this change set looks massive when its not that big, however some of the bluetooth handling changes are pretty significant.

Key changes are summarized below:

* a new `BridgeResponse` data class to handle replies from delegated processors like `Tomato` this allows for error passing etc.
* state handling with `volatile` for extra thread safety
* failed checksum causes a retry request but not more than 2 per minute.
* reinitialize when reconnecting

Within `DexCollectionService` the way disconnections and connections are handled has changed. More of the connection management is handled within the service itself and the backoff timer is reduced.

The idea behind these changes is to try to ensure that when disconnected it reconnects as effectively as possible but without overloading the Android Bluetooth stack.

These changes are the most problematic because they could improve or harm a great many of other unrelated things (non-Tomato), however if they improve Tomato performance then there is good chance they would improve everything.

This new mechanism is likely to use quite a bit more battery when the bluetooth device is out of range because it is much less prone to "giving up" on a missing device and will keep hunting it. If this new method works then I may look at putting in some more backoffs after extended outages because for example after 8 hours of missing device it should be backing off more.

Basically, please try this branch out and see what you think. If it works for Tomato then also we should try it for Blucon and LimiTTer and xBridge to see how they look with it too.

If you don't already have the lombok android studio plugin installed then you will likely need it to properly navigate this code.