### PR TITLE
Restrict maximum positive intercept value

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -602,8 +602,13 @@ public class BgReading extends Model implements ShareUploadableBg {
 
                 if ((plugin != null) && ((pcalibration = plugin.getCalibrationData()) != null) && (Pref.getBoolean("use_pluggable_alg_as_primary", false))) {
                     Log.d(TAG, "USING CALIBRATION PLUGIN AS PRIMARY!!!");
-                    bgReading.calculated_value = (pcalibration.slope * bgReading.age_adjusted_raw_value) + pcalibration.intercept;
-                    bgReading.filtered_calculated_value = (pcalibration.slope * bgReading.ageAdjustedFiltered()) + calibration.intercept;
+                    if (plugin.isCalibrationSane(pcalibration)) {
+                        bgReading.calculated_value = (pcalibration.slope * bgReading.age_adjusted_raw_value) + pcalibration.intercept;
+                        bgReading.filtered_calculated_value = (pcalibration.slope * bgReading.ageAdjustedFiltered()) + calibration.intercept;
+                    } else {
+                        UserError.Log.wtf(TAG, "Calibration plugin failed intercept sanity check: " + pcalibration.toS());
+                        Home.toaststaticnext("Calibration plugin failed intercept sanity check");
+                    }
                 } else {
                     bgReading.calculated_value = ((calibration.slope * bgReading.age_adjusted_raw_value) + calibration.intercept);
                     bgReading.filtered_calculated_value = ((calibration.slope * bgReading.ageAdjustedFiltered()) + calibration.intercept);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/calibrations/CalibrationAbstract.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/calibrations/CalibrationAbstract.java
@@ -25,6 +25,8 @@ public abstract class CalibrationAbstract {
 
     private static Map<String, CalibrationData> memory_cache = new HashMap<>();
 
+    private static final double HIGHEST_SANE_INTERCEPT = 35; // max value that intercept can be with positive slope
+
     /* Overridable methods */
 
     // boolean responses typically indicate if anything received and processed the call
@@ -114,6 +116,7 @@ public abstract class CalibrationAbstract {
 
     public double getGlucoseFromSensorValue(double raw, CalibrationData data) {
         if (data == null) return -1;
+        if (!isCalibrationSane(data)) return -1;
         return raw * data.slope + data.intercept;
     }
 
@@ -122,6 +125,10 @@ public abstract class CalibrationAbstract {
     public double getGlucoseFromBgReading(BgReading bgReading, CalibrationData data) {
         if (data == null) return -1;
         if (bgReading == null) return -1;
+        if (!isCalibrationSane(data)) {
+            recordSanityFailure(data);
+            return -1;
+        }
         // algorithm can override to decide whether or not to be using age_adjusted_raw
         return bgReading.age_adjusted_raw_value * data.slope + data.intercept;
     }
@@ -141,11 +148,40 @@ public abstract class CalibrationAbstract {
     public double getGlucoseFromFilteredBgReading(BgReading bgReading, CalibrationData data) {
         if (data == null) return -1;
         if (bgReading == null) return -1;
+        if (!isCalibrationSane(data)) {
+            recordSanityFailure(data);
+            return -1;
+        }
         // algorithm can override to decide whether or not to be using age_adjusted_raw
         return bgReading.ageAdjustedFiltered_fast() * data.slope + data.intercept;
     }
 
+    public boolean isCalibrationSane() {
+        return isCalibrationSane(JoH.tsl());
+    }
 
+    public boolean isCalibrationSane(final long until) {
+        final CalibrationData data = getCalibrationData(until);
+        return isCalibrationSane(data);
+    }
+
+    // Check that intercept is less than the highest allowed value.
+    // This does not cater for negative slopes but they are not used by any algorithm at this point.
+    public boolean isCalibrationSane(final CalibrationData data) {
+        return data != null && !(data.intercept > HIGHEST_SANE_INTERCEPT);
+    }
+
+    private void recordSanityFailure(final CalibrationData pcalibration) {
+        if (JoH.pratelimit("best-sanity-failure", 600)) {
+            UserError.Log.wtf(getAlgorithmName(), "Unable to produce data due to plugin failing sanity check: " + pcalibration.toS());
+        }
+    }
+
+    // TODO there currently is no way to opt out of this sanity check and for performance reasons
+    // TODO we have to be careful about how one is implemented if it is needed.
+    public static double getHighestSaneIntercept() {
+        return HIGHEST_SANE_INTERCEPT;
+    }
 
     protected static CalibrationData jsonStringToData(String json) {
         try {
@@ -216,6 +252,10 @@ public abstract class CalibrationAbstract {
             this.slope = slope;
             this.intercept = intercept;
             this.created = JoH.tsl();
+        }
+
+        public String toS() {
+            return JoH.defaultGsonInstance().toJson(this);
         }
     }
 }


### PR DESCRIPTION
I think @tzachi-dar has made a good point in https://github.com/NightscoutFoundation/xDrip/pull/638 - that we should restrict the maximum intercept value. 

This would be for unusual edge cases where it might be possible to produce calibrations which cannot measure below a certain value due to raw values and slopes always being positive in all the existing models.

This PR uses `CalibrationAbstract` to enforce this sanity check over all calibration plugins and directly in `Calibration.calculate_w_l_s()` along with the existing slope sanity checking. 

`Calibration.lastValid()` is also targeted to ensure that even if invalid records are synced from an external source they will not be used.

This should propagate the restriction to the graph, alarms, display glucose, inter-app communication and basically everywhere I can think of.

The restriction currently cannot be turned off.

I would consider pegging this to the `dead sensor testing` preference variable, but the main reason a switch isn't provided at the moment is that I think the code to do that needs to be really performance focused, provide a caching mechanism, work from static context and in a multi-threaded situation. 

I thought the code to do all that would add needless complexity at this stage and the other question is whether there is a use case that would actually need to turn it off?

Proof-reading, comments and testing very welcome! The most important test being whether this breaks anything.
