### PR TITLE
sclae event log items according to density

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/EventLogActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EventLogActivity.java
@@ -564,7 +564,7 @@ public class EventLogActivity extends BaseAppCompatActivity {
 
         // reformat text size for long messages
         public float textSize(String message) {
-            final float scale = 4f;
+            final float scale = 2.666f * getResources().getDisplayMetrics().density;
             if (message.length() > 100) return 5f * scale;
             return 7f * scale;
         }


### PR DESCRIPTION
This scales the event log items according to the display density.
`density` has MDPI as reference value (it exists since API Level1) - and I assume this was designed with at least HDPI in mind, I adjusted the scale factor by ~1.5.