### PR TITLE
Adding google pixel 2/2 xl as 'high capture'

### DIFF
--- a/Documentation/Phones_For_G5.md
+++ b/Documentation/Phones_For_G5.md
@@ -7,6 +7,8 @@ In theory, using the same phone with the same Android version should allow you t
 
 Phone Model | Android Version | Mode
 --- | --- | ---
+Google Pixel 2 | 9 |
+Google Pixel 2XL | 9 |
 Google Pixel | 7.1.1 |
 Google Pixel | 7.1.2 |
 Google Pixel XL | 7.1.1


### PR DESCRIPTION
I have access to both, and both have shown dexcom g5 capture rates of minimally every 5m as a baseline without issues in my usage.