### PR TITLE
Fix an exception that is created from a bad string.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/RollCall.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/RollCall.java
@@ -138,7 +138,13 @@ public class RollCall {
         final Gson gson = new GsonBuilder()
                 .excludeFieldsWithoutExposeAnnotation()
                 .create();
-        return gson.fromJson(json, RollCall.class);
+        try {
+            return gson.fromJson(json, RollCall.class);
+        } catch (Exception e) {
+            UserError.Log.e(TAG, "Got exception processing fromJson() " + e);
+            UserError.Log.e(TAG, "json = "  + json);
+            return null;
+        }   
     }
 
     public synchronized static void Seen(String item_json) {


### PR DESCRIPTION
Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>

This solves the immediate issue that was reported in https://github.com/NightscoutFoundation/xDrip/issues/612.

The crashes stopped.