### PR TITLE
Add poll delay for Nightscout Follow

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
@@ -132,6 +132,26 @@ public class NightscoutFollow {
         return Pref.getBooleanDefaultFalse("nsfollow_download_treatments");
     }
 
+    static long pollDelay() {
+        try {
+            long delay = Long.parseLong(Pref.getString("nsfollow_delay", "0"));
+            if (delay < 0) {
+                msg("Only positive values for delay allowed. Illegal value [" + delay + "]");
+                return 0;
+            }
+            if (delay > DEXCOM_PERIOD / 1000) {
+                msg("Delay is longer than poll period. Try a value less than [" + (DEXCOM_PERIOD / 1000) + "] seconds");
+            }
+
+            msg("");
+            return delay * 1000;
+
+        } catch (NumberFormatException nfe) {
+            msg("Unable to parse [" + Pref.getStringDefaultBlank("nsfollow_delay") + "] as number");
+            return 0;
+        }
+    }
+
     // TODO make reusable
     public static Retrofit getRetrofitInstance() throws IllegalArgumentException {
         if (retrofit == null) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
@@ -139,12 +139,12 @@ public class NightscoutFollow {
                 msg("Only positive values for delay allowed. Illegal value [" + delay + "]");
                 return 0;
             }
-            if (delay > DEXCOM_PERIOD / 1000) {
-                msg("Delay is longer than poll period. Try a value less than [" + (DEXCOM_PERIOD / 1000) + "] seconds");
+            if (delay > DEXCOM_PERIOD / Constants.SECOND_IN_MS) {
+                msg("Delay is longer than poll period. Try a value less than [" + (DEXCOM_PERIOD / Constants.SECOND_IN_MS) + "] seconds");
             }
 
             msg("");
-            return delay * 1000;
+            return delay * Constants.SECOND_IN_MS;
 
         } catch (NumberFormatException nfe) {
             msg("Unable to parse [" + Pref.getStringDefaultBlank("nsfollow_delay") + "] as number");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -118,7 +118,7 @@ public class NightscoutFollowService extends ForegroundService {
 
     static void updateTreatmentDownloaded() {
         lastTreatment = Treatments.last();
-        if (lastTreatment != null && lastTreatmentTime != lastTreatment.timestamp) {
+        if(lastTreatment != null && lastTreatmentTime != lastTreatment.timestamp) {
             treatmentReceivedDelay = JoH.msSince(lastTreatment.timestamp);
             lastTreatmentTime = lastTreatment.timestamp;
         }
@@ -181,7 +181,7 @@ public class NightscoutFollowService extends ForegroundService {
         // Status for treatments
         String ageLastTreatment = "n/a";
         String ageOfTreatmentWhenReceived = "n/a";
-        if (lastTreatment != null) {
+        if(lastTreatment != null) {
             long age = JoH.msSince(lastTreatment.timestamp);
             ageLastTreatment = JoH.niceTimeScalar(age);
             ageOfTreatmentWhenReceived = JoH.niceTimeScalar(treatmentReceivedDelay);
@@ -193,7 +193,7 @@ public class NightscoutFollowService extends ForegroundService {
         statuses.add(new StatusItem("Latest BG", ageLastBg + (lastBg != null ? " ago" : ""), bgAgeHighlight));
         statuses.add(new StatusItem("BG receive delay", ageOfBgLastPoll, ageOfLastBgPollHighlight));
 
-        if (NightscoutFollow.treatmentDownloadEnabled()) {
+        if(NightscoutFollow.treatmentDownloadEnabled()) {
             statuses.add(new StatusItem());
             statuses.add(new StatusItem("Latest Treatment", ageLastTreatment + (lastTreatment != null ? " ago" : "")));
             statuses.add(new StatusItem("Treatment receive delay", ageOfTreatmentWhenReceived));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -118,7 +118,7 @@ public class NightscoutFollowService extends ForegroundService {
 
     static void updateTreatmentDownloaded() {
         lastTreatment = Treatments.last();
-        if(lastTreatment != null && lastTreatmentTime != lastTreatment.timestamp) {
+        if (lastTreatment != null && lastTreatmentTime != lastTreatment.timestamp) {
             treatmentReceivedDelay = JoH.msSince(lastTreatment.timestamp);
             lastTreatmentTime = lastTreatment.timestamp;
         }
@@ -129,7 +129,7 @@ public class NightscoutFollowService extends ForegroundService {
         final long last = lastBg != null ? lastBg.timestamp : 0;
 
         final long grace = Constants.SECOND_IN_MS * 10;
-        final long next = Anticipate.next(JoH.tsl(), last, SAMPLE_PERIOD, grace) + grace;
+        final long next = Anticipate.next(JoH.tsl(), last, SAMPLE_PERIOD, grace) + grace + NightscoutFollow.pollDelay();
         wakeup_time = next;
         UserError.Log.d(TAG, "Anticipate next: " + JoH.dateTimeText(next) + "  last: " + JoH.dateTimeText(last));
 
@@ -181,7 +181,7 @@ public class NightscoutFollowService extends ForegroundService {
         // Status for treatments
         String ageLastTreatment = "n/a";
         String ageOfTreatmentWhenReceived = "n/a";
-        if(lastTreatment != null) {
+        if (lastTreatment != null) {
             long age = JoH.msSince(lastTreatment.timestamp);
             ageLastTreatment = JoH.niceTimeScalar(age);
             ageOfTreatmentWhenReceived = JoH.niceTimeScalar(treatmentReceivedDelay);
@@ -193,7 +193,7 @@ public class NightscoutFollowService extends ForegroundService {
         statuses.add(new StatusItem("Latest BG", ageLastBg + (lastBg != null ? " ago" : ""), bgAgeHighlight));
         statuses.add(new StatusItem("BG receive delay", ageOfBgLastPoll, ageOfLastBgPollHighlight));
 
-        if(NightscoutFollow.treatmentDownloadEnabled()) {
+        if (NightscoutFollow.treatmentDownloadEnabled()) {
             statuses.add(new StatusItem());
             statuses.add(new StatusItem("Latest Treatment", ageLastTreatment + (lastTreatment != null ? " ago" : "")));
             statuses.add(new StatusItem("Treatment receive delay", ageOfTreatmentWhenReceived));
@@ -202,6 +202,10 @@ public class NightscoutFollowService extends ForegroundService {
         statuses.add(new StatusItem());
         statuses.add(new StatusItem("Last poll", lastPollText + (lastPoll > 0 ? " ago" : "")));
         statuses.add(new StatusItem("Next poll in", JoH.niceTimeScalar(wakeup_time - JoH.tsl())));
+        statuses.add(new StatusItem("Poll delay", JoH.niceTimeScalar(NightscoutFollow.pollDelay())));
+        if (lastBg != null) {
+            statuses.add(new StatusItem("Last BG time", JoH.dateTimeText(lastBg.timestamp)));
+        }
         statuses.add(new StatusItem("Next poll time", JoH.dateTimeText(wakeup_time)));
         statuses.add(new StatusItem());
         statuses.add(new StatusItem("Buggy Samsung", JoH.buggy_samsung ? "Yes" : "No"));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -49,6 +49,7 @@ public class NightscoutFollowService extends ForegroundService {
 
     private static BuggySamsung buggySamsung;
     private static volatile long wakeup_time = 0;
+    private static volatile long last_wakeup = 0;
 
     private static volatile BgReading lastBg;
     private static volatile long lastPoll = 0;
@@ -80,6 +81,9 @@ public class NightscoutFollowService extends ForegroundService {
                 stopSelf();
                 return START_NOT_STICKY;
             }
+
+            last_wakeup = JoH.tsl();
+
             buggySamsungCheck();
 
             // Check current
@@ -147,11 +151,6 @@ public class NightscoutFollowService extends ForegroundService {
     public static List<StatusItem> megaStatus() {
         final BgReading lastBg = BgReading.lastNoSenssor();
 
-        String lastPollText = "n/a";
-        if (lastPoll > 0) {
-            lastPollText = JoH.niceTimeScalar(JoH.msSince(lastPoll));
-        }
-
         long hightlightGrace = Constants.SECOND_IN_MS * 30; // 30 seconds
 
         // Status for BG receive delay (time from bg was recorded till received in xdrip)
@@ -200,7 +199,8 @@ public class NightscoutFollowService extends ForegroundService {
         }
 
         statuses.add(new StatusItem());
-        statuses.add(new StatusItem("Last poll", lastPollText + (lastPoll > 0 ? " ago" : "")));
+        statuses.add(new StatusItem("Last poll", lastPoll > 0 ? JoH.niceTimeScalar(JoH.msSince(lastPoll)) + " ago" : "n/a"));
+        statuses.add(new StatusItem("Last wakeup", last_wakeup > 0 ? JoH.niceTimeScalar(JoH.msSince(last_wakeup)) + " ago" : "n/a"));
         statuses.add(new StatusItem("Next poll in", JoH.niceTimeScalar(wakeup_time - JoH.tsl())));
         statuses.add(new StatusItem("Poll delay", JoH.niceTimeScalar(NightscoutFollow.pollDelay())));
         if (lastBg != null) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -983,11 +983,16 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             final Preference nsFollowDownload = findPreference("nsfollow_download_treatments");
             final Preference nsFollowUrl = findPreference("nsfollow_url");
+            final Preference nsFollowDelay = findPreference("nsfollow_delay");
             try {
                 nsFollowUrl.setOnPreferenceChangeListener((preference, newValue) -> {
                     NightscoutFollow.resetInstance();
                     return true;
                 });
+                nsFollowDelay.setOnPreferenceChangeListener(((preference, newValue) -> {
+                    NightscoutFollow.resetInstance();
+                    return true;
+                }));
             } catch (Exception e) {
                 //
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1333,6 +1333,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 try {
                     collectionCategory.removePreference(nsFollowUrl);
                     collectionCategory.removePreference(nsFollowDownload);
+                    collectionCategory.removePreference(nsFollowDelay);
                 } catch (Exception e) {
                     //
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1247,9 +1247,9 @@
     <string name="summary_medtrum_a_hex">Hex diagnostic test value</string>
     <string name="title_medtrum_a_hex">Medtrum Debug</string>
     <string name="summary_nsfollow_url">Web address for following</string>
-    <string name="title_nsfollow_delay">Nightscout download delay (seconds)</string>
-    <string name="summary_nsfollow_delay">Fixed delay (seconds) for polling nightscout to better sync with actual arrival of data at Nightscout</string>
     <string name="title_nsfollow_url">Nightscout Follow URL</string>
+    <string name="summary_nsfollow_delay">Fixed delay (seconds) for polling nightscout to better sync with actual arrival of data at Nightscout</string>
+    <string name="title_nsfollow_delay">Nightscout download delay (sec.)</string>
     <string name="summary_nsfollow_download_treatments">Also download treatments from Nightscout as follower</string>
     <string name="title_nsfollow_download_treatments">Download Treatments</string>
     <string name="title_ob1_options">OB1 G5/G6 Collector Settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1247,6 +1247,8 @@
     <string name="summary_medtrum_a_hex">Hex diagnostic test value</string>
     <string name="title_medtrum_a_hex">Medtrum Debug</string>
     <string name="summary_nsfollow_url">Web address for following</string>
+    <string name="title_nsfollow_delay">Nightscout download delay (seconds)</string>
+    <string name="summary_nsfollow_delay">Fixed delay (seconds) for polling nightscout to better sync with actual arrival of data at Nightscout</string>
     <string name="title_nsfollow_url">Nightscout Follow URL</string>
     <string name="summary_nsfollow_download_treatments">Also download treatments from Nightscout as follower</string>
     <string name="title_nsfollow_download_treatments">Download Treatments</string>

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -109,12 +109,19 @@
             android:singleLine="true"
             android:summary="@string/summary_nsfollow_url"
             android:title="@string/title_nsfollow_url" />
+        <EditTextPreference
+            android:defaultValue="30"
+            android:inputType="textNoSuggestions|textVisiblePassword"
+            android:key="nsfollow_delay"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:summary="@string/summary_nsfollow_delay"
+            android:title="@string/title_nsfollow_delay" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="nsfollow_download_treatments"
             android:summary="@string/summary_nsfollow_download_treatments"
-            android:title="@string/title_nsfollow_download_treatments"
-            />
+            android:title="@string/title_nsfollow_download_treatments" />
 
         <EditTextPreference
             android:defaultValue=""

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -110,7 +110,7 @@
             android:summary="@string/summary_nsfollow_url"
             android:title="@string/title_nsfollow_url" />
         <EditTextPreference
-            android:defaultValue="30"
+            android:defaultValue=""
             android:inputType="textNoSuggestions|textVisiblePassword"
             android:key="nsfollow_delay"
             android:maxLines="1"


### PR DESCRIPTION
Enabling a poll delay for Nightscout follow to reduce the time from
a new value is made available on Nightscout until xdrip polls for new
data. Depending on the setup of nightscout this might be anything
between 0 and 150 seconds. Minimum value is set to 0s. Max is 300s.

This pull request fixes #929 by allowing custom poll delay.

@jamorham tested in AVD and works fine. There are sanity checks for input values.