### PR TITLE
 Allow wear sync if timestamp difference is older than zero.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -645,7 +645,7 @@ public class WatchUpdaterService extends WearableListenerService implements
                             continue;
                         }
                         final long since = JoH.msSince(timestamp);
-                        if ((since < 0) || (since > Constants.HOUR_IN_MS * 72)) {
+                        if ((since < -(5 * 1000)) || (since > Constants.HOUR_IN_MS * 72)) {
                             JoH.static_toast_long("Rejecting wear treatment as time out of range!");
                             UserError.Log.e(TAG, "Rejecting wear treatment due to time: " + record + " since: " + since);
                         } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -645,7 +645,7 @@ public class WatchUpdaterService extends WearableListenerService implements
                             continue;
                         }
                         final long since = JoH.msSince(timestamp);
-                        if ((since < -(5 * 1000)) || (since > Constants.HOUR_IN_MS * 72)) {
+                        if ((since < -(Constants.SECOND_IN_MS * 5)) || (since > Constants.HOUR_IN_MS * 72)) {
                             JoH.static_toast_long("Rejecting wear treatment as time out of range!");
                             UserError.Log.e(TAG, "Rejecting wear treatment due to time: " + record + " since: " + since);
                         } else {


### PR DESCRIPTION
Every time when entering data using my smartwatch (Ticwatch E) the sync would fail because the timestamp difference (`since` variable) was around `-900`.

This PR fixes the issue by allowing timestamps up to five seconds older than the current time.