### PR TITLE
Gregorybel: fix displayed BG value into wear complication

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -253,16 +253,23 @@ public class BgReading extends Model implements ShareUploadableBg {
         String unit = prefs.getString("units", "mgdl");
         DecimalFormat df = new DecimalFormat("#");
         df.setMaximumFractionDigits(0);
+        double usedBgValue = 0;
 
-        if (calculated_value >= 400) {
+        if (dg_mgdl > 0) {
+            usedBgValue = dg_mgdl;//from plugin
+        } else {
+            usedBgValue = calculated_value;//xdrip original
+        }
+
+        if (usedBgValue >= 400) {
             return "HIGH";
-        } else if (calculated_value >= 40) {
+        } else if (usedBgValue >= 40) {
             if (unit.compareTo("mgdl") == 0) {
                 df.setMaximumFractionDigits(0);
-                return df.format(calculated_value);
+                return df.format(usedBgValue);
             } else {
                 df.setMaximumFractionDigits(1);
-                return df.format(calculated_value_mmol());
+                return df.format(mmolConvert(usedBgValue));
             }
         } else {
             return "LOW";

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -249,27 +249,18 @@ public class BgReading extends Model implements ShareUploadableBg {
     }
 
     public String displayValue(Context context) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String unit = prefs.getString("units", "mgdl");
-        DecimalFormat df = new DecimalFormat("#");
-        df.setMaximumFractionDigits(0);
-        double usedBgValue = 0;
-
-        if (dg_mgdl > 0) {
-            usedBgValue = dg_mgdl;//from plugin
-        } else {
-            usedBgValue = calculated_value;//xdrip original
-        }
-
-        if (usedBgValue >= 400) {
+        final String unit = Pref.getString("units", "mgdl");
+        final DecimalFormat df = new DecimalFormat("#");
+        final double this_value = getDg_mgdl();
+        if (this_value >= 400) {
             return "HIGH";
-        } else if (usedBgValue >= 40) {
-            if (unit.compareTo("mgdl") == 0) {
+        } else if (this_value >= 40) {
+            if (unit.equals("mgdl")) {
                 df.setMaximumFractionDigits(0);
-                return df.format(usedBgValue);
+                return df.format(this_value);
             } else {
                 df.setMaximumFractionDigits(1);
-                return df.format(mmolConvert(usedBgValue));
+                return df.format(mmolConvert(this_value));
             }
         } else {
             return "LOW";

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -253,23 +253,23 @@ public class BgReading extends Model implements ShareUploadableBg {
         String unit = prefs.getString("units", "mgdl");
         DecimalFormat df = new DecimalFormat("#");
         df.setMaximumFractionDigits(0);
-        double localBgValue = 0;
+        double usedBgValue = 0;
 
         if (dg_mgdl > 0) {
-            localBgValue = dg_mgdl;
+            usedBgValue = dg_mgdl;//from plugin
         } else {
-            localBgValue = calculated_value;
+            usedBgValue = calculated_value;//xdrip original
         }
 
-        if (localBgValue >= 400) {
+        if (usedBgValue >= 400) {
             return "HIGH";
-        } else if (localBgValue >= 40) {
+        } else if (usedBgValue >= 40) {
             if (unit.compareTo("mgdl") == 0) {
                 df.setMaximumFractionDigits(0);
-                return df.format(localBgValue);
+                return df.format(usedBgValue);
             } else {
                 df.setMaximumFractionDigits(1);
-                return df.format(mmolConvert(localBgValue));
+                return df.format(mmolConvert(usedBgValue));
             }
         } else {
             return "LOW";

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -208,8 +208,8 @@ public class BgReading extends Model implements ShareUploadableBg {
     }
 
     public double getDg_mgdl(){
-        if(dg_mgdl != 0) return dg_mgdl;
-        return calculated_value;
+        if(dg_mgdl != 0) return dg_mgdl;//from plugin
+        return calculated_value;//xdrip original
     }
 
     public double getDg_slope(){
@@ -249,27 +249,18 @@ public class BgReading extends Model implements ShareUploadableBg {
     }
 
     public String displayValue(Context context) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String unit = prefs.getString("units", "mgdl");
-        DecimalFormat df = new DecimalFormat("#");
-        df.setMaximumFractionDigits(0);
-        double usedBgValue = 0;
-
-        if (dg_mgdl > 0) {
-            usedBgValue = dg_mgdl;//from plugin
-        } else {
-            usedBgValue = calculated_value;//xdrip original
-        }
-
-        if (usedBgValue >= 400) {
+        final String unit = Pref.getString("units", "mgdl");
+        final DecimalFormat df = new DecimalFormat("#");
+        final double this_value = getDg_mgdl();
+        if (this_value >= 400) {
             return "HIGH";
-        } else if (usedBgValue >= 40) {
-            if (unit.compareTo("mgdl") == 0) {
+        } else if (this_value >= 40) {
+            if (unit.equals("mgdl")) {
                 df.setMaximumFractionDigits(0);
-                return df.format(usedBgValue);
+                return df.format(this_value);
             } else {
                 df.setMaximumFractionDigits(1);
-                return df.format(mmolConvert(usedBgValue));
+                return df.format(mmolConvert(this_value));
             }
         } else {
             return "LOW";

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -253,16 +253,23 @@ public class BgReading extends Model implements ShareUploadableBg {
         String unit = prefs.getString("units", "mgdl");
         DecimalFormat df = new DecimalFormat("#");
         df.setMaximumFractionDigits(0);
+        double localBgValue = 0;
 
-        if (calculated_value >= 400) {
+        if (dg_mgdl > 0) {
+            localBgValue = dg_mgdl;
+        } else {
+            localBgValue = calculated_value;
+        }
+
+        if (localBgValue >= 400) {
             return "HIGH";
-        } else if (calculated_value >= 40) {
+        } else if (localBgValue >= 40) {
             if (unit.compareTo("mgdl") == 0) {
                 df.setMaximumFractionDigits(0);
-                return df.format(calculated_value);
+                return df.format(localBgValue);
             } else {
                 df.setMaximumFractionDigits(1);
-                return df.format(calculated_value_mmol());
+                return df.format(mmolConvert(localBgValue));
             }
         } else {
             return "LOW";


### PR DESCRIPTION
This is an old bug, somehow til now wear complication shows the original xdrip BG value even if a plugin is activated and users wants to use BG value from plugin. This PR fixes this.

Successfully tested on my watch. 

see issues:
https://github.com/NightscoutFoundation/xDrip/issues/492
https://github.com/NightscoutFoundation/xDrip/issues/391
https://github.com/NightscoutFoundation/xDrip/issues/468

 