### PR TITLE
Libre2 add raw graph

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Libre2RawValue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Libre2RawValue.java
@@ -37,6 +37,25 @@ public class Libre2RawValue extends PlusModel {
                 .execute();
     }
 
+    public static List<Libre2RawValue> latestForGraph(int number, double startTime) {
+        return latestForGraph(number, (long) startTime, Long.MAX_VALUE);
+    }
+
+    public static List<Libre2RawValue> latestForGraph(int number, long startTime) {
+        return latestForGraph(number, startTime, Long.MAX_VALUE);
+    }
+
+    public static List<Libre2RawValue> latestForGraph(int number, long startTime, long endTime) {
+        return new Select()
+                .from(Libre2RawValue.class)
+                .where("ts >= " + Math.max(startTime, 0))
+                .where("ts <= " + endTime)
+                .where("glucose != 0")
+                .orderBy("ts desc")
+                .limit(number)
+                .execute();
+    }
+
     public static void updateDB() {
         fixUpTable(schema, false);
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -208,6 +208,9 @@ public class BgGraphBuilder {
             loaded_start=start;
             loaded_end=end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
+            if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver) {
+                Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
+            }
             plugin_adjusted = false;
         } finally {
             readings_lock.unlock();
@@ -1304,7 +1307,6 @@ public class BgGraphBuilder {
             }
 
             if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver && prefs.getBoolean("Libre2_showRawGraph",false)) {
-                Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
                 for (final Libre2RawValue bgLibre : Libre2RawValues) {
                     if (bgLibre.glucose > 0) {
                         rawInterpretedValues.add(new PointValue((float) (bgLibre.timestamp / FUZZER), (float) unitized(bgLibre.glucose)));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -137,7 +137,7 @@ public class BgGraphBuilder {
     private final int loaded_numValues;
     private final long loaded_start, loaded_end;
     private final List<BgReading> bgReadings;
-    private List<Libre2RawValue> Libre2RawValues;
+    private final List<Libre2RawValue> Libre2RawValues = new ArrayList<>();
     private final List<Calibration> calibrations;
     private final List<BloodTest> bloodtests;
     private final List<PointValue> inRangeValues = new ArrayList<>();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -137,7 +137,7 @@ public class BgGraphBuilder {
     private final int loaded_numValues;
     private final long loaded_start, loaded_end;
     private final List<BgReading> bgReadings;
-    private final List<Libre2RawValue> Libre2RawValues = new ArrayList<>();
+    private final List<Libre2RawValue> Libre2RawValues;
     private final List<Calibration> calibrations;
     private final List<BloodTest> bloodtests;
     private final List<PointValue> inRangeValues = new ArrayList<>();
@@ -208,9 +208,8 @@ public class BgGraphBuilder {
             loaded_start=start;
             loaded_end=end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
-            if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver) {
                 Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
-            }
+
             plugin_adjusted = false;
         } finally {
             readings_lock.unlock();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -137,7 +137,7 @@ public class BgGraphBuilder {
     private final int loaded_numValues;
     private final long loaded_start, loaded_end;
     private final List<BgReading> bgReadings;
-    private final List<Libre2RawValue> Libre2RawValues;
+    private final List<Libre2RawValue> Libre2RawValues = new ArrayList<>();
     private final List<Calibration> calibrations;
     private final List<BloodTest> bloodtests;
     private final List<PointValue> inRangeValues = new ArrayList<>();
@@ -208,8 +208,9 @@ public class BgGraphBuilder {
             loaded_start=start;
             loaded_end=end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
+            if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver) {
                 Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
-
+            }
             plugin_adjusted = false;
         } finally {
             readings_lock.unlock();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -208,7 +208,9 @@ public class BgGraphBuilder {
             loaded_start=start;
             loaded_end=end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
-            Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
+            if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver) {
+                Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
+            }
             plugin_adjusted = false;
         } finally {
             readings_lock.unlock();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -208,9 +208,6 @@ public class BgGraphBuilder {
             loaded_start=start;
             loaded_end=end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
-            if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver) {
-                Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
-            }
             plugin_adjusted = false;
         } finally {
             readings_lock.unlock();
@@ -1307,6 +1304,7 @@ public class BgGraphBuilder {
             }
 
             if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver && prefs.getBoolean("Libre2_showRawGraph",false)) {
+                Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
                 for (final Libre2RawValue bgLibre : Libre2RawValues) {
                     if (bgLibre.glucose > 0) {
                         rawInterpretedValues.add(new PointValue((float) (bgLibre.timestamp / FUZZER), (float) unitized(bgLibre.glucose)));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -1306,12 +1306,16 @@ public class BgGraphBuilder {
 
             }
 
-            if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver && prefs.getBoolean("Libre2_showRawGraph",false)) {
-                for (final Libre2RawValue bgLibre : Libre2RawValues) {
-                    if (bgLibre.glucose > 0) {
-                        rawInterpretedValues.add(new PointValue((float) (bgLibre.timestamp / FUZZER), (float) unitized(bgLibre.glucose)));
+            try {
+                if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver && prefs.getBoolean("Libre2_showRawGraph",false)) {
+                    for (final Libre2RawValue bgLibre : Libre2RawValues) {
+                        if (bgLibre.glucose > 0) {
+                            rawInterpretedValues.add(new PointValue((float) (bgLibre.timestamp / FUZZER), (float) unitized(bgLibre.glucose)));
+                        }
                     }
                 }
+            } catch (Exception e) {
+                Log.wtf(TAG, "Exception to generate Raw-Graph Libre2");
             }
             if (avg1counter > 0) {
                 avg1value = avg1value / avg1counter;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -137,7 +137,7 @@ public class BgGraphBuilder {
     private final int loaded_numValues;
     private final long loaded_start, loaded_end;
     private final List<BgReading> bgReadings;
-    private final List<Libre2RawValue> Libre2RawValues = null;
+    private List<Libre2RawValue> Libre2RawValues;
     private final List<Calibration> calibrations;
     private final List<BloodTest> bloodtests;
     private final List<PointValue> inRangeValues = new ArrayList<>();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -137,7 +137,7 @@ public class BgGraphBuilder {
     private final int loaded_numValues;
     private final long loaded_start, loaded_end;
     private final List<BgReading> bgReadings;
-    private final List<Libre2RawValue> Libre2RawValues = new ArrayList<>();
+    private List<Libre2RawValue> Libre2RawValues;
     private final List<Calibration> calibrations;
     private final List<BloodTest> bloodtests;
     private final List<PointValue> inRangeValues = new ArrayList<>();
@@ -208,9 +208,8 @@ public class BgGraphBuilder {
             loaded_start=start;
             loaded_end=end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
-            if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver) {
+            if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver)
                 Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
-            }
             plugin_adjusted = false;
         } finally {
             readings_lock.unlock();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -137,7 +137,7 @@ public class BgGraphBuilder {
     private final int loaded_numValues;
     private final long loaded_start, loaded_end;
     private final List<BgReading> bgReadings;
-    private final List<Libre2RawValue> Libre2RawValues;
+    private final List<Libre2RawValue> Libre2RawValues = null;
     private final List<Calibration> calibrations;
     private final List<BloodTest> bloodtests;
     private final List<PointValue> inRangeValues = new ArrayList<>();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -208,9 +208,7 @@ public class BgGraphBuilder {
             loaded_start=start;
             loaded_end=end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
-            if (prefs.getBoolean("Libre2_showRawGraph",false)) {
-                Libre2RawValues = Libre2RawValue.latestForGraph(numValues, start, end);
-            }
+            Libre2RawValues = Libre2RawValue.latestForGraph(numValues, start, end);
             plugin_adjusted = false;
         } finally {
             readings_lock.unlock();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -1304,7 +1304,7 @@ public class BgGraphBuilder {
 
             }
 
-            if (prefs.getBoolean("Libre2_showRawGraph",false)) {
+            if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver && prefs.getBoolean("Libre2_showRawGraph",false)) {
                 for (final Libre2RawValue bgLibre : Libre2RawValues) {
                     if (bgLibre.glucose > 0) {
                         rawInterpretedValues.add(new PointValue((float) (bgLibre.timestamp / FUZZER), (float) unitized(bgLibre.glucose)));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -208,7 +208,7 @@ public class BgGraphBuilder {
             loaded_start=start;
             loaded_end=end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
-            Libre2RawValues = Libre2RawValue.latestForGraph(numValues, start, end);
+            Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
             plugin_adjusted = false;
         } finally {
             readings_lock.unlock();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -208,7 +208,9 @@ public class BgGraphBuilder {
             loaded_start=start;
             loaded_end=end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
-            Libre2RawValues = Libre2RawValue.latestForGraph(numValues, start, end);
+            if (prefs.getBoolean("Libre2_showRawGraph",false)) {
+                Libre2RawValues = Libre2RawValue.latestForGraph(numValues, start, end);
+            }
             plugin_adjusted = false;
         } finally {
             readings_lock.unlock();
@@ -1227,7 +1229,7 @@ public class BgGraphBuilder {
                         filteredValues.add(new PointValue((float) ((bgReading.timestamp + rollingOffset) / FUZZER), (float) unitized(rollingValue)));
                     }
                 }
-                if ((DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) && (interpret_raw && (bgReading.raw_calculated > 0))) {
+                if ((interpret_raw && (bgReading.raw_calculated > 0))) {
                     rawInterpretedValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.raw_calculated)));
                 }
                 if ((!glucose_from_plugin) && (plugin != null) && (cd != null)) {
@@ -1304,12 +1306,13 @@ public class BgGraphBuilder {
 
             }
 
-            for (final Libre2RawValue bgLibre : Libre2RawValues) {
-                if ((DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver) && (bgLibre.glucose > 0)) {
-                    rawInterpretedValues.add(new PointValue((float) (bgLibre.timestamp / FUZZER), (float) unitized(bgLibre.glucose)));
+            if (prefs.getBoolean("Libre2_showRawGraph",false)) {
+                for (final Libre2RawValue bgLibre : Libre2RawValues) {
+                    if (bgLibre.glucose > 0) {
+                        rawInterpretedValues.add(new PointValue((float) (bgLibre.timestamp / FUZZER), (float) unitized(bgLibre.glucose)));
+                    }
                 }
             }
-
             if (avg1counter > 0) {
                 avg1value = avg1value / avg1counter;
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1453,12 +1453,11 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             }
 
+            if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
+                collectionCategory.removePreference(libre2settings);
+            }
 
             try {
-
-                if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
-                    collectionCategory.removePreference(libre2settings);
-                }
 
                 try {
                     if (!DexCollectionType.hasWifi()) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1456,12 +1456,8 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             try {
 
-                try {
-                    if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
-                        collectionCategory.removePreference(libre2settings);
-                    }
-                } catch (NullPointerException e) {
-                    Log.wtf(TAG, "Nullpointer Libre2Settings: ", e);
+                if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
+                    collectionCategory.removePreference(libre2settings);
                 }
 
                 try {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1453,15 +1453,16 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             }
 
-            try {
-                if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
-                    collectionCategory.removePreference(libre2settings);
-                }
-            } catch (Exception e) {
-                Log.wtf(TAG, "xception preferences remove Libre2Settings: ", e);
-            }
 
             try {
+
+                try {
+                    if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
+                        collectionCategory.removePreference(libre2settings);
+                    }
+                } catch (NullPointerException e) {
+                    Log.wtf(TAG, "Nullpointer Libre2Settings: ", e);
+                }
 
                 try {
                     if (!DexCollectionType.hasWifi()) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1453,8 +1453,12 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             }
 
-            if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
-                collectionCategory.removePreference(libre2settings);
+            try {
+                if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
+                    collectionCategory.removePreference(libre2settings);
+                }
+            } catch (Exception e) {
+                Log.wtf(TAG, "xception preferences remove Libre2Settings: ", e);
             }
 
             try {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1453,11 +1453,12 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             }
 
-            if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
-                collectionCategory.removePreference(libre2settings);
-            }
 
             try {
+
+                if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
+                    collectionCategory.removePreference(libre2settings);
+                }
 
                 try {
                     if (!DexCollectionType.hasWifi()) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1456,8 +1456,12 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             try {
 
-                if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
-                    collectionCategory.removePreference(libre2settings);
+                try {
+                    if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
+                        collectionCategory.removePreference(libre2settings);
+                    }
+                } catch (NullPointerException e) {
+                    Log.wtf(TAG, "Nullpointer Libre2Settings: ", e);
                 }
 
                 try {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -942,6 +942,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             final Preference bfappid = findPreference("bugfender_appid");
             final Preference nfcSettings = findPreference("xdrip_plus_nfc_settings");
             final Preference bluereadersettings = findPreference("xdrip_blueReader_advanced_settings");
+            final Preference libre2settings = findPreference("xdrip_libre2_advanced_settings");
             //DexCollectionType collectionType = DexCollectionType.getType(findPreference("dex_collection_method").)
 
             final ListPreference currentCalibrationPlugin = (ListPreference)findPreference("current_calibration_plugin");
@@ -1450,6 +1451,10 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                         }
                 );
 
+            }
+
+            if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver) {
+                collectionCategory.removePreference(libre2settings);
             }
 
             try {

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -902,6 +902,17 @@
                 android:summary="@string/summary_write_Battery_Information_for_additional_analytic"
                 android:title="@string/title_Batterylog" />
         </PreferenceScreen>
+
+        <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+            android:key="xdrip_libre2_advanced_settings"
+            android:title="Advanced settings for Libre 2">
+            <SwitchPreference
+                android:defaultValue="false"
+                android:key="Libre2_showRawGraph"
+                android:summary="switch on to show the raw values on the Graph"
+                android:title="show Raw values in Graph" />
+        </PreferenceScreen>
+
             <CheckBoxPreference
                 android:defaultValue="true"
                 android:key="aggressive_service_restart"


### PR DESCRIPTION
This Pull-Request adds the raw-data from Libre2 into the graph.
- including advanced Pref to switch on/off (standard off) 
- Pref only visible if Libre2 is selected as collector
- pref-texts are not jet included in Strings.xml, as it is a new setting. Will made later a additional PR for active translation, because I also want to add other settings here later with other separated PR's

What is it good for: makes visible how noisy the data are, and how effective the smoothing algorithm works. Also it will be visible if there are lost intends if dots are not shown in the graph.

It will looks like this:
![Screenshot_20190809-084510__01](https://user-images.githubusercontent.com/942153/62759701-58369e00-ba82-11e9-9415-d4323ad48b0f.jpg)
