### PR TITLE
Add sensorage for libre bridges

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
@@ -172,9 +172,11 @@ public class Tomato {
         // Important note, the actual serial number is 8 bytes long and starts at addresses 0. Since the existing
         // code is looking for them starting at place 3, we copy extra 3 bytes.
         byte[] serialBuffer = Arrays.copyOfRange(s_full_data, 2, 13);
+        int sensorAge = LibreUtils.getSensorAge(data);
         Blukon.decodeSerialNumber(serialBuffer);
         PersistentStore.setString("Tomatobattery", Integer.toString(s_full_data[13]));
         Pref.setInt("bridge_battery", s_full_data[13]);
+        Pref.setInt("nfc_sensor_age", sensorAge);
         PersistentStore.setString("TomatoHArdware",HexDump.toHexString(s_full_data,16,2));
         PersistentStore.setString("TomatoFirmware",HexDump.toHexString(s_full_data,14,2));
 
@@ -213,6 +215,7 @@ public class Tomato {
     public static ArrayList<ByteBuffer> initialize() {
         Log.i(TAG, "initialize!");
         Pref.setInt("bridge_battery", 0); //force battery to no-value before first reading
+        Pref.setInt("nfc_sensor_age", 0); //force sensor age to no-value before first reading
         return resetTomatoState();
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
@@ -172,11 +172,9 @@ public class Tomato {
         // Important note, the actual serial number is 8 bytes long and starts at addresses 0. Since the existing
         // code is looking for them starting at place 3, we copy extra 3 bytes.
         byte[] serialBuffer = Arrays.copyOfRange(s_full_data, 2, 13);
-        int sensorAge = LibreUtils.getSensorAge(data);
         Blukon.decodeSerialNumber(serialBuffer);
         PersistentStore.setString("Tomatobattery", Integer.toString(s_full_data[13]));
         Pref.setInt("bridge_battery", s_full_data[13]);
-        Pref.setInt("nfc_sensor_age", sensorAge);
         PersistentStore.setString("TomatoHArdware",HexDump.toHexString(s_full_data,16,2));
         PersistentStore.setString("TomatoFirmware",HexDump.toHexString(s_full_data,14,2));
 
@@ -215,7 +213,6 @@ public class Tomato {
     public static ArrayList<ByteBuffer> initialize() {
         Log.i(TAG, "initialize!");
         Pref.setInt("bridge_battery", 0); //force battery to no-value before first reading
-        Pref.setInt("nfc_sensor_age", 0); //force sensor age to no-value before first reading
         return resetTomatoState();
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -494,7 +494,7 @@ public class NFCReaderX {
 
         int indexHistory = data[27] & 0xFF; // double check this bitmask? should be lower?
 
-        final int sensorTime = 256 * (data[317] & 0xFF) + (data[316] & 0xFF);
+        final int sensorTime = LibreUtils.getSensorAge(data);
 
         long sensorStartTime = CaptureDateTime - sensorTime * MINUTE;
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -227,6 +227,9 @@ public class NFCReaderX {
             return true;
         }
 
+	int sensorAge = LibreUtils.getSensorAge(data1);
+	Pref.setInt("nfc_sensor_age", sensorAge);
+
         if (Pref.getBooleanDefaultFalse("external_blukon_algorithm")) {
             // Save raw block record (we start from block 0)
             LibreBlock.createAndSave(tagId, CaptureDateTime, data1, 0);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
@@ -74,6 +74,12 @@ public class LibreUtils {
 
     }
 
+    public static int getSensorAge(byte[] data) {
+        int sensorAge = 256 * (data[317] & 0xFF) + (data[316] & 0xFF);
+        Log.i(TAG, "sensorAge=" + sensorAge);
+
+        return sensorAge;
+    }
     public static boolean isSensorReady(byte sensorStatusByte) {
     
         String sensorStatusString = "";


### PR DESCRIPTION
This enables all libre bridges that call the HandleGoodReading function to save the nfc sensor age and upload this to nightscout. In practise, blukons have their own implementation that don't use HandleGoodReading, so this affects miaomiao, librealarm and direct nfc readings only.

Needs some testing. I've talked to @tzachi-dar briefly about this implementation today.