### PR TITLE
Bind the CGM web service to all IPs

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/webservices/XdripWebService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/webservices/XdripWebService.java
@@ -149,10 +149,10 @@ public class XdripWebService implements Runnable {
                 final SSLServerSocketFactory ssocketFactory = SSLServerSocketHelper.makeSSLSocketFactory(
                         new BufferedInputStream(xdrip.getAppContext().getResources().openRawResource(R.raw.localhost_cert)),
                         "password".toCharArray());
-                mServerSocket = ssocketFactory.createServerSocket(listenPort, 1, InetAddress.getByName("127.0.0.1"));
+                mServerSocket = ssocketFactory.createServerSocket(listenPort, 1);
             } else {
                 // Non-SSL type
-                mServerSocket = new ServerSocket(listenPort, 1, InetAddress.getByName("127.0.0.1"));
+                mServerSocket = new ServerSocket(listenPort, 1);
             }
             while (isRunning) {
                 final Socket socket = mServerSocket.accept();


### PR DESCRIPTION
Removed the localhost IP from the web service creation, so OpenAPS etc can load data directly from the app as the API is then exposed to devices connected to the phone hotspot