### PR TITLE
Allow testing with a dead sensor on engineering mode.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -142,6 +142,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
@@ -1384,12 +1385,15 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             thisuuid = (end > 0 ? allWords.substring(0, end) : "");
             allWords = allWords.substring(end + 6, allWords.length());
         }
+        byte[] RTL_BYTES = {(byte)0xE2, (byte)0x80, (byte)0x8f}; // See https://stackoverflow.com/questions/21470476/why-is-e2808f-being-added-to-my-youtube-embed-code
+       
         allWords = allWords.trim();
         allWords = allWords.replaceAll(":", "."); // fix real times
         allWords = allWords.replaceAll("(\\d)([a-zA-Z])", "$1 $2"); // fix like 22mm
         allWords = allWords.replaceAll("([0-9]\\.[0-9])([0-9][0-9])", "$1 $2"); // fix multi number order like blood 3.622 grams
+        allWords = allWords.replaceAll(new String(RTL_BYTES, StandardCharsets.UTF_8),"");
         allWords = allWords.toLowerCase();
-
+        
         Log.d(TAG, "Processing speech input allWords second: " + allWords + " UUID: " + thisuuid);
 
         if (allWords.contentEquals("delete last treatment")

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
@@ -3,13 +3,10 @@ package com.eveningoutpost.dexdrip.UtilityModels;
 import com.eveningoutpost.dexdrip.Home;
 
 import android.util.Log;
-import lombok.Getter;
 
 public class LibreUtils {
 
     private static final String TAG = LibreUtils.class.getSimpleName();
-
-    @Getter private static final boolean testWithDeadSensor = false; // never in production
 
     private final static long[] crc16table = {
             0, 4489, 8978, 12955, 17956, 22445, 25910, 29887, 35912,
@@ -111,7 +108,13 @@ public class LibreUtils {
     
         Log.i(TAG, "Sensor status is: " + sensorStatusString);
     
-        if (testWithDeadSensor) return true;
+        
+        
+        
+        if (Pref.getBooleanDefaultFalse("allow_testing_with_dead_sensor")) {
+            Log.e(TAG, "Warning allow to use a dead sensor");
+            return true;
+        }
     
         if (!ret) {
             Home.toaststaticnext("Can't use this sensor as it is " + sensorStatusString);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
@@ -111,7 +111,7 @@ public class LibreUtils {
         
         
         
-        if (Pref.getBooleanDefaultFalse("allow_testing_with_dead_sensor")) {
+        if (allowTestingWithDeadSensor()) {
             Log.e(TAG, "Warning allow to use a dead sensor");
             return true;
         }
@@ -121,5 +121,10 @@ public class LibreUtils {
         }
     
         return ret;
+    }
+    
+    public static boolean allowTestingWithDeadSensor() {
+        return Pref.getBooleanDefaultFalse("engineering_mode") && 
+               Pref.getBooleanDefaultFalse("allow_testing_with_dead_sensor");
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/VoiceCommands.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/VoiceCommands.java
@@ -31,8 +31,6 @@ public class VoiceCommands {
         } else if (allWords.contentEquals("enable engineering mode")) {
             Pref.setBoolean("engineering_mode", true);
             JoH.static_toast_long("Engineering mode enabled - be careful");
-
-
         } else if (get_engineering_mode() && allWords.contentEquals("enable fake data source")) {
             Pref.setString(DexCollectionType.DEX_COLLECTION_METHOD, DexCollectionType.Mock.toString());
             JoH.static_toast_long("YOU ARE NOW USING FAKE DATA!!!");
@@ -86,6 +84,12 @@ public class VoiceCommands {
             } catch (Exception e) {
                 // do nothing
             }
+        } else if (get_engineering_mode() && allWords.contentEquals("enable dead sensor")) {
+            Pref.setBoolean("allow_testing_with_dead_sensor", true);
+            JoH.static_toast_long("testing libre with dead sensor enabled - be careful");
+        } else if (allWords.contentEquals("disable dead sensor")) {
+            Pref.setBoolean("allow_testing_with_dead_sensor", false);
+            JoH.static_toast_long("testing libre with dead sensor disabled");
         }
 
         switch (allWords) {

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -863,7 +863,7 @@
 
                 <CheckBoxPreference
                     android:defaultValue="false"
-                    android:dependency="engineering_mode"
+                    android:dependency="allow_testing_with_dead_sensor"
                     android:key="allow_testing_with_dead_sensor"
                     android:summary="allow testing with dead sensor"
                     android:title="NOT FOR PRODUCTION USE" />

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -846,7 +846,7 @@
                     android:summary="@string/use_external_blukon_algorithm_summary"
                     android:title="@string/use_external_blukon_algorithm" />
                 
-        	    <CheckBoxPreference
+                <CheckBoxPreference
                     android:enabled="false"
                     android:defaultValue="false"
                     android:dependency="external_blukon_algorithm"
@@ -860,6 +860,13 @@
                     android:key="retrieve_blukon_history"
                     android:summary="@string/retrieve_blukon_history_summary"
                     android:title="@string/retrieve_blukon_history_title" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:dependency="engineering_mode"
+                    android:key="allow_testing_with_dead_sensor"
+                    android:summary="allow testing with dead sensor"
+                    android:title="NOT FOR PRODUCTION USE" />
 
             </PreferenceScreen>
             <PreferenceCategory

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
@@ -8,8 +8,6 @@ public class LibreUtils {
 
     private static final String TAG = LibreUtils.class.getSimpleName();
 
-    private static final boolean testWithDeadSensor = false; // never in production
-
     private final static long[] crc16table = {
             0, 4489, 8978, 12955, 17956, 22445, 25910, 29887, 35912,
             40385, 44890, 48851, 51820, 56293, 59774, 63735, 4225, 264,
@@ -110,7 +108,13 @@ public class LibreUtils {
     
         Log.i(TAG, "Sensor status is: " + sensorStatusString);
     
-        if (testWithDeadSensor) return true;
+        
+        
+        
+        if (Pref.getBooleanDefaultFalse("allow_testing_with_dead_sensor")) {
+            Log.e(TAG, "Warning allow to use a dead sensor");
+            return true;
+        }
     
         if (!ret) {
             Home.toaststaticnext("Can't use this sensor as it is " + sensorStatusString);

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
@@ -111,7 +111,7 @@ public class LibreUtils {
         
         
         
-        if (Pref.getBooleanDefaultFalse("allow_testing_with_dead_sensor")) {
+        if (allowTestingWithDeadSensor()) {
             Log.e(TAG, "Warning allow to use a dead sensor");
             return true;
         }
@@ -121,5 +121,10 @@ public class LibreUtils {
         }
     
         return ret;
+    }
+    
+    public static boolean allowTestingWithDeadSensor() {
+        return Pref.getBooleanDefaultFalse("engineering_mode") && 
+               Pref.getBooleanDefaultFalse("allow_testing_with_dead_sensor");
     }
 }


### PR DESCRIPTION
Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>

This ades the option to allow testing bad sensors from UI based on engineering mode.

A safer option for this is to remove the UI, and allow to set it by editing the xml files.
@keencave @jamorham does removing UI sound reasonable.