### PR TITLE
G5 Native backfill analytics

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
@@ -220,6 +220,10 @@ public class BGHistory extends ActivityWithMenu {
             sb.append('\n');
             sb.append(statsResult.getCapturePercentage(true));
             sb.append(' ');
+            if (statsResult.canShowRealtimeCapture()) {
+                sb.append(statsResult.getRealtimeCapturePercentage(true));
+                sb.append(' ');
+            }
 
             statisticsTextView.setText(sb);
             statisticsTextView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
@@ -1010,7 +1010,7 @@ public class Ob1G5StateMachine {
         DexTimeKeeper.updateAge(getTransmitterID(), glucose.timestamp);
         if (glucose.usable() || (glucose.insufficient() && Pref.getBooleanDefaultFalse("ob1_g5_use_insufficiently_calibrated"))) {
             UserError.Log.d(TAG, "Got usable glucose data from G5!!");
-            final BgReading bgReading = BgReading.bgReadingInsertFromG5(glucose.glucose, JoH.tsl());
+            final BgReading bgReading = BgReading.bgReadingInsertFromG5(glucose.glucose, JoH.tsl(), null);
             if (bgReading != null) {
                 try {
                     bgReading.calculated_value_slope = glucose.getTrend() / Constants.MINUTE_IN_MS; // note this is different to the typical calculated slope, (normally delta)
@@ -1218,8 +1218,7 @@ public class Ob1G5StateMachine {
                 UserError.Log.wtf(TAG, "Backfill timestamp unrealistic: " + JoH.dateTimeText(time) + " (ignored)");
             } else {
                 if (BgReading.getForPreciseTimestamp(time, Constants.MINUTE_IN_MS * 4) == null) {
-                    final BgReading bgr = BgReading.bgReadingInsertFromG5(backsie.getGlucose(), time);
-                    if (bgr != null) bgr.appendSourceInfo("Backfill");
+                    final BgReading bgr = BgReading.bgReadingInsertFromG5(backsie.getGlucose(), time, "Backfill");
                     lastGlucoseBgReading = bgr;
                     UserError.Log.d(TAG, "Adding backfilled reading: " + JoH.dateTimeText(time) + " " + BgGraphBuilder.unitized_string_static(backsie.getGlucose()));
                     changed = true;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2859,6 +2859,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                 || Pref.getBoolean("status_line_royce_ratio", false)
                 || Pref.getBoolean("status_line_accuracy", false)
                 || Pref.getBoolean("status_line_capture_percentage", false)
+                || Pref.getBoolean("status_line_realtime_capture_percentage", false)
                 || Pref.getBoolean("status_line_pump_reservoir", false)
                 || Pref.getBooleanDefaultFalse("status_line_external_status")) {
 
@@ -2908,6 +2909,11 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             if (Pref.getBoolean("status_line_capture_percentage", false)) {
                 if (extraline.length() != 0) extraline.append(' ');
                 extraline.append(statsResult.getCapturePercentage(false));
+            }
+            if (Pref.getBoolean("status_line_realtime_capture_percentage", false) &&
+                    statsResult.canShowRealtimeCapture()) {
+                if (extraline.length() != 0) extraline.append(' ');
+                extraline.append(statsResult.getRealtimeCapturePercentage(false));
             }
             if (Pref.getBoolean("status_line_accuracy", false)) {
                 final long accuracy_period = DAY_IN_MS * 3;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -1060,7 +1060,7 @@ public class BgReading extends Model implements ShareUploadableBg {
     public static final double SPECIAL_G5_PLACEHOLDER = -0.1597;
 
     // TODO remember to sync this with wear code base
-    public static synchronized BgReading bgReadingInsertFromG5(double calculated_value, long timestamp) {
+    public static synchronized BgReading bgReadingInsertFromG5(double calculated_value, long timestamp, String sourceInfoAppend) {
 
         final Sensor sensor = Sensor.currentSensor();
         if (sensor == null) {
@@ -1079,6 +1079,9 @@ public class BgReading extends Model implements ShareUploadableBg {
             bgr.calculated_value = calculated_value;
             bgr.raw_data = SPECIAL_G5_PLACEHOLDER; // placeholder
             bgr.appendSourceInfo("G5 Native");
+            if (sourceInfoAppend != null && sourceInfoAppend.length() > 0) {
+                bgr.appendSourceInfo(sourceInfoAppend);
+            }
             bgr.save();
             if (JoH.ratelimit("sync wakelock", 15)) {
                 final PowerManager.WakeLock linger = JoH.getWakeLock("G5 Insert", 4000);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -710,12 +710,22 @@ public class NightscoutUploader {
         Log.e(TAG, msg);
     }
 
+    private String getDeviceString(BgReading record) {
+        String withMethod = "xDrip-" + prefs.getString("dex_collection_method", "BluetoothWixel");
+        if (Pref.getBooleanDefaultFalse("nightscout_device_append_source_info") &&
+                record.source_info != null &&
+                record.source_info.length() > 0) {
+            return withMethod + " " + record.source_info;
+        }
+        return withMethod;
+    }
+
 
     private void populateV1APIBGEntry(JSONArray array, BgReading record) throws Exception {
         JSONObject json = new JSONObject();
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
         format.setTimeZone(TimeZone.getDefault());
-        json.put("device", "xDrip-" + prefs.getString("dex_collection_method", "BluetoothWixel"));
+        json.put("device", getDeviceString(record));
         if (record != null) {//KS
             json.put("date", record.timestamp);
             json.put("dateString", format.format(record.timestamp));
@@ -744,7 +754,7 @@ public class NightscoutUploader {
             JSONObject json = new JSONObject();
             SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
             format.setTimeZone(TimeZone.getDefault());
-            json.put("device", "xDrip-"+prefs.getString("dex_collection_method", "BluetoothWixel"));
+            json.put("device", getDeviceString(record));
             json.put("date", record.timestamp);
             json.put("dateString", format.format(record.timestamp));
             json.put("sgv", (int)record.calculated_value);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1804,6 +1804,7 @@ public class Preferences extends PreferenceActivity {
             findPreference("status_line_low").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("extra_status_line").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("status_line_capture_percentage").setOnPreferenceChangeListener(new WidgetListener());
+            findPreference("status_line_realtime_capture_percentage").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("extra_status_stats_24h").setOnPreferenceChangeListener(new WidgetListener());
 
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -1634,6 +1634,7 @@ public class WatchUpdaterService extends WearableListenerService implements
             dataMap.putBoolean("status_line_stdev", mPrefs.getBoolean("status_line_stdev", false));
             dataMap.putBoolean("status_line_royce_ratio", mPrefs.getBoolean("status_line_royce_ratio", false));
             dataMap.putBoolean("status_line_capture_percentage", mPrefs.getBoolean("status_line_capture_percentage", false));
+            dataMap.putBoolean("status_line_realtime_capture_percentage", mPrefs.getBoolean("status_line_realtime_capture_percentage", false));
 
             //Calibration plugin
             dataMap.putBoolean("extra_status_calibration_plugin", mPrefs.getBoolean("extra_status_calibration_plugin", false));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -652,7 +652,9 @@
     <string name="show_total_insulin">Show treatment insulin total</string>
     <string name="total_insulin">Total Insulin</string>
     <string name="received_readings_percentage">Percentage of sensor readings received</string>
+    <string name="received_realtime_readings_percentage">Percentage of sensor readings received in realtime (non-backfilled). G5 Native mode ONLY</string>
     <string name="capture_percentage">Packet capture percentage</string>
+    <string name="realtime_capture_percentage">Realtime packet capture percentage</string>
     <string name="show_calibration_accuracy">Show calibration accuracy evaluation from last 3 days</string>
     <string name="accuracy_evaluation">Accuracy Evaluation</string>
     <string name="show_extra_status_on_widget">Also show the extra status line on the widget</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -519,6 +519,12 @@
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:dependency="extra_status_line"
+                    android:key="status_line_realtime_capture_percentage"
+                    android:summary="@string/received_realtime_readings_percentage"
+                    android:title="@string/realtime_capture_percentage" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:dependency="extra_status_line"
                     android:key="status_line_accuracy"
                     android:summary="@string/show_calibration_accuracy"
                     android:title="@string/accuracy_evaluation" />

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -122,6 +122,11 @@
                         android:key="warn_nightscout_failures"
                         android:summary="Display and sound a notification if Nightscout upload is failing."
                         android:title="Alert on failures" />
+                    <CheckBoxPreference
+                        android:defaultValue="false"
+                        android:key="nightscout_device_append_source_info"
+                        android:summary="For G5, sends collector type (e.g. OB1) and reading backfill status (for native) to Nightscout."
+                        android:title="Append source info to device name" />
                     <Preference
                         android:summary="Tap to send historical data to Nightscout"
                         android:title="Back-fill data">


### PR DESCRIPTION
Adds an option in Nightscout Sync>Extra Options to append the source_info for each BgReading to the device string. This lets the nightscout DB know whether or not a specific reading was a backfill, or whether it was captured with Ob1g5 since that is currently merged in with regular G5 as a collection method.

Nightscout doesn't explicitly make this user-visible in their web UI but this does mean that the data about the collection method for each record is stored outside of xDrip's database.

future todo is that source_info doesn't appear to be used outside of the ob1 g5 collector