### PR TITLE
add flexible Libre2 smooth filter range

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/LibreReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/LibreReceiver.java
@@ -71,7 +71,7 @@ public class LibreReceiver extends BroadcastReceiver {
                                 Log.v(TAG,"got bg reading: from sensor:"+currentRawValue.serial+" rawValue:"+currentRawValue.glucose+" at:"+currentRawValue.timestamp);
                                 // period of 4.5 minutes to collect 5 readings
                                 if(!BgReading.last_within_millis(45 * 6 * 1000 )) {
-                                    List<Libre2RawValue> smoothingValues = Libre2RawValue.last20Minutes();
+                                    List<Libre2RawValue> smoothingValues = Libre2RawValue.lastXMinutes();
                                     smoothingValues.add(currentRawValue);
                                     processValues(currentRawValue, smoothingValues, context);
                                 }
@@ -140,7 +140,7 @@ public class LibreReceiver extends BroadcastReceiver {
             }
         }
     }
-    private static long SMOOTHING_DURATION = TimeUnit.MINUTES.toMillis(25);
+    private static long SMOOTHING_DURATION = TimeUnit.MINUTES.toMillis(25); //todo check if this should be also changed to flexible smooth range
 
 
     private static double calculateWeightedAverage(List<Libre2RawValue> rawValues, long now) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Libre2RawValue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Libre2RawValue.java
@@ -6,6 +6,10 @@ package com.eveningoutpost.dexdrip.Models;
         import com.activeandroid.annotation.Column;
         import com.activeandroid.annotation.Table;
         import com.activeandroid.query.Select;
+import com.activeandroid.annotation.Column;
+import com.activeandroid.annotation.Table;
+import com.activeandroid.query.Select;
+import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 
         import java.util.Date;
         import java.util.List;
@@ -28,8 +32,8 @@ public class Libre2RawValue extends PlusModel {
     @Column(name = "glucose", index = false)
     public double glucose;
 
-    public static List<Libre2RawValue> last20Minutes() {
-        double timestamp = (new Date().getTime()) - (60000 * 20);
+    public static List<Libre2RawValue> lastXMinutes() {
+        double timestamp = (new Date().getTime()) - (60000 * Pref.getStringToInt("libre2smoothminuts",20));
         return new Select()
                 .from(Libre2RawValue.class)
                 .where("ts >= " + timestamp)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -942,6 +942,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             final Preference bfappid = findPreference("bugfender_appid");
             final Preference nfcSettings = findPreference("xdrip_plus_nfc_settings");
             final Preference bluereadersettings = findPreference("xdrip_blueReader_advanced_settings");
+            final Preference libre2settings = findPreference("xdrip_libre2_advanced_settings");
             //DexCollectionType collectionType = DexCollectionType.getType(findPreference("dex_collection_method").)
 
             final ListPreference currentCalibrationPlugin = (ListPreference)findPreference("current_calibration_plugin");
@@ -1450,6 +1451,10 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                         }
                 );
 
+            }
+
+            if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
+                collectionCategory.removePreference(libre2settings);
             }
 
             try {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1521,4 +1521,8 @@
     <string name="title_ob1_g5_preemptive_restart_extended_time_travel_all_firmwares">Always allow extended time-travel</string>
     <string name="summary_ob1_g5_preemptive_restart_extended_time_travel_all_firmwares">Allow extended time-travel with all firmware versions (engineering mode only) </string>
     <string name="collection_summary_ob1_g5_preemptive_restart">Automatically restart a sensor before it stops</string>
+    <string name="libre2_advanced_settings_summary">Advanced settings for Libre2 (Patched App)</string>
+    <string name="libre2_advanced_settings_title">Advanced settings for Libre2</string>
+    <string name="libre2smoothrange_summary">Timerange for smoothing</string>
+    <string name="libre2smoothrange_title">Timerange in minutes over wich the smoothing algorythm will be work</string>
 </resources>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -902,6 +902,19 @@
                 android:summary="@string/summary_write_Battery_Information_for_additional_analytic"
                 android:title="@string/title_Batterylog" />
         </PreferenceScreen>
+
+            <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+                android:key="xdrip_libre2_advanced_settings"
+                android:summary="@string/libre2_advanced_settings_summary"
+                android:title="@string/libre2_advanced_settings_title">
+                <EditTextPreference
+                    android:key="libre2smoothminuts"
+                    android:title="@string/libre2smoothrange_title"
+                    android:summary="@string/libre2smoothrange_summary"
+                    android:numeric="integer"
+                    android:defaultValue="20" />
+            </PreferenceScreen>
+
             <CheckBoxPreference
                 android:defaultValue="true"
                 android:key="aggressive_service_restart"


### PR DESCRIPTION
This PR will add the possibility to change the time frame of smoothing the Libre2 data in the settings.
- standard Timeframe is set to 20 as initial was chosen
- using it for half a day and works for me
@AdrianLxM and @keencave , can you have a closer look?