### PR TITLE
Nightscout Follow MegaStatus for Treatments fix

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Treatments.java
@@ -100,7 +100,12 @@ public class Treatments extends Model {
 
     public static synchronized Treatments create(final double carbs, final double insulin, long timestamp, double position, String suggested_uuid) {
         // TODO sanity check values
-        Log.d(TAG, "Creating treatment: Insulin: " + Double.toString(insulin) + " / Carbs: " + Double.toString(carbs) + (suggested_uuid != null && !suggested_uuid.isEmpty() ? " uuid: " + suggested_uuid : ""));
+        Log.d(TAG, "Creating treatment: " +
+                "Insulin: " + insulin + " / " +
+                "Carbs: " + carbs +
+                (suggested_uuid != null && !suggested_uuid.isEmpty()
+                        ? " " + "uuid: " + suggested_uuid
+                        : ""));
 
         if ((carbs == 0) && (insulin == 0)) return null;
 
@@ -278,6 +283,15 @@ public class Treatments extends Model {
         return new Select()
                 .from(Treatments.class)
                 .orderBy("_ID desc")
+                .executeSingle();
+    }
+
+    public static Treatments lastNotFromXdrip() {
+        fixUpTable();
+        return new Select()
+                .from(Treatments.class)
+                .where("enteredBy NOT LIKE '" + XDRIP_TAG + "%'")
+                .orderBy("_ID DESC")
                 .executeSingle();
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -117,7 +117,7 @@ public class NightscoutFollowService extends ForegroundService {
     }
 
     static void updateTreatmentDownloaded() {
-        lastTreatment = Treatments.last();
+        lastTreatment = Treatments.lastNotFromXdrip();
         if(lastTreatment != null && lastTreatmentTime != lastTreatment.timestamp) {
             treatmentReceivedDelay = JoH.msSince(lastTreatment.timestamp);
             lastTreatmentTime = lastTreatment.timestamp;

--- a/app/src/test/java/com/eveningoutpost/dexdrip/Models/TreatmentsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/Models/TreatmentsTest.java
@@ -1,0 +1,104 @@
+package com.eveningoutpost.dexdrip.Models;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Tests for {@link Treatments}
+ *
+ * @author Asbjørn Aarrestad - 2019.07 - asbjorn@aarrestad.com
+ */
+public class TreatmentsTest extends RobolectricTestWithConfig {
+
+    @Test
+    public void createAndReadTreatment() {
+        // :: Create
+        long time = Instant.now().getEpochSecond();
+        Treatments.create(55, 2, time);
+
+        // :: Read
+        Treatments lastTreatment = Treatments.last();
+
+        // :: Verify
+        assertThat(lastTreatment.carbs).isEqualTo(55.0);
+        assertThat(lastTreatment.insulin).isEqualTo(2.0);
+        assertThat(lastTreatment.timestamp).isEqualTo(time);
+        assertThat(lastTreatment.enteredBy).startsWith(Treatments.XDRIP_TAG);
+    }
+
+
+    @Test
+    public void createManyReadLast() {
+        // :: Setup
+        long time = Instant.now().getEpochSecond();
+        Treatments.create(1, 8, time);
+        Treatments.create(2, 7, time);
+        Treatments.create(3, 6, time);
+        Treatments.create(4, 5, time);
+        Treatments.create(5, 4, time);
+        Treatments.create(6, 3, time);
+        Treatments.create(7, 2, time);
+        Treatments.create(8, 1, time);
+
+        // :: Act
+        Treatments lastTreatment = Treatments.last();
+
+        // :: Verify
+        assertThat(lastTreatment.carbs).isEqualTo(8.0);
+        assertThat(lastTreatment.insulin).isEqualTo(1.0);
+        assertThat(lastTreatment.timestamp).isEqualTo(time);
+        assertThat(lastTreatment.enteredBy).startsWith(Treatments.XDRIP_TAG);
+    }
+
+    @Test
+    public void getLastestNoneXdrip_noneEntered() {
+        // :: Create
+        long time = Instant.now().getEpochSecond();
+        Treatments.create(1, 8, time);
+        Treatments.create(2, 7, time);
+        Treatments.create(3, 6, time);
+        Treatments.create(4, 5, time);
+        Treatments.create(5, 4, time);
+        Treatments.create(6, 3, time);
+        Treatments.create(7, 2, time);
+        Treatments.create(8, 1, time);
+
+        // :: Read
+        Treatments lastTreatment = Treatments.lastNotFromXdrip();
+
+        // :: Verify
+        assertThat(lastTreatment).isNull();
+    }
+
+    @Test
+    public void getLastestNoneXdrip_oneEntered() {
+        // :: Create
+        long time = Instant.now().getEpochSecond();
+        Treatments.create(1, 8, time);
+        Treatments.create(2, 7, time);
+        Treatments.create(3, 6, time);
+        Treatments.create(4, 5, time);
+        Treatments.create(5, 4, time);
+        Treatments.create(6, 3, time);
+
+        Treatments notFromXdrip = Treatments.create(7, 2, time);
+        notFromXdrip.enteredBy = "SomeOtherSource";
+        notFromXdrip.save();
+
+        Treatments.create(8, 1, time);
+
+        // :: Read
+        Treatments lastTreatment = Treatments.lastNotFromXdrip();
+
+        // :: Verify
+        assertThat(lastTreatment.carbs).isEqualTo(7.0);
+        assertThat(lastTreatment.insulin).isEqualTo(2.0);
+        assertThat(lastTreatment.timestamp).isEqualTo(time);
+        assertThat(lastTreatment.enteredBy).startsWith("SomeOtherSource");
+    }
+}


### PR DESCRIPTION
Nightscout follow mega status checked for all treatments, but should
only check for none-xdrip treatments. Added a new query method
to keep the query quick, and also added tests to verify new code works
as expected.