### PR TITLE
Replace read-only ui-controls by non-interactive-look controls at InitialStatusPopup layout

### DIFF
--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#009900"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_hourglass.xml
+++ b/app/src/main/res/drawable/ic_hourglass.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#EEEEEE"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M6,2v6h0.01L6,8.01 10,12l-4,4 0.01,0.01L6,16.01L6,22h12v-5.99h-0.01L18,16l-4,-4 4,-3.99 -0.01,-0.01L18,8L18,2L6,2zM16,16.5L16,20L8,20v-3.5l4,-4 4,4zM12,11.5l-4,-4L8,4h8v3.5l-4,4z"/>
+</vector>

--- a/app/src/main/res/layout/popup_initial_status_helper.xml
+++ b/app/src/main/res/layout/popup_initial_status_helper.xml
@@ -60,7 +60,7 @@
                 android:layout_column="0"
                 android:layout_gravity="center"
                 android:src="@{idq.received_raw_data ? @drawable/ic_check : @drawable/ic_hourglass}"
-                android:visibility="@{idq.collector_running ? android.view.View.VISIBLE : android.view.View.INVISIBLE}" />
+                appx:showIfTrue="@{idq.collector_running}" />
 
             <TextView
                 android:layout_width="match_parent"
@@ -77,7 +77,7 @@
                 android:layout_column="0"
                 android:layout_gravity="center"
                 android:src="@{idq.recent_data ? @drawable/ic_check : @drawable/ic_hourglass}"
-                android:visibility="@{idq.received_raw_data ? android.view.View.VISIBLE : android.view.View.INVISIBLE}" />
+                appx:showIfTrue="@{idq.received_raw_data}" />
 
             <TextView
                 android:layout_width="match_parent"
@@ -94,8 +94,7 @@
                 android:layout_column="0"
                 android:layout_gravity="center"
                 android:src="@{idq.pass ? @drawable/ic_check : @drawable/ic_hourglass}"
-                android:visibility="@{idq.recent_data ? android.view.View.VISIBLE : android.view.View.INVISIBLE}"
-                appx:srcCompat="@drawable/ic_check" />
+                appx:showIfTrue="@{idq.recent_data}" />
 
             <TextView
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/popup_initial_status_helper.xml
+++ b/app/src/main/res/layout/popup_initial_status_helper.xml
@@ -21,7 +21,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:padding="10dp">
+        android:padding="8dp">
 
         <ProgressBar
             android:id="@+id/progressBar2"
@@ -30,39 +30,81 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <RadioButton
-            android:id="@+id/collector_running_indicator"
+        <GridLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@{idq.collector_running ? @android:color/transparent : @android:color/holo_red_dark}"
-            android:checked="@{idq.collector_running}"
-            android:clickable="false"
-            android:enabled="true"
-            android:text="@string/data_collector_running" />
+            android:alignmentMode="alignBounds"
+            android:useDefaultMargins="true">
 
-        <RadioButton
-            android:id="@+id/received_data_indicator"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:checked="@{idq.received_raw_data}"
-            android:clickable="false"
-            android:text="@{@string/receiving_data_from_collector(ms.gs(`niceCollector`))}" />
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_row="0"
+                android:layout_column="0"
+                android:layout_gravity="center"
+                android:src="@{idq.collector_running ? @drawable/ic_check : @drawable/ic_hourglass}" />
 
-        <RadioButton
-            android:id="@+id/recent_data_indicator"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:checked="@{idq.recent_data}"
-            android:clickable="false"
-            android:text="@string/received_some_recent_data" />
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_row="0"
+                android:layout_column="1"
+                android:layout_gravity="center_vertical"
+                android:background="@{idq.collector_running ? @android:color/transparent : @android:color/holo_red_dark}"
+                android:text="@string/data_collector_running" />
 
-        <RadioButton
-            android:id="@+id/enough_data_indicator"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:checked="@{idq.pass}"
-            android:clickable="false"
-            android:text="@string/received_enough_good_data_to_calibrate" />
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_row="1"
+                android:layout_column="0"
+                android:layout_gravity="center"
+                android:src="@{idq.received_raw_data ? @drawable/ic_check : @drawable/ic_hourglass}"
+                android:visibility="@{idq.collector_running ? android.view.View.VISIBLE : android.view.View.INVISIBLE}" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_row="1"
+                android:layout_column="1"
+                android:layout_gravity="center_vertical"
+                android:text="@{@string/receiving_data_from_collector(ms.gs(`niceCollector`))}" />
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_row="2"
+                android:layout_column="0"
+                android:layout_gravity="center"
+                android:src="@{idq.recent_data ? @drawable/ic_check : @drawable/ic_hourglass}"
+                android:visibility="@{idq.received_raw_data ? android.view.View.VISIBLE : android.view.View.INVISIBLE}" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_row="2"
+                android:layout_column="1"
+                android:layout_gravity="center_vertical"
+                android:text="@string/received_some_recent_data" />
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_row="3"
+                android:layout_column="0"
+                android:layout_gravity="center"
+                android:src="@{idq.pass ? @drawable/ic_check : @drawable/ic_hourglass}"
+                android:visibility="@{idq.recent_data ? android.view.View.VISIBLE : android.view.View.INVISIBLE}"
+                appx:srcCompat="@drawable/ic_check" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_row="3"
+                android:layout_column="1"
+                android:layout_gravity="center_vertical"
+                android:text="@string/received_enough_good_data_to_calibrate" />
+        </GridLayout>
 
         <TextView
             android:id="@+id/advice_text"


### PR DESCRIPTION
The problem is that the controls assuming user interaction are used on this screen. There are 4 radio-buttons. The one is selected and users click on the other trying to make some action instead of waiting of initial data collection.
I think using non-interactive controls on the wait-screen would be more user-friendly and more clearly for users.
I've tried to improve initialStatusPopup layout without using radio-buttons.

![59563875-1839d880-9048-11e9-947a-e44420a7fe261](https://user-images.githubusercontent.com/8264069/60506111-d064b380-9ccd-11e9-92c1-c53023a7347d.png)





