### PR TITLE
external storage permission check before data export as CSV

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -3525,7 +3525,16 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                     new AsyncTask<Void, Void, String>() {
                         @Override
                         protected String doInBackground(Void... params) {
-                            return DatabaseUtil.saveCSV(getBaseContext(), date.getTimeInMillis());
+                            int permissionCheck = ContextCompat.checkSelfPermission(Home.this,
+                                    Manifest.permission.READ_EXTERNAL_STORAGE);
+                            if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
+                                ActivityCompat.requestPermissions(Home.this,
+                                        new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                                        0);
+                                return null;
+                            } else {
+                                return DatabaseUtil.saveCSV(getBaseContext(), date.getTimeInMillis());
+                            }
                         }
 
                         @Override


### PR DESCRIPTION
Bug symptoms: after first install of the app and first attempt to export the data in CSV, the file is not created, even when a toast says it was and points to non existing location.

Circumvented (in App): exported as SQL (gains permissions + creates the folder), then the CSV export works.

Bug fix: copied the permission to access the external storage from SQL background task to CSV one.

Hope this helps.

