### PR TITLE
Optionally store g5/g6 transmitter battery information in nightscout

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5BaseService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5BaseService.java
@@ -51,6 +51,8 @@ public abstract class G5BaseService extends Service {
         updateBatteryWarningLevel();
     }
 
+    public static int getLowBatteryWarningLevel() { return LOW_BATTERY_WARNING_LEVEL; }
+
 
     @Override
     public void onCreate() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Ob1G5TransmitterBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Ob1G5TransmitterBattery.java
@@ -1,0 +1,81 @@
+package com.eveningoutpost.dexdrip.UtilityModels;
+
+import com.eveningoutpost.dexdrip.G5Model.BatteryInfoRxMessage;
+import com.eveningoutpost.dexdrip.G5Model.Ob1G5StateMachine;
+import com.eveningoutpost.dexdrip.G5Model.TransmitterStatus;
+import com.eveningoutpost.dexdrip.G5Model.VersionRequestRxMessage;
+import com.eveningoutpost.dexdrip.Services.G5BaseService;
+
+/**
+ * Holds information about a G5/G6 transmitter's battery status,
+ * used when sent to Nightscout and obtained via Ob1G5StateMachine.
+ *
+ * @author James Woglom (j@wogloms.net)
+ */
+public class Ob1G5TransmitterBattery implements TransmitterBattery {
+   public static Ob1G5TransmitterBattery getTransmitterBattery() {
+       return new Ob1G5TransmitterBattery(Pref.getStringDefaultBlank("dex_txid"));
+   }
+
+   private BatteryInfoRxMessage batteryRx;
+   private VersionRequestRxMessage versionRx;
+   private static final int batteryWarningLevel = G5BaseService.getLowBatteryWarningLevel();
+
+   public Ob1G5TransmitterBattery(String tx_id) {
+       batteryRx = Ob1G5StateMachine.getBatteryDetails(tx_id);
+       versionRx = Ob1G5StateMachine.getFirmwareDetails(tx_id);
+   }
+
+   public TransmitterStatus status() {
+       return TransmitterStatus.getBatteryLevel(versionRx.status);
+   }
+
+   public int days() {
+       return batteryRx.runtime;
+   }
+
+   public int voltageA() {
+       return batteryRx.voltagea;
+   }
+
+   public VoltageStatus voltageAStatus() {
+       if (batteryRx.voltagea < batteryWarningLevel) return VoltageStatus.WARNING;
+       return VoltageStatus.GOOD;
+   }
+
+   public int voltageB() {
+       return batteryRx.voltageb;
+   }
+
+   public VoltageStatus voltageBStatus() {
+       if (batteryRx.voltageb < batteryWarningLevel) return VoltageStatus.WARNING;
+       return VoltageStatus.GOOD;
+   }
+
+   public int resistance() {
+       return batteryRx.resist;
+   }
+
+   public ResistanceStatus resistanceStatus() {
+       int r = batteryRx.resist;
+
+       if (r > 1400) {
+           return ResistanceStatus.BAD;
+       } else if (r > 1000) {
+           return ResistanceStatus.NOTICE;
+       } else if (r > 750) {
+           return ResistanceStatus.NORMAL;
+       } else {
+           return ResistanceStatus.GOOD;
+       }
+   }
+
+   public int temperature() {
+       return batteryRx.temperature;
+   }
+
+   // This is what nightscout shows in the UI
+   public String battery() {
+       return voltageA()+"/"+voltageB()+"/"+resistance();
+   }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/TransmitterBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/TransmitterBattery.java
@@ -1,0 +1,35 @@
+package com.eveningoutpost.dexdrip.UtilityModels;
+
+import com.eveningoutpost.dexdrip.G5Model.TransmitterStatus;
+
+/**
+ * Abstract representation of information about a transmitter battery and
+ * the states of each specific parameter.
+ *
+ * @author James Woglom (j@wogloms.net)
+ */
+public interface TransmitterBattery {
+    TransmitterStatus status();
+    int days();
+    int voltageA();
+
+    enum VoltageStatus {
+        GOOD,
+        WARNING
+    }
+    VoltageStatus voltageAStatus();
+    int voltageB();
+    VoltageStatus voltageBStatus();
+    int resistance();
+
+    enum ResistanceStatus {
+        GOOD,
+        NORMAL,
+        NOTICE,
+        BAD
+    }
+    ResistanceStatus resistanceStatus();
+    int temperature();
+
+    String battery();
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
@@ -127,6 +127,8 @@ public enum DexCollectionType {
 
     public static boolean usesClassicTransmitterBattery() { return usesTransmitterBattery.contains(getDexCollectionType()); }
 
+    public static boolean isG5G6() { return getDexCollectionType() == DexcomG5 || getDexCollectionType() == DexcomG6; }
+
     public static boolean hasDexcomRaw(DexCollectionType type) {
         return usesDexcomRaw.contains(type);
     }

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -113,6 +113,11 @@
                         android:summary="Send your bridge battery level to Nightscout. Uncheck if your battery sensor is broken."
                         android:title="Upload bridge battery" />
                     <CheckBoxPreference
+                        android:defaultValue="false"
+                        android:key="send_g5tx_battery_to_nightscout"
+                        android:summary="Send transmitter battery statistics to Nightscout. Includes detailed info not shown in the UI."
+                        android:title="Upload Ob1G5/G6 transmitter battery" />
+                    <CheckBoxPreference
                         android:defaultValue="true"
                         android:key="send_treatments_to_nightscout"
                         android:summary="Send treatment data to Nightscout. Uncheck if your careportal is broken."


### PR DESCRIPTION
When enabled, this will add an object like the following in nightscout's devicestatus whenever the voltages or resistance state of the battery changes:
```
{
  "_id": "5b98a7d3d2ea1d06adda76db",
  "device": "G6 Transmitter",
  "uploader": {
    "days": 20,
    "status": "OK",
    "battery": "298/282/959",
    "voltagea": 298,
    "voltagea_status": "GOOD",
    "voltageb": 282,
    "voltageb_status": "WARNING",
    "resistance": 959,
    "resistance_status": "NORMAL",
    "temperature": 35
  },
  "created_at": "2018-09-12T05:44:51.553Z"
}
```

In the nightscout UI, the G5/G6's voltagea, voltageb, and resistance will appear when hovering over the battery icon:

![image](https://user-images.githubusercontent.com/192620/45404807-70156000-b62e-11e8-81f0-026fcf0a7107.png)
