### PR TITLE
resolve issue 795 upload backfill bgs to dexcom share

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NewDataObserver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NewDataObserver.java
@@ -124,8 +124,8 @@ public class NewDataObserver {
     // share uploader
     private static void uploadToShare(BgReading bgReading, boolean is_follower) {
         if ((!is_follower) && (Pref.getBooleanDefaultFalse("share_upload"))) {
-            if (JoH.ratelimit("sending-to-share-upload", 10)) {
-                UserError.Log.d("ShareRest", "About to call ShareRest!!");
+            if (JoH.ratelimit("sending-to-share-upload", 10) || Home.get_enable_wear()) {
+                UserError.Log.d("ShareRest", "About to call ShareRest!! " + JoH.dateTimeText(bgReading.timestamp) + " BG: " + bgReading.calculated_value);
                 String receiverSn = Pref.getString("share_key", "SM00000000").toUpperCase();
                 BgUploader bgUploader = new BgUploader(xdrip.getAppContext());
                 bgUploader.upload(new ShareUploadPayload(receiverSn, bgReading));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NewDataObserver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NewDataObserver.java
@@ -38,18 +38,20 @@ public class NewDataObserver {
     // TODO move appropriate functions in to their responsible classes
 
     // when we receive new glucose reading we want to propagate
-    public static void newBgReading(BgReading bgReading, boolean is_follower) {
+    public static void newBgReading(BgReading bgReading, boolean is_follower, boolean quick) {
 
-        sendToPebble();
-        sendToWear();
-        sendToAmazfit();
-        sendToLeFun();
-        Notifications.start();
-        uploadToShare(bgReading, is_follower);
-        textToSpeech(bgReading, null);
-        LibreBlock.UpdateBgVal(bgReading.timestamp, bgReading.calculated_value);
-        LockScreenWallPaper.setIfEnabled();
-        TidepoolEntry.newData();
+        if (!quick) {
+            sendToPebble();
+            sendToWear();
+            sendToAmazfit();
+            sendToLeFun();
+            Notifications.start();
+            textToSpeech(bgReading, null);
+            LibreBlock.UpdateBgVal(bgReading.timestamp, bgReading.calculated_value);
+            LockScreenWallPaper.setIfEnabled();
+            TidepoolEntry.newData();
+        }
+        uploadToShare(bgReading, is_follower, quick);
 
     }
 
@@ -122,9 +124,9 @@ public class NewDataObserver {
     }
 
     // share uploader
-    private static void uploadToShare(BgReading bgReading, boolean is_follower) {
+    private static void uploadToShare(BgReading bgReading, boolean is_follower, boolean quick) {
         if ((!is_follower) && (Pref.getBooleanDefaultFalse("share_upload"))) {
-            if (JoH.ratelimit("sending-to-share-upload", 10) || Home.get_enable_wear()) {
+            if (JoH.ratelimit("sending-to-share-upload", 10) || quick) {
                 UserError.Log.d("ShareRest", "About to call ShareRest!! " + JoH.dateTimeText(bgReading.timestamp) + " BG: " + bgReading.calculated_value);
                 String receiverSn = Pref.getString("share_key", "SM00000000").toUpperCase();
                 BgUploader bgUploader = new BgUploader(xdrip.getAppContext());

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -106,12 +106,8 @@ public class BgSendQueue extends Model {
         handleNewBgReading(bgReading, operation_type, context, is_follower, false);
     }
 
-    public static void handleNewBgReading(BgReading bgReading, String operation_type, Context context, boolean is_follower, boolean quick) {
-        handleNewBgReading(bgReading, operation_type, context, is_follower, quick, quick);
-    }
-
     // TODO extract to non depreciated class
-    public static void handleNewBgReading(final BgReading bgReading, String operation_type, Context context, boolean is_follower, boolean quick, boolean quickui) {
+    public static void handleNewBgReading(final BgReading bgReading, String operation_type, Context context, boolean is_follower, boolean quick) {
         if (bgReading == null) {
             UserError.Log.wtf("BgSendQueue", "handleNewBgReading called with null bgReading!");
             return;
@@ -125,7 +121,7 @@ public class BgSendQueue extends Model {
             //}
 
             // all this other UI stuff probably shouldn't be here but in lieu of a better method we keep with it..
-            if (!quickui) {
+            if (!quick) {
                 if (Home.activityVisible) {
                     context.sendBroadcast(new Intent(Intents.ACTION_NEW_BG_ESTIMATE_NO_DATA));
                 }
@@ -146,10 +142,7 @@ public class BgSendQueue extends Model {
                     JoH.getWakeLock("broadcstNightWatch", 3000);
                 }
 
-
-            if (!quick) {
-                NewDataObserver.newBgReading(bgReading, is_follower);
-            }
+            NewDataObserver.newBgReading(bgReading, is_follower, quick);
 
             if ((!is_follower) && (Pref.getBoolean("plus_follow_master", false))) {
                 if (Pref.getBoolean("display_glucose_from_plugin", false))

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -106,8 +106,12 @@ public class BgSendQueue extends Model {
         handleNewBgReading(bgReading, operation_type, context, is_follower, false);
     }
 
+    public static void handleNewBgReading(BgReading bgReading, String operation_type, Context context, boolean is_follower, boolean quick) {
+        handleNewBgReading(bgReading, operation_type, context, is_follower, quick, quick);
+    }
+
     // TODO extract to non depreciated class
-    public static void handleNewBgReading(final BgReading bgReading, String operation_type, Context context, boolean is_follower, boolean quick) {
+    public static void handleNewBgReading(final BgReading bgReading, String operation_type, Context context, boolean is_follower, boolean quick, boolean quickui) {
         if (bgReading == null) {
             UserError.Log.wtf("BgSendQueue", "handleNewBgReading called with null bgReading!");
             return;
@@ -121,7 +125,7 @@ public class BgSendQueue extends Model {
             //}
 
             // all this other UI stuff probably shouldn't be here but in lieu of a better method we keep with it..
-            if (!quick) {
+            if (!quickui) {
                 if (Home.activityVisible) {
                     context.sendBroadcast(new Intent(Intents.ACTION_NEW_BG_ESTIMATE_NO_DATA));
                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -413,7 +413,7 @@ public class WatchUpdaterService extends WearableListenerService implements
                                     Log.d(TAG, "Saving new synced pre-calculated bg-reading: " + JoH.dateTimeText(bgData.timestamp) + " last entry: " + (idx == count) + " " + BgGraphBuilder.unitized_string_static(bgData.calculated_value));
                                     bgData.sensor = current_sensor;
                                     bgData.save();
-                                    BgSendQueue.handleNewBgReading(bgData, "create", xdrip.getAppContext(), Home.get_follower(), false, idx != count);
+                                    BgSendQueue.handleNewBgReading(bgData, "create", xdrip.getAppContext(), Home.get_follower(), idx != count);
                                 } else {
                                     Log.d(TAG, "BgReading for timestamp already exists: " + JoH.dateTimeText(bgData.timestamp));
                                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -413,7 +413,7 @@ public class WatchUpdaterService extends WearableListenerService implements
                                     Log.d(TAG, "Saving new synced pre-calculated bg-reading: " + JoH.dateTimeText(bgData.timestamp) + " last entry: " + (idx == count) + " " + BgGraphBuilder.unitized_string_static(bgData.calculated_value));
                                     bgData.sensor = current_sensor;
                                     bgData.save();
-                                    BgSendQueue.handleNewBgReading(bgData, "create", xdrip.getAppContext(), Home.get_follower(), idx != count);
+                                    BgSendQueue.handleNewBgReading(bgData, "create", xdrip.getAppContext(), Home.get_follower(), false, idx != count);
                                 } else {
                                     Log.d(TAG, "BgReading for timestamp already exists: " + JoH.dateTimeText(bgData.timestamp));
                                 }


### PR DESCRIPTION
This PR resolves issue #795 . In particular, performs `uploadToShare()` for ALL BGs in watch sync queue when watch is collector, backfill when phone is collector. This issue was noticed when using sugarmate.io as a Dexcom Follower. sugarmate.io failed to show BGs that were synced from the watch to phone on re-connect, as well as BGs that were backfilled by the phone.

LOG:
**02-25 10:43**:46.283 1880-7846/? D/ShareRest: About to call ShareRest!! **2019-02-25 10:43:43 BG: 110.0**

Move phone out-of-range of transmitter, then re-connect phone (in-range with transmitter) after 10 minutes:

**02-25 10:53**:47.005 1880-16271/? D/ShareRest: About to call ShareRest!! **2019-02-25 10:53:43 BG: 109.0**
**02-25 10:53**:50.575 1880-16468/? D/ShareRest: About to call ShareRest!! **2019-02-25 10:48:44 BG: 111.0**