### PR TITLE
Correct Setting of LibreSN:

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
@@ -5,6 +5,7 @@ import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.NFCReaderX;
 import com.eveningoutpost.dexdrip.UtilityModels.Blukon;
 import com.eveningoutpost.dexdrip.UtilityModels.BridgeResponse;
+import com.eveningoutpost.dexdrip.UtilityModels.LibreUtils;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 
@@ -163,20 +164,18 @@ public class Tomato {
         long now = JoH.tsl();
         // Important note, the actual serial number is 8 bytes long and starts at addresses 0. Since the existing
         // code is looking for them starting at place 3, we copy extra 3 bytes.
-        byte[] serialBuffer = Arrays.copyOfRange(s_full_data, 2, 13);
-        String SensorSn = Blukon.decodeSerialNumber(serialBuffer);
+        String SensorSn = LibreUtils.decodeSerialNumberKey(Arrays.copyOfRange(s_full_data, 5, 13));
         boolean checksum_ok = NFCReaderX.HandleGoodReading(SensorSn, data, now);
         Log.e(TAG, "We have all the data that we need " + s_acumulatedSize + " checksum_ok = " + checksum_ok + HexDump.dumpHexString(data));
 
         if(!checksum_ok) {
             throw new RuntimeException(CHECKSUM_FAILED);
         }
-        
-        
         PersistentStore.setString("Tomatobattery", Integer.toString(s_full_data[13]));
         Pref.setInt("bridge_battery", s_full_data[13]);
         PersistentStore.setString("TomatoHArdware",HexDump.toHexString(s_full_data,16,2));
         PersistentStore.setString("TomatoFirmware",HexDump.toHexString(s_full_data,14,2));
+        PersistentStore.setString("LibreSN", SensorSn);
 
         
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -34,6 +34,7 @@ import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -272,10 +273,12 @@ public class NFCReaderX {
                 if (succeeded) {
                     final String tagId = bytesToHexString(tag.getId());
                     long now = JoH.tsl();
+                    String SensorSn = LibreUtils.decodeSerialNumberKey(tag.getId());
                     boolean checksum_ok = HandleGoodReading(tagId, data, now);
                     if(checksum_ok == false) {
                         Log.e(TAG, "Read data but checksum is wrong");
                     }
+                    PersistentStore.setString("LibreSN", SensorSn);
                 } else {
                     Log.d(TAG, "Scan did not succeed so ignoring buffer");
                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Blukon.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Blukon.java
@@ -358,7 +358,7 @@ private static final int POSITION_OF_SENSOR_STATUS_BYTE = 17;
             */
 
             if (JoH.pratelimit(BLUKON_DECODE_SERIAL_TIMER, GET_DECODE_SERIAL_DELAY)) {
-                String SensorSn = decodeSerialNumber(buffer);
+                String SensorSn = LibreUtils.decodeSerialNumber(buffer);
                 // TODO: Only write this after checksum was verified
                 PersistentStore.setString("LibreSN", SensorSn);
             }
@@ -622,43 +622,6 @@ private static final int POSITION_OF_SENSOR_STATUS_BYTE = 17;
         } else {
             currentCommand = "";
         }
-    }
-
-    // This function assumes that the UID is starting at place 3, and is 8 bytes long
-    public static String decodeSerialNumber(byte[] input) {
-        
-        byte[] uuid = new byte[]{0, 0, 0, 0, 0, 0, 0, 0};
-        String lookupTable[] =
-                {
-                        "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
-                        "A", "C", "D", "E", "F", "G", "H", "J", "K", "L",
-                        "M", "N", "P", "Q", "R", "T", "U", "V", "W", "X",
-                        "Y", "Z"
-                };
-        byte[] uuidShort = new byte[]{0, 0, 0, 0, 0, 0, 0, 0};
-        int i;
-
-        for (i = 2; i < 8; i++) uuidShort[i - 2] = input[(2 + 8) - i];
-        uuidShort[6] = 0x00;
-        uuidShort[7] = 0x00;
-
-        String binary = "";
-        String binS = "";
-        for (i = 0; i < 8; i++) {
-            binS = String.format("%8s", Integer.toBinaryString(uuidShort[i] & 0xFF)).replace(' ', '0');
-            binary += binS;
-        }
-        
-        String v = "0";
-        char[] pozS = {0, 0, 0, 0, 0};
-        for (i = 0; i < 10; i++) {
-            for (int k = 0; k < 5; k++) pozS[k] = binary.charAt((5 * i) + k);
-            int value = (pozS[0] - '0') * 16 + (pozS[1] - '0') * 8 + (pozS[2] - '0') * 4 + (pozS[3] - '0') * 2 + (pozS[4] - '0') * 1;
-            v += lookupTable[value];
-        }
-        Log.e(TAG, "decodeSerialNumber=" + v);
-
-        return v;
     }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LibreUtils.java
@@ -127,4 +127,49 @@ public class LibreUtils {
         return Pref.getBooleanDefaultFalse("engineering_mode") && 
                Pref.getBooleanDefaultFalse("allow_testing_with_dead_sensor");
     }
+    
+    // This is the function that all should read (only the correct 8 bytes)
+    // Since I don't have a blukon to test, not changing decodeSerialNumber
+    public static String decodeSerialNumberKey(byte[] input) {
+        byte[] serialBuffer = new byte[3+8];
+        System.arraycopy(input,0, serialBuffer, 3, 8);
+        return decodeSerialNumber( serialBuffer);
+    }
+    
+    
+    // This function assumes that the UID is starting at place 3, and is 8 bytes long
+    public static String decodeSerialNumber(byte[] input) {
+        
+        String lookupTable[] =
+                {
+                        "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+                        "A", "C", "D", "E", "F", "G", "H", "J", "K", "L",
+                        "M", "N", "P", "Q", "R", "T", "U", "V", "W", "X",
+                        "Y", "Z"
+                };
+        byte[] uuidShort = new byte[]{0, 0, 0, 0, 0, 0, 0, 0};
+        int i;
+
+        for (i = 2; i < 8; i++) uuidShort[i - 2] = input[(2 + 8) - i];
+        uuidShort[6] = 0x00;
+        uuidShort[7] = 0x00;
+
+        String binary = "";
+        String binS = "";
+        for (i = 0; i < 8; i++) {
+            binS = String.format("%8s", Integer.toBinaryString(uuidShort[i] & 0xFF)).replace(' ', '0');
+            binary += binS;
+        }
+        
+        String v = "0";
+        char[] pozS = {0, 0, 0, 0, 0};
+        for (i = 0; i < 10; i++) {
+            for (int k = 0; k < 5; k++) pozS[k] = binary.charAt((5 * i) + k);
+            int value = (pozS[0] - '0') * 16 + (pozS[1] - '0') * 8 + (pozS[2] - '0') * 4 + (pozS[3] - '0') * 2 + (pozS[4] - '0') * 1;
+            v += lookupTable[value];
+        }
+        Log.e(TAG, "decodeSerialNumber=" + v);
+
+        return v;
+    }
 }


### PR DESCRIPTION
decodeSerialNumber is moved to LibreUtils.
It is used also for manual scanning.
We set LibreSN for tomato (a bug fix) and also for manual scanning.

Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>