### PR TITLE
Tzachi libre wifi 2

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/BluetoothScan.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BluetoothScan.java
@@ -420,7 +420,7 @@ public class BluetoothScan extends ListActivityWithMenu {
                 }
                 returnToHome();
             } else if (device.getName().toLowerCase().contains("miaomiao")) {
-                if (!CollectionServiceStarter.isLimitter()) {
+                if (!(CollectionServiceStarter.isLimitter() || CollectionServiceStarter.isWifiandBTLibre())) {
                     prefs.edit().putString("dex_collection_method", "LimiTTer").apply();
                 }
                 returnToHome();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2251,9 +2251,12 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         // port this lot to DexCollectionType to avoid multiple lookups of the same preference
         boolean isDexbridgeWixel = CollectionServiceStarter.isDexBridgeOrWifiandDexBridge();
         boolean isWifiBluetoothWixel = CollectionServiceStarter.isWifiandBTWixel(getApplicationContext());
+        boolean isWifiandBTLibre = CollectionServiceStarter.isWifiandBTLibre(getApplicationContext());
+
         isBTShare = CollectionServiceStarter.isBTShare(getApplicationContext());
         isG5Share = CollectionServiceStarter.isBTG5(getApplicationContext());
         boolean isWifiWixel = CollectionServiceStarter.isWifiWixel(getApplicationContext());
+        boolean isWifiLibre = CollectionServiceStarter.isWifiLibre(getApplicationContext());
         alreadyDisplayedBgInfoCommon = false; // reset flag
         if (isBTShare) {
             updateCurrentBgInfoForBtShare(notificationText);
@@ -2261,10 +2264,10 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         if (isG5Share) {
             updateCurrentBgInfoCommon(collector, notificationText);
         }
-        if (isBTWixel || isDexbridgeWixel || isWifiBluetoothWixel) {
+        if (isBTWixel || isDexbridgeWixel || isWifiBluetoothWixel || isWifiandBTLibre) {
             updateCurrentBgInfoForBtBasedWixel(collector, notificationText);
         }
-        if (isWifiWixel || isWifiBluetoothWixel || collector.equals(DexCollectionType.Mock)) {
+        if (isWifiWixel || isWifiBluetoothWixel || isWifiandBTLibre || isWifiLibre || collector.equals(DexCollectionType.Mock)) {
             updateCurrentBgInfoForWifiWixel(collector, notificationText);
         } else if (is_follower || collector.equals(DexCollectionType.NSEmulator) ||DexCollectionType.isLibreOOPAlgorithm(collector)) {
             displayCurrentInfo();
@@ -2480,6 +2483,9 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         if(DexCollectionType.isLibreOOPAlgorithm(collector)) {
         	// Rest of this function deals with initial calibration. Since we currently don't have a way to calibrate,
         	// And even once we will have, there is probably no need to force a calibration at start of sensor use.
+            displayCurrentInfo();
+            // JamorHam, should I put here something like:
+            // ?? if (screen_forced_on)  dontKeepScreenOn();
         	return;
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/usbserial/util/HexDump.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/usbserial/util/HexDump.java
@@ -33,18 +33,19 @@ public class HexDump {
     public static String dumpHexString(byte[] array, int offset, int length) {
         if (array == null) return "<null>";
         StringBuilder result = new StringBuilder();
+        final int LINESIZE = 16;
 
-        byte[] line = new byte[16];
+        byte[] line = new byte[LINESIZE];
         int lineIndex = 0;
 
         result.append("\n0x");
         result.append(toHexString(offset));
 
         for (int i = offset; i < offset + length; i++) {
-            if (lineIndex == 16) {
+            if (lineIndex == LINESIZE) {
                 result.append(" ");
 
-                for (int j = 0; j < 16; j++) {
+                for (int j = 0; j < LINESIZE; j++) {
                     if (line[j] > ' ' && line[j] < '~') {
                         result.append(new String(line, j, 1));
                     } else {
@@ -65,8 +66,8 @@ public class HexDump {
             line[lineIndex++] = b;
         }
 
-        if (lineIndex != 16) {
-            int count = (16 - lineIndex) * 3;
+        if (lineIndex != LINESIZE) {
+            int count = (LINESIZE - lineIndex) * 3;
             count++;
             for (int i = 0; i < count; i++) {
                 result.append(" ");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
@@ -150,7 +150,7 @@ public class LibreAlarmReceiver extends BroadcastReceiver {
                                 try {
                                     final ReadingData.TransferObject object =
                                             new Gson().fromJson(data, ReadingData.TransferObject.class);
-                                    processReadingDataTransferObject(object);
+                                    processReadingDataTransferObject(object, JoH.tsl());
                                     Log.d(TAG, "At End: Oldest : " + JoH.dateTimeText(oldest_cmp) + " Newest : " + JoH.dateTimeText(newest_cmp));
                                 } catch (Exception e) {
                                     Log.wtf(TAG, "Could not process data structure from LibreAlarm: " + e.toString());
@@ -171,11 +171,10 @@ public class LibreAlarmReceiver extends BroadcastReceiver {
         }.start();
     }
 
-    public static void processReadingDataTransferObject(ReadingData.TransferObject object) {
+    public static void processReadingDataTransferObject(ReadingData.TransferObject object, long CaptureDateTime) {
     	Log.i(TAG, "Data that was recieved from librealarm is " + HexDump.dumpHexString(object.data.raw_data));
     	// Save raw block record (we start from block 0)
-    	long now = JoH.tsl();
-        LibreBlock.createAndSave("LibreAlarm", now, object.data.raw_data, 0);
+        LibreBlock.createAndSave("LibreAlarm", CaptureDateTime, object.data.raw_data, 0);
 
         if(Pref.getBooleanDefaultFalse("external_blukon_algorithm")) {
         	if(object.data.raw_data == null) {
@@ -183,7 +182,7 @@ public class LibreAlarmReceiver extends BroadcastReceiver {
         		JoH.static_toast_long("Please update LibreAlarm to use OOP algorithm");
         		return;
         	}
-        	LibreOOPAlgorithm.SendData(object.data.raw_data, now);
+        	LibreOOPAlgorithm.SendData(object.data.raw_data, CaptureDateTime);
         	return;
         }
         CalculateFromDataTransferObject(object, use_raw_);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/OOPResultsContainer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/OOPResultsContainer.java
@@ -16,7 +16,7 @@ class HistoricBg {
 class OOPResults {
     double currentBg;
     int currentTime;
-    int currenTrend;
+    int currentTrend;
     HistoricBg [] historicBg;
     long timestamp;
     String serialNumber;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
@@ -48,7 +48,7 @@ public class Tomato {
         final BridgeResponse reply = new BridgeResponse();
         // Check time, probably need to start on sending
         long now = JoH.tsl();
-        if(now - s_lastReceiveTimestamp > 10*1000) {
+        if(now - s_lastReceiveTimestamp > 3*1000) {
             // We did not receive data in 10 seconds, moving to init state again
             Log.e(TAG, "Recieved a buffer after " + (now - s_lastReceiveTimestamp) / 1000 +  " seconds, starting again. "+
             "already acumulated " + s_acumulatedSize + " bytes.");
@@ -102,7 +102,7 @@ public class Tomato {
                 
             } else {
                 if (JoH.quietratelimit("unknown-initial-packet", 1)) {
-                    Log.d(TAG, "Unknown initial packet makeup received");
+                    Log.d(TAG,"Unknown initial packet makeup received" + HexDump.dumpHexString(buffer));
                 }
                 return reply;
             }
@@ -159,7 +159,8 @@ public class Tomato {
         byte[] data = Arrays.copyOfRange(s_full_data, TOMATO_HEADER_LENGTH, TOMATO_HEADER_LENGTH+344);
         s_recviedEnoughData = true;
         
-        boolean checksum_ok = NFCReaderX.HandleGoodReading("tomato", data);
+        long now = JoH.tsl();
+        boolean checksum_ok = NFCReaderX.HandleGoodReading("tomato", data, now);
         Log.e(TAG, "We have all the data that we need " + s_acumulatedSize + " checksum_ok = " + checksum_ok + HexDump.dumpHexString(data));
 
         if(!checksum_ok) {
@@ -212,12 +213,6 @@ public class Tomato {
 
         s_state = TOMATO_STATES.REQUEST_DATA_SENT;
 
-        // For debug, make it send data every minute (ERROR - We fail to send this message... needs more work,
-        // not sure it works at all)
-        ByteBuffer newFreqMessage = ByteBuffer.allocate(2);
-        newFreqMessage.put(0, (byte) 0xD1);
-        newFreqMessage.put(1, (byte) 0x05);
-        ret.add(newFreqMessage);
 
         //command to start reading
         ByteBuffer ackMessage = ByteBuffer.allocate(1);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/ComunicationHeader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/ComunicationHeader.java
@@ -30,3 +30,30 @@ class ComunicationHeader {
         return new GsonBuilder().create().toJson(this);
     }
 }
+
+class ComunicationHeaderV2 {
+
+
+    @Expose
+    int version;
+    @Expose
+    int numberOfRecords;
+    
+    // Only send packets that are newer than this time
+    @Expose
+    long fromTime;
+    
+    // bluetooth device addresses
+    @Expose
+    String btAddresses;
+
+
+    ComunicationHeaderV2(int numberOfRecords) {
+        this.numberOfRecords = numberOfRecords;
+        this.version = 2;
+    }
+
+    String toJson() {
+        return new GsonBuilder().create().toJson(this);
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiData.java
@@ -1,11 +1,17 @@
 package com.eveningoutpost.dexdrip.Services;
 
+import java.util.Arrays;
+
 import com.google.gson.annotations.Expose;
 import com.mongodb.BasicDBObject;
 
 // This class contains data that is received for all house coverage.
 // The must fields are the raw data read from the sensor, and timestamp (and relative time).
 public class LibreWifiData {
+    
+    LibreWifiData(){
+        
+    }
     
     @Expose
     String BlockBytes; // The base 64 encoded FARM
@@ -32,10 +38,10 @@ public class LibreWifiData {
     int Uploaded;
     
     @Expose
-    int HwVersion;
+    String HwVersion;
     
     @Expose
-    int FwVersion;
+    String FwVersion;
     
     @Expose
     String SensorId;
@@ -53,8 +59,8 @@ public class LibreWifiData {
         TomatoBatteryLife = src.getInt("TomatoBatteryLife");
         UploaderBatteryLife = src.getInt("UploaderBatteryLife");
         Uploaded = src.getInt("Uploaded");
-        HwVersion = src.getInt("HwVersion");
-        FwVersion = src.getInt("FwVersion");
+        HwVersion = src.getString("HwVersion");
+        FwVersion = src.getString("FwVersion");
         SensorId = src.getString("SensorId");
     }
     
@@ -67,5 +73,40 @@ public class LibreWifiData {
                 + ", HwVersion=" + HwVersion + ", FwVersion=" + FwVersion + ", SensorId=" + SensorId + "]";
     }
     
+}
+
+class LibreWifiHeader {
     
+    // Version of the reply
+    @Expose
+    int reply_version;
+    
+    // Maximum version of protocol supported by this version
+    @Expose
+    int max_protocol_version;
+    
+    // Time of last reading from libre (can be no sensor for example
+    @Expose
+    long last_reading;
+    
+    // Any debug message that wants to be displayed.
+    @Expose
+    String debug_message;
+    
+    @Expose
+    String device_type;
+    
+    // The actual data
+    @Expose
+    LibreWifiData [] libre_wifi_data;
+
+    @Override
+    public String toString() {
+        return "LibreWifiHeader [reply_version=" + reply_version + ", max_protocol_version=" + max_protocol_version
+                + ", last_reading=" + last_reading + ", debug_message=" + debug_message + ", device_type=" + device_type
+                + ", libre_wifi_data=" + Arrays.toString(libre_wifi_data) + "]";
+    }
+
+   
+
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiData.java
@@ -1,0 +1,71 @@
+package com.eveningoutpost.dexdrip.Services;
+
+import com.google.gson.annotations.Expose;
+import com.mongodb.BasicDBObject;
+
+// This class contains data that is received for all house coverage.
+// The must fields are the raw data read from the sensor, and timestamp (and relative time).
+public class LibreWifiData {
+    
+    @Expose
+    String BlockBytes; // The base 64 encoded FARM
+    
+    @Expose
+    Long CaptureDateTime;
+    
+    @Expose
+    public long RelativeTime;
+    
+    @Expose
+    int ChecksumOk ;
+    
+    @Expose
+    String DebugInfo;
+    
+    @Expose
+    int TomatoBatteryLife;
+    
+    @Expose
+    int UploaderBatteryLife;
+    
+    @Expose
+    int Uploaded;
+    
+    @Expose
+    int HwVersion;
+    
+    @Expose
+    int FwVersion;
+    
+    @Expose
+    String SensorId;
+    
+    public Long getCaptureDateTime() {
+        return CaptureDateTime;
+    }
+    
+    public LibreWifiData(BasicDBObject src) {
+
+        BlockBytes = src.getString("BlockBytes");
+        CaptureDateTime = src.getLong("CaptureDateTime");
+        ChecksumOk = src.getInt("ChecksumOk");
+        DebugInfo = src.getString("DebugInfo");
+        TomatoBatteryLife = src.getInt("TomatoBatteryLife");
+        UploaderBatteryLife = src.getInt("UploaderBatteryLife");
+        Uploaded = src.getInt("Uploaded");
+        HwVersion = src.getInt("HwVersion");
+        FwVersion = src.getInt("FwVersion");
+        SensorId = src.getString("SensorId");
+    }
+    
+    
+    @Override
+    public String toString() {
+        return "LibreWifiData [BlockBytes=" + BlockBytes + ", CaptureDateTime=" + CaptureDateTime + ", RelativeTime="
+                + RelativeTime + ", ChecksumOk=" + ChecksumOk + ", DebugInfo=" + DebugInfo + ", TomatoBatteryLife="
+                + TomatoBatteryLife + ", UploaderBatteryLife=" + UploaderBatteryLife + ", Uploaded=" + Uploaded
+                + ", HwVersion=" + HwVersion + ", FwVersion=" + FwVersion + ", SensorId=" + SensorId + "]";
+    }
+    
+    
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
@@ -1,0 +1,500 @@
+package com.eveningoutpost.dexdrip.Services;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.os.PowerManager;
+import android.util.Base64;
+
+import com.eveningoutpost.dexdrip.GcmActivity;
+import com.eveningoutpost.dexdrip.Home;
+import com.eveningoutpost.dexdrip.MapsActivity;
+import com.eveningoutpost.dexdrip.NFCReaderX;
+import com.eveningoutpost.dexdrip.Models.BgReading;
+import com.eveningoutpost.dexdrip.Models.Calibration;
+import com.eveningoutpost.dexdrip.Models.JoH;
+import com.eveningoutpost.dexdrip.Models.LibreBlock;
+import com.eveningoutpost.dexdrip.Models.Sensor;
+import com.eveningoutpost.dexdrip.Models.TransmitterData;
+import com.eveningoutpost.dexdrip.Models.UserError.Log;
+import com.eveningoutpost.dexdrip.ParakeetHelper;
+import com.eveningoutpost.dexdrip.UtilityModels.BgGraphBuilder;
+import com.eveningoutpost.dexdrip.UtilityModels.MockDataSource;
+import com.eveningoutpost.dexdrip.UtilityModels.Pref;
+import com.eveningoutpost.dexdrip.UtilityModels.StatusItem;
+import com.eveningoutpost.dexdrip.utils.CheckBridgeBattery;
+import com.eveningoutpost.dexdrip.utils.DexCollectionType;
+import com.eveningoutpost.dexdrip.utils.Mdns;
+import com.google.gson.Gson;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+
+// Important note, this class is based on the fact that android will always run it one thread, which means it does not
+// need synchronization
+
+public class LibreWifiReader extends AsyncTask<String, Void, Void> {
+
+    private final static String TAG = LibreWifiReader.class.getSimpleName();
+
+    private static final HashMap<String, String> hostStatus = new HashMap<>();
+    private static final HashMap<String, Long> hostStatusTime = new HashMap<>();
+
+    private static final Gson gson = JoH.defaultGsonInstance();
+
+    private final static long DEXCOM_PERIOD = 300000;
+
+    // This variables are for fake function only
+    static int i = 0;
+    static int added = 5;
+
+    LibreWifiReader(Context ctx) {
+        Log.d(TAG, "LibreWifiReader init");
+    }
+
+    static boolean almostEquals(LibreWifiData e1, LibreWifiData e2) {
+        if (e1 == null || e2 == null) {
+            return false;
+        }
+        // relative time is in ms
+        return (Math.abs(e1.CaptureDateTime - e2.CaptureDateTime) < 120 * 1000);
+    }
+
+    // last in the array, is first in time
+    private static List<LibreWifiData> Merge2Lists(List<LibreWifiData> list1, List<LibreWifiData> list2) {
+        final List<LibreWifiData> merged = new LinkedList<>();
+        while (true) {
+            if (list1.size() == 0 && list2.size() == 0) {
+                break;
+            }
+            if (list1.size() == 0) {
+                merged.addAll(list2);
+                break;
+            }
+            if (list2.size() == 0) {
+                merged.addAll(list1);
+                break;
+            }
+            if (almostEquals(list1.get(0), list2.get(0))) {
+                // favour records which have real parakeet geolocation
+                if (hasGeoLocation(list1.get(0))) {
+                    list2.remove(0);
+                    merged.add(list1.remove(0));
+                } else {
+                    list1.remove(0);
+                    merged.add(list2.remove(0));
+                }
+                continue;
+            }
+
+            if (list1.get(0).RelativeTime > list2.get(0).RelativeTime) {
+                merged.add(list1.remove(0));
+            } else {
+                merged.add(list2.remove(0));
+            }
+
+        }
+        return merged;
+    }
+
+    private static boolean hasGeoLocation(LibreWifiData record) {
+        return false;
+    }
+
+    private static List<LibreWifiData> MergeLists(List<List<LibreWifiData>> allTransmitterRawData) {
+        List<LibreWifiData> MergedList;
+        MergedList = allTransmitterRawData.remove(0);
+        for (List<LibreWifiData> it : allTransmitterRawData) {
+            MergedList = Merge2Lists(MergedList, it);
+        }
+
+        return MergedList;
+    }
+
+    private static List<LibreWifiData> readFake() {
+        final LibreWifiData trd = gson.fromJson(MockDataSource.getFakeWifiData(), LibreWifiData.class);
+        trd.CaptureDateTime = System.currentTimeMillis() - trd.RelativeTime;
+        final List<LibreWifiData> l = new ArrayList<>();
+        l.add(trd);
+        return l;
+    }
+
+    private static List<LibreWifiData> ReadHost(String hostAndIp, int numberOfRecords) {
+        int port;
+        //System.out.println("Reading From " + hostAndIp);
+        Log.i(TAG, "Reading From " + hostAndIp);
+        String[] hosts = hostAndIp.split(":");
+        if (hosts.length != 2) {
+          //  System.out.println("Invalid hostAndIp " + hostAndIp);
+            Log.e(TAG, "Invalid hostAndIp " + hostAndIp);
+
+            return null;
+        }
+        try {
+            port = Integer.parseInt(hosts[1]);
+        } catch (NumberFormatException nfe) {
+            System.out.println("Invalid port " + hosts[1]);
+            Log.e(TAG, "Invalid hostAndIp " + hostAndIp, nfe);
+            statusLog(hosts[0], JoH.hourMinuteString() + " Invalid Port: " + hostAndIp);
+            return null;
+
+        }
+        if (port < 10 || port > 65535) {
+            System.out.println("Invalid port " + hosts[1]);
+            Log.e(TAG, "Invalid hostAndIp " + hostAndIp);
+            statusLog(hosts[0], JoH.hourMinuteString() + " Invalid Host/Port: " + hostAndIp);
+            return null;
+
+        }
+        System.out.println("Reading from " + hosts[0] + " " + port);
+        final List<LibreWifiData> ret;
+        try {
+            ret = Read(hosts[0], port, numberOfRecords);
+        } catch (Exception e) {
+            // We had some error, need to move on...
+            System.out.println("read from host failed cought expation" + hostAndIp);
+            Log.e(TAG, "read from host failed " + hostAndIp, e);
+
+            return null;
+
+        }
+        return ret;
+    }
+
+    
+    
+    private static List<LibreWifiData> ReadFromMongo(String dbury, int numberOfRecords) {
+       
+        Log.i(TAG, "Reading From " + dbury);
+        // format is dburi/db/collection. We need to find the collection and strip it from the dburi.
+        int indexOfSlash = dbury.lastIndexOf('/');
+        if (indexOfSlash == -1) {
+            // We can not find a collection name
+            Log.e(TAG, "Error bad dburi. Did not find a collection name starting with / " + dbury);
+            // in order for the user to understand that there is a problem, we return null
+            return null;
+
+        }
+        final String collection = dbury.substring(indexOfSlash + 1);
+        dbury = dbury.substring(0, indexOfSlash);
+
+        // Make sure that we have another /, since this is used in the constructor.
+        indexOfSlash = dbury.lastIndexOf('/');
+        if (indexOfSlash == -1) {
+            // We can not find a collection name
+            Log.e(TAG, "Error bad dburi. Did not find a collection name starting with / " + dbury);
+            // in order for the user to understand that there is a problem, we return null
+            return null;
+        }
+
+        final MongoWrapper mt = new MongoWrapper(dbury, collection, "CaptureDateTime", "MachineNameNotUsed");
+        List<LibreWifiData> rd = mt.ReadFromMongoLibre(numberOfRecords);
+        if (rd != null) {
+            long newest_timestamp = 0;
+            for (LibreWifiData r : rd) {
+                if (newest_timestamp < r.getCaptureDateTime()) {
+                    statusLog(dbury, JoH.hourMinuteString() + " OK data from:", r.getCaptureDateTime());
+                    newest_timestamp = r.getCaptureDateTime();
+                }
+            }
+        }
+        return rd;
+        
+    }
+
+    // format of string is ip1:port1,ip2:port2;
+    public static LibreWifiData[] Read(String hostsNames, int numberOfRecords) {
+        String[] hosts = hostsNames.split(",");
+        if (hosts.length == 0) {
+            Log.e(TAG, "Error no hosts were found " + hostsNames);
+            return null;
+        }
+        List<List<LibreWifiData>> allTransmitterRawData = new LinkedList<List<LibreWifiData>>();
+
+        // go over all hosts and read data from them
+        for (String host : hosts) {
+            host = host.trim();
+            List<LibreWifiData> tmpList;
+            if (host.startsWith("mongodb://")) {
+                tmpList = ReadFromMongo(host, numberOfRecords);
+            }  else if ((host.startsWith("fake://")
+                    && (Home.get_engineering_mode())
+                    && (DexCollectionType.getDexCollectionType() == DexCollectionType.Mock))) {
+                tmpList = readFake();
+            } else {
+                tmpList = ReadHost(host, numberOfRecords);
+            }
+            if (tmpList != null && tmpList.size() > 0) {
+                allTransmitterRawData.add(tmpList);
+            }
+        }
+        // merge the information
+        if (allTransmitterRawData.size() == 0) {
+            //System.out.println("Could not read anything from " + hostsNames);
+            Log.e(TAG, "Could not read anything from " + hostsNames);
+            return null;
+
+        }
+        final List<LibreWifiData> mergedData = MergeLists(allTransmitterRawData);
+
+        int retSize = Math.min(numberOfRecords, mergedData.size());
+        LibreWifiData[] trd_array = new LibreWifiData[retSize];
+        mergedData.subList(mergedData.size() - retSize, mergedData.size()).toArray(trd_array);
+
+        //      System.out.println("Final Results========================================================================");
+        //       for (int i= 0; i < trd_array.length; i++) {
+        //           System.out.println( trd_array[i].toTableString());
+        //      }
+        return trd_array;
+
+    }
+
+    public static List<LibreWifiData> Read(String hostName, int port, int numberOfRecords) {
+        final List<LibreWifiData> trd_list = new LinkedList<LibreWifiData>();
+        Log.i(TAG, "Read called: " + hostName + " port: " + port);
+
+        final boolean skip_lan = Pref.getBooleanDefaultFalse("skip_lan_uploads_when_no_lan");
+
+        if (skip_lan && (hostName.endsWith(".local")) && !JoH.isLANConnected()) {
+            Log.d(TAG, "Skipping due to no lan: " + hostName);
+            statusLog(hostName, "Skipping, no LAN");
+            return trd_list; // blank
+        }
+
+        final long time_start = JoH.tsl();
+        String currentAddress = "null";
+        long newest_timestamp = 0;
+
+        try {
+
+
+            // An example of using gson.
+            final ComunicationHeader ch = new ComunicationHeader(numberOfRecords);
+            //ch.version = 1;
+            //ch.numberOfRecords = numberOfRecords;
+            // String flat = gson.toJson(ch);
+            //ComunicationHeader ch2 = gson.fromJson(flat, ComunicationHeader.class);
+            //System.out.println("Results code" + flat + ch2.version);
+
+            // Real client code
+            final InetSocketAddress ServerAddress = new InetSocketAddress(Mdns.genericResolver(hostName), port);
+            currentAddress = ServerAddress.getAddress().getHostAddress();
+            if (skip_lan && currentAddress.startsWith("192.168.") && !JoH.isLANConnected()) {
+                Log.d(TAG, "Skipping due to no lan: " + hostName);
+                statusLog(hostName, "Skipping, no LAN");
+                return trd_list; // blank
+            }
+
+            final Socket MySocket = new Socket();
+            MySocket.connect(ServerAddress, 10000);
+
+            //System.out.println("After the new socket \n");
+            MySocket.setSoTimeout(3000);
+
+            //System.out.println("client connected... " );
+
+            final PrintWriter out = new PrintWriter(MySocket.getOutputStream(), true);
+            final BufferedReader in = new BufferedReader(new InputStreamReader(MySocket.getInputStream()));
+
+            out.println(ch.toJson());
+
+            while (true) {
+                String data = in.readLine();
+                if (data == null) {
+                    Log.d(TAG, "recieved null exiting");
+                    break;
+                }
+                if (data.equals("")) {
+                    Log.d(TAG, "recieved \"\" exiting");
+                    break;
+                }
+
+                Log.e(TAG,  "data size " +data.length() + " data = "+ data);
+                
+                final LibreWifiData trd = gson.fromJson(data, LibreWifiData.class);
+                Log.e(TAG, "LibreWifiData = " + trd);
+                trd.CaptureDateTime = System.currentTimeMillis() - trd.RelativeTime;
+                //MapsActivity.newMapLocation(trd.GeoLocation, trd.CaptureDateTime);
+
+                if (newest_timestamp < trd.CaptureDateTime) {
+                    statusLog(hostName, JoH.hourMinuteString() + " OK data from:", trd.CaptureDateTime);
+                    newest_timestamp = trd.CaptureDateTime;
+                }
+
+                trd_list.add(0, trd);
+                //  System.out.println( trd.toTableString());
+                if (trd_list.size() == numberOfRecords) {
+                    // We have the data we want, let's get out
+                    break;
+                }
+            }
+
+
+            MySocket.close();
+            return trd_list;
+        } catch (SocketTimeoutException s) {
+            Log.e(TAG, "Socket timed out! " + hostName + " : " + currentAddress + " : " + s.toString() + " after: " + JoH.msSince(time_start));
+            statusLog(hostName, JoH.hourMinuteString() + " " + s.toString());
+        } catch (IOException e) {
+            Log.e(TAG, "caught IOException! " + hostName + " : " + currentAddress + " : " + " : " + e.toString());
+            statusLog(hostName, JoH.hourMinuteString() + " " + e.toString());
+        } catch (IllegalArgumentException e) {
+            Log.e(TAG, "Argument error on: " + hostName + " " + e.toString());
+        } catch (NullPointerException e) {
+            Log.e(TAG, "Got null pointer exception " + hostName + " " + e.toString());
+        }
+        return trd_list;
+    }
+
+    static Long timeForNextRead() {
+
+        LibreBlock libreBlock = LibreBlock.getLatestForTrend(0L, JoH.tsl() + 5 * 60000); // Allow some packets from the future.
+        
+        if (libreBlock == null) {
+            // We did not receive a packet, well someone hopefully is looking at data, return relatively fast
+            Log.e(TAG, "libreBlock == null returning 60000");
+            return 60 * 1000L;
+        }
+        Long gapTime = new Date().getTime() - libreBlock.timestamp;
+        Log.d(TAG, "gapTime = " + gapTime);
+        if (gapTime < 0) {
+            // There is some confusion here (clock was readjusted?)
+            Log.e(TAG, "gapTime <= null returning 60000");
+            return 60 * 1000L;
+        }
+
+        if (gapTime < DEXCOM_PERIOD) {
+            // We have received the last packet...
+            // 300000 - gaptime is when we expect to have the next packet.
+            return (DEXCOM_PERIOD - gapTime) + 2000;
+        }
+
+        gapTime = gapTime % DEXCOM_PERIOD;
+        Log.d(TAG, "modulus gapTime = " + gapTime);
+        if (gapTime < 10000) {
+            // A new packet should arrive any second now
+            return 10000L;
+        }
+        if (gapTime < 60000) {
+            // A new packet should arrive but chance is we have missed it...
+            return 30000L;
+        }
+
+        return (DEXCOM_PERIOD - gapTime) + 2000;
+    }
+
+    public Void doInBackground(String... urls) {
+        final PowerManager.WakeLock wl = JoH.getWakeLock("LibreWifiReader", 120000);
+        try {
+            //getwakelock();
+            readData();
+        } finally {
+            JoH.releaseWakeLock(wl);
+           // Log.d(TAG, "wakelock released " + lockCounter);
+        }
+        return null;
+    }
+
+    private void readData() {
+        // Start very simply by getting only one object and using it.
+        Log.e(TAG, "readData called");
+        Long LastReportedTime = 0L;
+        
+        // TODO change that to work based on readings as well ???
+        LibreBlock libreBlock = LibreBlock.getLatestForTrend(0L, JoH.tsl() + 5 * 60000); // Allow some packets from the future.
+        if (libreBlock != null) {
+            LastReportedTime = libreBlock.timestamp;
+
+            // jamorham fix to avoid going twice to network when we just got a packet
+            if ((new Date().getTime() - LastReportedTime) < DEXCOM_PERIOD - 2000) {
+                Log.d(TAG, "Already have a recent packet - returning");
+                if (JoH.ratelimit("deferred-msg", 60)) {
+                    statusLog(" Deferred", "Already have recent reading");
+                }
+                return;
+            } else {
+                statusLog(" Deferred", "");
+            }
+        }
+        String recieversIpAddresses;
+
+        // This is the same ip location as for the wixelreader.
+        if (!WixelReader.IsConfigured()) {
+            Log.e(TAG, "LibreWifiReader not configured");
+            return;
+        }
+
+        if ((DexCollectionType.getDexCollectionType() == DexCollectionType.Mock) && Home.get_engineering_mode()) {
+            recieversIpAddresses = "fake://FAKE_DATA";
+        } else {
+            recieversIpAddresses = Pref.getString("wifi_recievers_addresses", "");
+        }
+        int packetsToRead = 1;
+        Log.d(TAG, "reading " + packetsToRead + " packets");
+        LibreWifiData[] LibreWifiDataArr = Read(recieversIpAddresses, packetsToRead);
+        
+        Log.d(TAG, "After reading ..." + LibreWifiDataArr);
+
+        if (LibreWifiDataArr == null || LibreWifiDataArr.length == 0) {
+            return;
+        }
+        Log.d(TAG, "After verification ..." + LibreWifiDataArr);
+        // Last in the array is the most updated reading we have.
+        for (LibreWifiData LastReading : LibreWifiDataArr) {
+            // Last in the array is the most updated reading we have.
+            //TransmitterRawData LastReading = LastReadingArr[LastReadingArr.length -1];
+
+
+            //if (LastReading.CaptureDateTime > LastReportedReading + 5000) {
+            // Make sure we do not report packets from the far future...
+            if ((LastReading.CaptureDateTime > LastReportedTime + 4 * 60000) &&
+                    LastReading.CaptureDateTime < new Date().getTime() + 120000) {
+                // We have a real new reading...
+                Log.d(TAG, "calling HandleGoodReading from " +  JoH.dateTimeText(LastReading.CaptureDateTime ));
+
+                byte data[] = Base64.decode(LastReading.BlockBytes, Base64.DEFAULT);
+                boolean checksum_ok = NFCReaderX.HandleGoodReading("tomato", data, LastReading.CaptureDateTime);
+                if (checksum_ok) {
+                    // TODO use battery, and other interesting data.
+                    LastReportedTime = LastReading.CaptureDateTime;
+                } else {
+                    Log.e(TAG, "Recieved a pacjet with bad checksum");
+                }
+            }
+        }
+    }
+    
+
+    // data for MegaStatus
+    static List<StatusItem> megaStatus() {
+        final List<StatusItem> l = new ArrayList<>();
+        for (Map.Entry<String, String> entry : hostStatus.entrySet()) {
+            final long status_time = hostStatusTime.get(entry.getKey());
+            if (entry.getValue().length() > 0)
+                l.add(new StatusItem(entry.getKey(), entry.getValue() + ((status_time != 0) ? (" " + JoH.niceTimeSince(status_time) + " " + "ago") : ""), JoH.msSince(status_time) <= BgGraphBuilder.DEXCOM_PERIOD ? StatusItem.Highlight.GOOD : JoH.msSince(status_time) <= BgGraphBuilder.DEXCOM_PERIOD * 2 ? StatusItem.Highlight.NOTICE : StatusItem.Highlight.NORMAL));
+        }
+        return l;
+    }
+
+    static void statusLog(String key, String msg) {
+        statusLog(key, msg, 0); // default no time since
+    }
+
+    // timestamp or 0 = don't use or -1 = now
+    static void statusLog(String key, String msg, long time) {
+        hostStatus.put(key, msg);
+        hostStatusTime.put(key, (time != -1) ? time : JoH.tsl());
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/WifiCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/WifiCollectionService.java
@@ -6,6 +6,7 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -74,7 +75,12 @@ public class WifiCollectionService extends Service {
         if (JoH.buggy_samsung) {
             l.add(new StatusItem("Buggy Samsung", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : StatusItem.Highlight.BAD));
         }
-        l.addAll(WixelReader.megaStatus());
+        if(DexCollectionType.hasLibre()) {
+            l.addAll(LibreWifiReader.megaStatus());
+        } else {
+            l.addAll(WixelReader.megaStatus());
+        }
+        
         final int bridgeBattery = Pref.getInt("parakeet_battery", 0);
         if (bridgeBattery > 0) {
             l.add(new StatusItem("Parakeet Battery", bridgeBattery + "%", bridgeBattery < 50 ? bridgeBattery < 40 ? StatusItem.Highlight.BAD : StatusItem.Highlight.NOTICE : StatusItem.Highlight.GOOD));
@@ -152,7 +158,12 @@ public class WifiCollectionService extends Service {
 
     public void setFailoverTimer() {
         if (DexCollectionType.hasWifi()) {
-            final long retry_in = WixelReader.timeForNextRead();
+            long retry_in;
+            if(DexCollectionType.hasLibre()) {
+                retry_in = LibreWifiReader.timeForNextRead();
+            } else {
+                retry_in = WixelReader.timeForNextRead();
+            }
             Log.d(TAG, "setFailoverTimer: Fallover Restarting in: " + (retry_in / (60 * 1000)) + " minutes");
             requested_wake_time = JoH.wakeUpIntent(this, retry_in, PendingIntent.getService(this, Constants.WIFI_COLLECTION_SERVICE_ID, new Intent(this, this.getClass()), 0));
             PersistentStore.setLong(WIFI_COLLECTION_WAKEUP, requested_wake_time);
@@ -168,8 +179,12 @@ public class WifiCollectionService extends Service {
     private void runWixelReader() {
         // Theoretically can create more than one task. Should not be a problem since android runs them
         // on the same thread.
-        final WixelReader task = new WixelReader(getApplicationContext());
-        // Assume here that task will execute, otheirwise we leak a wake lock...
+        AsyncTask<String, Void, Void> task;
+        if(DexCollectionType.hasLibre()) {
+            task = new LibreWifiReader(getApplicationContext());
+        } else {
+            task = new WixelReader(getApplicationContext());
+        }
         task.executeOnExecutor(xdrip.executor);
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
@@ -48,6 +48,16 @@ public class CollectionServiceStarter {
         return false;
     }
 
+    public static boolean isWifiandBTLibre(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        String collection_method = prefs.getString("dex_collection_method", "BluetoothWixel");
+        if (collection_method.compareTo("LimiTTerWifi") == 0) {
+            return true;
+        }
+        return false;
+    }
+
+    
     // are we in the specifc mode supporting wifi and dexbridge at the same time
     public static boolean isWifiandDexBridge()
     {
@@ -119,6 +129,15 @@ public class CollectionServiceStarter {
         return false;
     }
 
+    public static boolean isWifiLibre(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        String collection_method = prefs.getString("dex_collection_method", "BluetoothWixel");
+        if (collection_method.compareTo("LibreWifi") == 0) {
+            return true;
+        }
+        return false;
+    }
+
         /*
      * LimiTTer emulates a BT-Wixel and works with the BT-Wixel service.
      * It would work without any changes but in some cases knowing that the data does not
@@ -128,10 +147,20 @@ public class CollectionServiceStarter {
     public static boolean isLimitter() {
         return Pref.getStringDefaultBlank("dex_collection_method").equals("LimiTTer");
     }
+    
+    public static boolean isWifiandBTLibre() {
+        return Pref.getStringDefaultBlank("dex_collection_method").equals("LimiTTerWifi");
+    }
+    
 
     public static boolean isWifiWixel(String collection_method) {
         return collection_method.equals("WifiWixel") || DexCollectionType.getDexCollectionType() == DexCollectionType.Mock;
     }
+    
+    public static boolean isWifiLibre(String collection_method) {
+        return collection_method.equals("LibreWifi") || DexCollectionType.getDexCollectionType() == DexCollectionType.Mock;
+    }
+    
 
     public static boolean isFollower(String collection_method) {
         return collection_method.equals("Follower");
@@ -165,7 +194,7 @@ public class CollectionServiceStarter {
             else {
                 startBtWixelService();
             }
-        } else if (isWifiWixel(collection_method)) {
+        } else if (isWifiWixel(collection_method) || isWifiLibre(collection_method)) {
             Log.d("DexDrip", "Starting wifi wixel collector");
             stopBtWixelService();
             stopFollowerThread();
@@ -212,7 +241,7 @@ public class CollectionServiceStarter {
                 startBtG5Service();
             }
 
-        } else if (isWifiandBTWixel(context) || isWifiandDexBridge()) {
+        } else if (isWifiandBTWixel(context) || isWifiandDexBridge() || isWifiandBTLibre(context)) {
             Log.d("DexDrip", "Starting wifi and bt wixel collector");
             stopBtWixelService();
             stopFollowerThread();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
@@ -24,6 +24,8 @@ public enum DexCollectionType {
     DexcomShare("DexcomShare"),
     DexbridgeWixel("DexbridgeWixel"),
     LimiTTer("LimiTTer"),
+    LimiTTerWifi("LimiTTerWifi"),
+    LibreWifi("LibreWifi"),
     WifiBlueToothWixel("WifiBlueToothWixel"),
     WifiWixel("WifiWixel"),
     DexcomG5("DexcomG5"),
@@ -59,13 +61,13 @@ public enum DexCollectionType {
             mapToInternalName.put(dct.internalName, dct);
         }
 
-        Collections.addAll(usesBluetooth, BluetoothWixel, DexcomShare, DexbridgeWixel, LimiTTer, WifiBlueToothWixel, DexcomG5, WifiDexBridgeWixel);
-        Collections.addAll(usesBtWixel, BluetoothWixel, LimiTTer, WifiBlueToothWixel);
-        Collections.addAll(usesWifi, WifiBlueToothWixel,WifiWixel,WifiDexBridgeWixel, Mock);
+        Collections.addAll(usesBluetooth, BluetoothWixel, DexcomShare, DexbridgeWixel, LimiTTer, WifiBlueToothWixel, DexcomG5, WifiDexBridgeWixel, LimiTTerWifi);
+        Collections.addAll(usesBtWixel, BluetoothWixel, LimiTTer, WifiBlueToothWixel, LimiTTerWifi); // Name is misleading here, should probably be using dexcollectionservice
+        Collections.addAll(usesWifi, WifiBlueToothWixel,WifiWixel,WifiDexBridgeWixel, Mock, LimiTTerWifi, LibreWifi);
         Collections.addAll(usesXbridge, DexbridgeWixel,WifiDexBridgeWixel);
         Collections.addAll(usesFiltered, DexbridgeWixel, WifiDexBridgeWixel, DexcomG5, WifiWixel, Follower, Mock); // Bluetooth and Wifi+Bluetooth need dynamic mode
-        Collections.addAll(usesLibre, LimiTTer, LibreAlarm);
-        Collections.addAll(usesBattery, BluetoothWixel, DexbridgeWixel, WifiBlueToothWixel, WifiDexBridgeWixel, Follower, LimiTTer, LibreAlarm); // parakeet separate
+        Collections.addAll(usesLibre, LimiTTer, LibreAlarm, LimiTTerWifi, LibreWifi);
+        Collections.addAll(usesBattery, BluetoothWixel, DexbridgeWixel, WifiBlueToothWixel, WifiDexBridgeWixel, Follower, LimiTTer, LibreAlarm, LimiTTerWifi, LibreWifi); // parakeet separate
         Collections.addAll(usesDexcomRaw, BluetoothWixel, DexbridgeWixel, WifiWixel, WifiBlueToothWixel, DexcomG5, WifiDexBridgeWixel, Mock);
         Collections.addAll(usesTransmitterBattery, WifiWixel, BluetoothWixel, DexbridgeWixel, WifiBlueToothWixel, WifiDexBridgeWixel); // G4 transmitter battery
     }
@@ -118,7 +120,7 @@ public enum DexCollectionType {
 
     public static boolean hasDexcomRaw() { return hasDexcomRaw(getDexCollectionType()); }
 
-    public static boolean usesDexCollectionService(DexCollectionType type) { return usesBtWixel.contains(type) || usesXbridge.contains(type) || type.equals(LimiTTer); }
+    public static boolean usesDexCollectionService(DexCollectionType type) { return usesBtWixel.contains(type) || usesXbridge.contains(type) || type.equals(LimiTTer);}
 
     public static boolean usesClassicTransmitterBattery() { return usesTransmitterBattery.contains(getDexCollectionType()); }
 
@@ -136,7 +138,7 @@ public enum DexCollectionType {
     	if(collector == null) {
     		collector = DexCollectionType.getDexCollectionType();
     	}
-        return collector == DexCollectionType.LimiTTer && 
+        return hasLibre(collector) && 
                Pref.getBooleanDefaultFalse("external_blukon_algorithm");
     }
 
@@ -209,6 +211,8 @@ public enum DexCollectionType {
                 return "Network G4";
             case LimiTTer:
                 return DexCollectionService.getBestLimitterHardwareName();
+            case LimiTTerWifi:
+                return "Network " + DexCollectionService.getBestLimitterHardwareName();
             case WifiDexBridgeWixel:
                 return "Network G4 and xBridge";
             case WifiBlueToothWixel:
@@ -218,6 +222,8 @@ public enum DexCollectionType {
                     return "G5 Native";
                 }
                 return dct.name();
+            case LibreWifi:
+                return "Network libre";
 
             default:
                 return dct.name();

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -9,6 +9,8 @@
         <item>G4 Share Receiver</item>
         <item>G5 Transmitter</item>
         <item>Libre Bluetooth</item>
+        <item>Libre Bluetooth + wifi</item>
+        <item>Libre wifi</item>
         <item>xDrip+ Sync Follower</item>
         <item>LibreAlarm</item>
         <item>640G / EverSense</item>
@@ -24,6 +26,8 @@
         <item>DexcomShare</item>
         <item>DexcomG5</item>
         <item>LimiTTer</item>
+        <item>LimiTTerWifi</item>
+        <item>LibreWifi</item>
         <item>Follower</item>
         <item>LibreAlarm</item>
         <item>NSEmulator</item>


### PR DESCRIPTION
This replaces tzachi libre wifi 1 that worked very well with raspberry pi receivers.

Merging this with current code worked well, but there is one thing that somehow frightening me:
As part of the changes to to tomato.java I have removed one buffer that was sent in tomato.resetTomatoState().
Theoretically, this should not change anything, but as android BT code is so sensitive, I wonder if this does not start a new testing cycle for every phone.
(my fear is that since now there is a 150 ms sleep between each two buffers, a change in number of buffers changes timing ). So jamorham@ if you think that this should be reverted let me know.

In any case I'm starting to check the new code.