### PR TITLE
resolve issue 795 upload bgs to follower when watch is collector

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NewDataObserver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NewDataObserver.java
@@ -124,8 +124,8 @@ public class NewDataObserver {
     // share uploader
     private static void uploadToShare(BgReading bgReading, boolean is_follower) {
         if ((!is_follower) && (Pref.getBooleanDefaultFalse("share_upload"))) {
-            if (JoH.ratelimit("sending-to-share-upload", 10)) {
-                UserError.Log.d("ShareRest", "About to call ShareRest!!");
+            if (JoH.ratelimit("sending-to-share-upload", 10) || Home.get_enable_wear()) {
+                UserError.Log.d("ShareRest", "About to call ShareRest!! " + JoH.dateTimeText(bgReading.timestamp) + " BG: " + bgReading.calculated_value);
                 String receiverSn = Pref.getString("share_key", "SM00000000").toUpperCase();
                 BgUploader bgUploader = new BgUploader(xdrip.getAppContext());
                 bgUploader.upload(new ShareUploadPayload(receiverSn, bgReading));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -106,8 +106,12 @@ public class BgSendQueue extends Model {
         handleNewBgReading(bgReading, operation_type, context, is_follower, false);
     }
 
+    public static void handleNewBgReading(BgReading bgReading, String operation_type, Context context, boolean is_follower, boolean quick) {
+        handleNewBgReading(bgReading, operation_type, context, is_follower, quick, quick);
+    }
+
     // TODO extract to non depreciated class
-    public static void handleNewBgReading(final BgReading bgReading, String operation_type, Context context, boolean is_follower, boolean quick) {
+    public static void handleNewBgReading(final BgReading bgReading, String operation_type, Context context, boolean is_follower, boolean quick, boolean quickui) {
         if (bgReading == null) {
             UserError.Log.wtf("BgSendQueue", "handleNewBgReading called with null bgReading!");
             return;
@@ -121,7 +125,7 @@ public class BgSendQueue extends Model {
             //}
 
             // all this other UI stuff probably shouldn't be here but in lieu of a better method we keep with it..
-            if (!quick) {
+            if (!quickui) {
                 if (Home.activityVisible) {
                     context.sendBroadcast(new Intent(Intents.ACTION_NEW_BG_ESTIMATE_NO_DATA));
                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -413,7 +413,7 @@ public class WatchUpdaterService extends WearableListenerService implements
                                     Log.d(TAG, "Saving new synced pre-calculated bg-reading: " + JoH.dateTimeText(bgData.timestamp) + " last entry: " + (idx == count) + " " + BgGraphBuilder.unitized_string_static(bgData.calculated_value));
                                     bgData.sensor = current_sensor;
                                     bgData.save();
-                                    BgSendQueue.handleNewBgReading(bgData, "create", xdrip.getAppContext(), Home.get_follower(), idx != count);
+                                    BgSendQueue.handleNewBgReading(bgData, "create", xdrip.getAppContext(), Home.get_follower(), false, idx != count);
                                 } else {
                                     Log.d(TAG, "BgReading for timestamp already exists: " + JoH.dateTimeText(bgData.timestamp));
                                 }


### PR DESCRIPTION
This PR resolves issue #795.  In particular, performs `uploadToShare()` for ALL BGs in watch sync queue when watch is collector.  This issue was noticed when using sugarmate.io as a Dexcom Follower.  sugarmate.io failed to show BGs that were synced from the watch to phone on re-connect.

LOG:

02-24 13:48:49.009 2194-10483/? D/jamorham watchupdater: Saving new synced pre-calculated bg-reading: 2019-02-24 13:48:42 last entry: true 81
02-24 13:48:49.169 2194-10483/? D/ShareRest: About to call ShareRest!! 2019-02-24 13:48:42 BG: 81.0
02-24 13:48:49.289 2194-10490/? D/UploaderTask: UploaderTask doInBackground called

Disconnect watch from phone:
<img width="435" alt="screen shot 2019-02-24 at 2 03 51 pm" src="https://user-images.githubusercontent.com/16564065/53304145-30d77600-3840-11e9-86ca-06ac9a7531aa.png">

On RE-CONNECT with Phone, all BGs in queue get sent to Share:

02-24 14:03:46.704 2194-21196/? D/jamorham watchupdater: Saving new synced pre-calculated bg-reading: 2019-02-24 13:53:42 last entry: false 86
02-24 14:03:46.944 2194-21196/? D/ShareRest: About to call ShareRest!! 2019-02-24 13:53:42 BG: 86.0
02-24 14:03:47.044 2194-21203/? D/UploaderTask: UploaderTask doInBackground called
02-24 14:03:47.114 2194-21196/? D/jamorham watchupdater: Saving new synced pre-calculated bg-reading: 2019-02-24 13:58:42 last entry: false 84
02-24 14:03:47.294 2194-21196/? D/ShareRest: About to call ShareRest!! 2019-02-24 13:58:42 BG: 84.0

02-24 14:03:47.404 2194-21196/? D/jamorham watchupdater: Saving new synced pre-calculated bg-reading: 2019-02-24 14:03:42 last entry: true 73

02-24 14:03:47.784 2194-21196/? D/ShareRest: About to call ShareRest!! 2019-02-24 14:03:42 BG: 72.5032418111937

<img width="521" alt="screen shot 2019-02-24 at 2 05 51 pm" src="https://user-images.githubusercontent.com/16564065/53304167-62504180-3840-11e9-858b-5734a0bc685c.png">

