### PR TITLE
Allow xDrip to also recognize miaomiao2.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
@@ -45,7 +45,7 @@ public class Tomato {
             return false;
         }
 
-        return activeBluetoothDevice.name.contentEquals("miaomiao");
+        return activeBluetoothDevice.name.startsWith("miaomiao");
     }
 
     public static BridgeResponse decodeTomatoPacket(byte[] buffer, int len) {


### PR DESCRIPTION
It seems that device name there is miaomiao2_XX
Where xx is the mac addresses.
This commit allows xDrip to recognize both versions of mm.

Tested with MM1 and MM2.

Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>