### PR TITLE
Large number icon in notification

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -614,7 +614,16 @@ public class Notifications extends IntentService {
                     }
                 }
 
-                if (NumberGraphic.largeNumberIconEnabled()) {
+                if (NumberGraphic.largeWithArrowEnabled()) {
+                    if ((dg != null) && (!dg.isStale())) {
+                        final Bitmap icon_bitmap = NumberGraphic.getLargeWithArrowBitmap(dg.unitized, dg.delta_arrow);
+                        //if (icon_bitmap != null) b.setSmallIcon(Icon.createWithBitmap(icon_bitmap));
+                        if (icon_bitmap != null) {
+                            b.setLargeIcon(Icon.createWithBitmap(icon_bitmap));
+                            setLargeIcon = true;
+                        }
+                    }
+                } else if (NumberGraphic.largeNumberIconEnabled()) {
                     if ((dg != null) && (!dg.isStale())) {
                         final Bitmap icon_bitmap = NumberGraphic.getLargeIconBitmap(dg.unitized);
                         //if (icon_bitmap != null) b.setSmallIcon(Icon.createWithBitmap(icon_bitmap));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -600,14 +600,28 @@ public class Notifications extends IntentService {
                 .setSmallIcon(R.drawable.ic_action_communication_invert_colors_on)
                 .setUsesChronometer(false);
 
+        boolean setLargeIcon = false;
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             // in case the graphic crashes the system-ui we wont do it immediately after reboot so the
             // user has a chance to disable the feature
             if (SystemClock.uptimeMillis() > Constants.MINUTE_IN_MS * 15) {
                 if (NumberGraphic.numberIconEnabled()) {
                     if ((dg != null) && (!dg.isStale())) {
-                        final Bitmap icon_bitmap = NumberGraphic.getBitmap(dg.unitized);
+                        final Bitmap icon_bitmap = NumberGraphic.getSmallIconBitmap(dg.unitized);
                         if (icon_bitmap != null) b.setSmallIcon(Icon.createWithBitmap(icon_bitmap));
+
+                    }
+                }
+
+                if (NumberGraphic.largeNumberIconEnabled()) {
+                    if ((dg != null) && (!dg.isStale())) {
+                        final Bitmap icon_bitmap = NumberGraphic.getLargeIconBitmap(dg.unitized);
+                        //if (icon_bitmap != null) b.setSmallIcon(Icon.createWithBitmap(icon_bitmap));
+                        if (icon_bitmap != null) {
+                            b.setLargeIcon(Icon.createWithBitmap(icon_bitmap));
+                            setLargeIcon = true;
+                        }
                     }
                 }
             }
@@ -627,7 +641,7 @@ public class Notifications extends IntentService {
                     .setBgGraphBuilder(bgGraphBuilder)
                     .setBackgroundColor(getCol(X.color_notification_chart_background))
                     .build();
-            b.setLargeIcon(iconBitmap);
+            if (!setLargeIcon) b.setLargeIcon(iconBitmap);
             Notification.BigPictureStyle bigPictureStyle = new Notification.BigPictureStyle();
             notifiationBitmap = new BgSparklineBuilder(mContext)
                     .setBgGraphBuilder(bgGraphBuilder)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/NumberGraphic.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/NumberGraphic.java
@@ -36,7 +36,7 @@ public class NumberGraphic {
 
                 final Notification.Builder mBuilder = new Notification.Builder(xdrip.getAppContext());
 
-                mBuilder.setSmallIcon(Icon.createWithBitmap(getBitmap(text)));
+                mBuilder.setSmallIcon(Icon.createWithBitmap(getSmallIconBitmap(text)));
 
                 mBuilder.setContentTitle("Test Number Graphic");
                 mBuilder.setContentText("Check the number is visible");
@@ -72,7 +72,19 @@ public class NumberGraphic {
         return Pref.getBooleanDefaultFalse("use_number_icon") && (Pref.getBooleanDefaultFalse("number_icon_tested"));
     }
 
-    public static Bitmap getBitmap(final String text) {
+    public static boolean largeNumberIconEnabled() {
+        return Pref.getBooleanDefaultFalse("use_number_icon_large") && (Pref.getBooleanDefaultFalse("number_icon_tested"));
+    }
+
+    public static Bitmap getSmallIconBitmap(final String text) {
+        return getBitmap(text, Color.WHITE);
+    }
+
+    public static Bitmap getLargeIconBitmap(final String text) {
+        return getBitmap(text, Color.BLACK);
+    }
+
+    public static Bitmap getBitmap(final String text, int fillColor) {
         {
             if ((text == null) || (text.length() > 4)) return null;
             try {
@@ -87,7 +99,7 @@ public class NumberGraphic {
                 final Paint paint = new Paint();
 
                 paint.setStyle(Paint.Style.FILL);
-                paint.setColor(Color.WHITE);
+                paint.setColor(fillColor);
                 paint.setAntiAlias(true);
                 //paint.setTypeface(Typeface.MONOSPACE);
                 paint.setTypeface(Typeface.SANS_SERIF); // TODO BEST?

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/NumberGraphic.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/NumberGraphic.java
@@ -76,15 +76,23 @@ public class NumberGraphic {
         return Pref.getBooleanDefaultFalse("use_number_icon_large") && (Pref.getBooleanDefaultFalse("number_icon_tested"));
     }
 
+    public static boolean largeWithArrowEnabled() {
+        return largeNumberIconEnabled() && Pref.getBooleanDefaultFalse("number_icon_large_arrow");
+    }
+
     public static Bitmap getSmallIconBitmap(final String text) {
-        return getBitmap(text, Color.WHITE);
+        return getBitmap(text, Color.WHITE, null);
     }
 
     public static Bitmap getLargeIconBitmap(final String text) {
-        return getBitmap(text, Color.BLACK);
+        return getBitmap(text, Color.BLACK, null);
     }
 
-    public static Bitmap getBitmap(final String text, int fillColor) {
+    public static Bitmap getLargeWithArrowBitmap(final String text, final String arrow) {
+        return getBitmap(text, Color.BLACK, arrow);
+    }
+
+    public static Bitmap getBitmap(final String text, int fillColor, final String arrow) {
         {
             if ((text == null) || (text.length() > 4)) return null;
             try {
@@ -104,20 +112,22 @@ public class NumberGraphic {
                 //paint.setTypeface(Typeface.MONOSPACE);
                 paint.setTypeface(Typeface.SANS_SERIF); // TODO BEST?
                 paint.setTextAlign(Paint.Align.LEFT);
-                paint.setTextSize(17);
+                float paintTs = (arrow == null ? 17 : 17 - arrow.length());
+                paint.setTextSize(paintTs);
                 final Rect bounds = new Rect();
 
+                String fullText = text + (arrow != null ? arrow : "");
 
-                paint.getTextBounds(text, 0, text.length(), bounds);
-                float textsize = (16 * width) / bounds.width();
+                paint.getTextBounds(fullText, 0, fullText.length(), bounds);
+                float textsize = ((paintTs-1) * width) / bounds.width();
                 paint.setTextSize(textsize);
-                paint.getTextBounds(text, 0, text.length(), bounds);
+                paint.getTextBounds(fullText, 0, fullText.length(), bounds);
 
                 // cannot be Config.ALPHA_8 as it doesn't work on Samsung
                 final Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
                 final Canvas c = new Canvas(bitmap);
 
-                c.drawText(text, 0, (height / 2) + (bounds.height() / 2), paint);
+                c.drawText(fullText, 0, (height / 2) + (bounds.height() / 2), paint);
                 return bitmap;
             } catch (Exception e) {
                 if (JoH.ratelimit("icon-failure", 60)) {

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -422,7 +422,15 @@
                     android:summary="Shows the current glucose number as an icon for the notification bar and lock screen"
                     android:switchTextOff="@string/short_off_text_for_switches"
                     android:switchTextOn="@string/short_on_text_for_switches"
-                    android:title="Show Number Icon" />
+                    android:title="Show Small Number Icon" />
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:dependency="number_icon_tested"
+                    android:key="use_number_icon_large"
+                    android:summary="Shows a larger icon in the notification area only visible when opened"
+                    android:switchTextOff="@string/short_off_text_for_switches"
+                    android:switchTextOn="@string/short_on_text_for_switches"
+                    android:title="Use Large Number Icon" />
             </PreferenceScreen>
             <SwitchPreference
                 android:defaultValue="false"

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -431,6 +431,14 @@
                     android:switchTextOff="@string/short_off_text_for_switches"
                     android:switchTextOn="@string/short_on_text_for_switches"
                     android:title="Use Large Number Icon" />
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:dependency="use_number_icon_large"
+                    android:key="number_icon_large_arrow"
+                    android:summary="Shows the trend arrow in the large icon"
+                    android:switchTextOff="@string/short_off_text_for_switches"
+                    android:switchTextOn="@string/short_on_text_for_switches"
+                    android:title="Show Arrow in Large Icon" />
             </PreferenceScreen>
             <SwitchPreference
                 android:defaultValue="false"


### PR DESCRIPTION
Option for showing the current bg reading and optionally the trend in the largeIcon section of the notification, in place of a condensed version of the expanding graph. Partially addresses #415, though a more complete solution to that would probably involve a custom notification layout.

The text size can likely be a bit larger in the with-arrow case, I imagine that the bitmap generation code can be done a bit more intelligently to ensure the text fills the space.

![screenshot_20180517-003425](https://user-images.githubusercontent.com/192620/40156925-2ed5c272-596a-11e8-8235-9fd397a63e0c.png)
![screenshot_20180517-003344](https://user-images.githubusercontent.com/192620/40156921-2d80a7c0-596a-11e8-96c4-7e5b18029d4d.png)
