### PR TITLE
Reload BG table on data update

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
@@ -121,12 +121,14 @@ public class BgReadingTable extends ListActivity implements NavigationDrawerFrag
                                 case DialogInterface.BUTTON_POSITIVE:
                                     bgReading.ignoreForStats = true;
                                     bgReading.save();
+                                    notifyDataSetChanged();
                                     if (Pref.getBooleanDefaultFalse("wear_sync")) BgReading.pushBgReadingSyncToWatch(bgReading, false);
                                     break;
 
                                 case DialogInterface.BUTTON_NEGATIVE:
                                     bgReading.ignoreForStats = false;
                                     bgReading.save();
+                                    notifyDataSetChanged();
                                     if (Pref.getBooleanDefaultFalse("wear_sync")) BgReading.pushBgReadingSyncToWatch(bgReading, false);
                                     break;
                             }


### PR DESCRIPTION
Fix BGReadingTable data automatic invalidate:

The `BGReadingTable` was not updated immediately after the `ignoreForStats` flag updates before this fix.
![BGTableInvalidateError](https://user-images.githubusercontent.com/8264069/57957442-efb5a600-7904-11e9-8982-bd74fcbcbf95.gif)
