### PR TITLE
gregorybel: do not allow BT watchdog timer smaller than 6min

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -1732,7 +1732,7 @@ public class DexCollectionService extends Service implements BtCallBack {
             int MAX_BT_WDG = 20;
             int bt_wdg_timer = JoH.parseIntWithDefault(Pref.getString("bluetooth_watchdog_timer", Integer.toString(MAX_BT_WDG)), 10, MAX_BT_WDG);
 
-            if ( (bt_wdg_timer <= 0) || (bt_wdg_timer > MAX_BT_WDG) ) {
+            if ( (bt_wdg_timer <= 5) || (bt_wdg_timer > MAX_BT_WDG) ) {
                 bt_wdg_timer = MAX_BT_WDG;
             }
 

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -1732,7 +1732,7 @@ public class DexCollectionService extends Service implements BtCallBack {
             int MAX_BT_WDG = 20;
             int bt_wdg_timer = JoH.parseIntWithDefault(Pref.getString("bluetooth_watchdog_timer", Integer.toString(MAX_BT_WDG)), 10, MAX_BT_WDG);
 
-            if ( (bt_wdg_timer <= 0) || (bt_wdg_timer > MAX_BT_WDG) ) {
+            if ( (bt_wdg_timer <= 5) || (bt_wdg_timer > MAX_BT_WDG) ) {
                 bt_wdg_timer = MAX_BT_WDG;
             }
 


### PR DESCRIPTION
If user wants to set a timer smaller than 6min then default value will be applied,
This to avoid to frequent watchdog calls, which will be useless as most CGM send new value every 5min.