### PR TITLE
Rework of 'more insulin types' PR from gruoner and k2s

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -609,6 +609,11 @@
             android:label="@string/title_activity_profile_editor"
             android:windowSoftInputMode="adjustPan" />
         <activity
+            android:name=".insulin.InsulinProfileEditor"
+            android:configChanges="orientation|screenSize"
+            android:label="@string/title_activity_profile_editor"
+            android:windowSoftInputMode="adjustPan" />
+        <activity
             android:name=".languageeditor.LanguageEditor"
             android:configChanges="orientation|screenSize"
             android:label="@string/language_editor"

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/InsulinInjection.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/InsulinInjection.java
@@ -1,0 +1,41 @@
+package com.eveningoutpost.dexdrip.Models;
+
+import com.eveningoutpost.dexdrip.insulin.Insulin;
+import com.eveningoutpost.dexdrip.insulin.InsulinManager;
+import com.google.gson.annotations.Expose;
+
+import lombok.Getter;
+
+public class InsulinInjection {
+    private Insulin profile;
+
+    @Expose
+    @Getter
+    private double units;
+
+    @Expose
+    @Getter
+    private String insulin;
+
+    public InsulinInjection(final Insulin p, final double u) {
+        profile = p;
+        units = u;
+        insulin = p.getName();
+    }
+
+
+    public Insulin getProfile() {
+        // populate on demand
+        if (profile == null) {
+            profile = InsulinManager.getProfile(insulin);
+        }
+        return profile;
+    }
+
+    // This is just a rough way to decide if it is a basal insulin without user needing to set it
+    // question as to whether this should be here or call to encapsulated method in Insulin
+    public boolean isBasal() {
+        return getProfile().getMaxEffect() > 1000;
+    }
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Iob.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Iob.java
@@ -10,7 +10,6 @@ public class Iob {
     public double cob = 0;
     public double rawCarbImpact = 0;
     public double jCarbImpact = 0;
-    public double activity = 0;
     public double jActivity = 0;
 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/NSClientChat.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/NSClientChat.java
@@ -49,6 +49,9 @@ public class NSClientChat {
                     }
 
                     data.put("insulin", thistreatment.insulin);
+                    if (thistreatment.insulinJSON != null) {
+                        data.put("insulinInjections", thistreatment.insulinJSON);
+                    }
                     data.put("carbs", thistreatment.carbs);
                     if (thistreatment.notes != null) {
                         data.put("notes", thistreatment.notes);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Treatments.java
@@ -6,6 +6,7 @@ package com.eveningoutpost.dexdrip.Models;
 
 import android.content.Context;
 import android.provider.BaseColumns;
+import android.util.Pair;
 
 import com.activeandroid.Model;
 import com.activeandroid.annotation.Column;
@@ -21,12 +22,16 @@ import com.eveningoutpost.dexdrip.Services.SyncService;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.UndoRedo;
 import com.eveningoutpost.dexdrip.UtilityModels.UploaderQueue;
+import com.eveningoutpost.dexdrip.insulin.Insulin;
+import com.eveningoutpost.dexdrip.insulin.InsulinManager;
+import com.eveningoutpost.dexdrip.insulin.MultipleInsulins;
 import com.eveningoutpost.dexdrip.watch.thinjam.BlueJayEntry;
 import com.eveningoutpost.dexdrip.xdrip;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 import com.google.gson.internal.bind.DateTypeAdapter;
+import com.google.gson.reflect.TypeToken;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -41,6 +46,9 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
 
+import static com.eveningoutpost.dexdrip.UtilityModels.Constants.HOUR_IN_MS;
+import static com.eveningoutpost.dexdrip.UtilityModels.Constants.MINUTE_IN_MS;
+import static java.lang.StrictMath.abs;
 import static com.eveningoutpost.dexdrip.Models.JoH.emptyString;
 
 // TODO Switchable Carb models
@@ -78,64 +86,200 @@ public class Treatments extends Model {
     @Column(name = "insulin")
     public double insulin;
     @Expose
+    @Column(name = "insulinJSON")
+    public String insulinJSON;
+    @Expose
     @Column(name = "created_at")
     public String created_at;
+
+    // don't access this directly use getInsulinInjections()
+    private List<InsulinInjection> insulinInjections = null;
+
+    private boolean hasInsulinInjections() {
+        final List<InsulinInjection> injections = getInsulinInjections();
+        return ((injections != null) && (injections.size() > 0));
+    }
+
+    public boolean isBasalOnly() {
+        if (!hasInsulinInjections()) return false;
+        boolean foundBasal = false;
+        final List<InsulinInjection> injections = getInsulinInjections();
+        for (InsulinInjection injection : injections) {
+            Log.d(TAG,"isBasalOnly: "+injection.isBasal()+" "+injection.getInsulin());
+            if (!injection.isBasal()) {
+                return false;
+            } else {
+                foundBasal = true;
+            }
+        }
+        return foundBasal;
+    }
+
+    private String getInsulinInjectionsShortString() {
+        final StringBuilder sb = new StringBuilder();
+        for (InsulinInjection injection : insulinInjections) {
+            sb.append(injection.getProfile().getName());
+            sb.append(" ");
+            sb.append(injection.getUnits() + "U ");
+        }
+        return sb.toString();
+    }
+
+    private void setInsulinInjections(List<InsulinInjection> i)
+    {
+        // TODO possiblity here to preserve null if Multiple Injections is not enabled
+        if (i == null) {
+            i = new ArrayList<>();
+        }
+        insulinInjections = i;
+        Gson gson = new GsonBuilder()
+                .excludeFieldsWithoutExposeAnnotation()
+               // .registerTypeAdapter(Date.class, new DateTypeAdapter())
+                .serializeSpecialFloatingPointValues()
+                .create();
+        insulinJSON = gson.toJson(i);
+    }
+
+    // lazily populate and return InsulinInjection array from json
+    List<InsulinInjection> getInsulinInjections() {
+       // Log.d(TAG,"get injections: "+insulinJSON);
+        if (insulinInjections == null) {
+            if (insulinJSON != null) {
+                try {
+
+                    insulinInjections = new Gson().fromJson(insulinJSON, new TypeToken<ArrayList<InsulinInjection>>() {
+                    }.getType());
+
+                    StringBuilder x = new StringBuilder();
+                    for (InsulinInjection y : insulinInjections) {
+                        x.append(y.getProfile().getName() + " " + y.getUnits()+" ");
+                    }
+
+
+                } catch (Exception e) {
+                    if (JoH.ratelimit("ij-json-error", 60)) {
+                        UserError.Log.wtf(TAG, "Error converting insulinJson: " + e + " " + insulinJSON);
+                    }
+                    notes = "CORRUPT DATA";
+                    // state of insulinInjections is basically undefined here as we cannot recover from corrupt data
+                    // we could neutralise the treatment data in other ways perhaps.
+                }
+            } else {
+                // return empty if not set // TODO do we want to cache this or not to avoid memory creation?
+                return new ArrayList<>();
+            }
+        }
+        return insulinInjections;
+    }
+
+    // take a simple insulin value and produce a list assuming it is bolus insulin - for legacy conversion
+    static private List<InsulinInjection> convertLegacyDoseToBolusInjectionList(final double insulinSum) {
+        final ArrayList<InsulinInjection> injections = new ArrayList<>();
+        injections.add(new InsulinInjection(InsulinManager.getBolusProfile(), insulinSum));
+        return injections;
+    }
+
+    // take a simple insulin value and produce a list by name of insulin - for general quick conversion
+    public static List<InsulinInjection> convertLegacyDoseToInjectionListByName(final String insulinName, final double insulinSum) {
+        Log.d(TAG,"convertingLegacyDoseByName: "+insulinName+" "+insulinSum);
+        final Insulin insulin = InsulinManager.getProfile(insulinName);
+        if (insulin == null) return null; // TODO should we actually throw an exception here as this should never happen and the result would be invalid
+        final ArrayList<InsulinInjection> injections = new ArrayList<>();
+        injections.add(new InsulinInjection(insulin, insulinSum));
+        return injections;
+    }
+
+
+    public void setInsulinJSON(String json) {
+        if ((json == null) || json.isEmpty())
+            json = "[]";
+        try {
+            insulinInjections = new Gson().fromJson(json, new TypeToken<ArrayList<InsulinInjection>>() {
+            }.getType());
+            insulinJSON = json; // set json only if we didn't get exception processing it
+        } catch (Exception e) {
+            UserError.Log.e(TAG, "Got exception in setInsulinJson: " + e + " for " + json);
+        }
+    }
+
+    public Treatments()
+    {
+        eventType = DEFAULT_EVENT_TYPE;
+        carbs = 0;
+        insulin = 0;
+        //setInsulinInjections(null);
+    }
 
     public static synchronized Treatments create(final double carbs, final double insulin, long timestamp) {
         return create(carbs, insulin, timestamp, null);
     }
 
-    public static synchronized Treatments create(final double carbs, final double insulin, long timestamp, String suggested_uuid) {
+    public static synchronized Treatments create(final double carbs, final double insulinSum, final long timestamp, final String suggested_uuid) {
+
+        if (MultipleInsulins.isEnabled()) {
+            return create(carbs, insulinSum, convertLegacyDoseToBolusInjectionList(insulinSum), timestamp, suggested_uuid);
+        } else {
+            return create(carbs, insulinSum, null, timestamp, suggested_uuid);
+        }
+
+    }
+
+    public static synchronized Treatments create(final double carbs, final double insulinSum, final List<InsulinInjection> insulin, long timestamp) {
+        return create(carbs, insulinSum, insulin, timestamp, null);
+    }
+
+    public static synchronized Treatments create(final double carbs, final double insulinSum, final List<InsulinInjection> insulin, long timestamp, String suggested_uuid) {
         // if treatment more than 1 minutes in the future
         final long future_seconds = (timestamp - JoH.tsl()) / 1000;
         if (future_seconds > (60 * 60)) {
             JoH.static_toast_long("Refusing to create a treatement more than 1 hours in the future!");
             return null;
         }
-        if ((future_seconds > 60) && (future_seconds < 86400) && ((carbs > 0) || (insulin > 0))) {
+        if ((future_seconds > 60) && (future_seconds < 86400) && ((carbs > 0) || (insulinSum > 0))) {
             final Context context = xdrip.getAppContext();
             JoH.scheduleNotification(context, "Treatment Reminder", "@" + JoH.hourMinuteString(timestamp) + " : "
                     + carbs + " " + context.getString(R.string.carbs) + " / "
-                    + insulin + " " + context.getString(R.string.units), (int) future_seconds, 34026);
+                    + insulinSum + " " + context.getString(R.string.units), (int) future_seconds, 34026);
         }
-        return create(carbs, insulin, timestamp, -1, suggested_uuid);
+        return create(carbs, insulinSum, insulin, timestamp, -1, suggested_uuid);
     }
 
-    public static synchronized Treatments create(final double carbs, final double insulin, long timestamp, double position, String suggested_uuid) {
+    public static synchronized Treatments create(final double carbs, final double insulinSum, final List<InsulinInjection> insulin, long timestamp, double position, String suggested_uuid) {
         // TODO sanity check values
         Log.d(TAG, "Creating treatment: " +
-                "Insulin: " + insulin + " / " +
+                "Insulin: " + insulinSum + " / " +
                 "Carbs: " + carbs +
                 (suggested_uuid != null && !suggested_uuid.isEmpty()
                         ? " " + "uuid: " + suggested_uuid
                         : ""));
 
-        if ((carbs == 0) && (insulin == 0)) return null;
+        if ((carbs == 0) && (insulinSum == 0)) return null;
 
         if (timestamp == 0) {
             timestamp = new Date().getTime();
         }
 
-        Treatments Treatment = new Treatments();
+        final Treatments treatment = new Treatments();
 
         if (position > 0) {
-            Treatment.enteredBy = XDRIP_TAG + " pos:" + JoH.qs(position, 2);
+            treatment.enteredBy = XDRIP_TAG + " pos:" + JoH.qs(position, 2);
         } else {
-            Treatment.enteredBy = XDRIP_TAG;
+            treatment.enteredBy = XDRIP_TAG;
         }
 
-        Treatment.eventType = DEFAULT_EVENT_TYPE;
-        Treatment.carbs = carbs;
-        Treatment.insulin = insulin;
-        Treatment.timestamp = timestamp;
-        Treatment.created_at = DateUtil.toISOString(timestamp);
-        Treatment.uuid = suggested_uuid != null ? suggested_uuid : UUID.randomUUID().toString();
-        Treatment.save();
+        treatment.carbs = carbs;
+        treatment.insulin = insulinSum;
+        treatment.setInsulinInjections(insulin);
+        treatment.timestamp = timestamp;
+        treatment.created_at = DateUtil.toISOString(timestamp);
+        treatment.uuid = suggested_uuid != null ? suggested_uuid : UUID.randomUUID().toString();
+        treatment.save();
         // GcmActivity.pushTreatmentAsync(Treatment);
         //  NSClientChat.pushTreatmentAsync(Treatment);
-        pushTreatmentSync(Treatment);
-        UndoRedo.addUndoTreatment(Treatment.uuid);
-        return Treatment;
+
+        pushTreatmentSync(treatment);
+        UndoRedo.addUndoTreatment(treatment.uuid);
+        return treatment;
     }
 
     // Note
@@ -163,16 +307,13 @@ public class Treatments extends Model {
         boolean is_new = false;
         // find treatment
 
-        Treatments treatment = byTimestamp(timestamp, 60 * 1000 * 5);
+        Treatments treatment = byTimestamp(timestamp, MINUTE_IN_MS * 5);
         // if unknown create
         if (treatment == null) {
             treatment = new Treatments();
             Log.d(TAG, "Creating new treatment entry for note");
             is_new = true;
 
-            treatment.eventType = DEFAULT_EVENT_TYPE;
-            treatment.carbs = 0;
-            treatment.insulin = 0;
             treatment.notes = note;
             treatment.timestamp = timestamp;
             treatment.created_at = DateUtil.toISOString(timestamp);
@@ -267,6 +408,7 @@ public class Treatments extends Model {
                 "ALTER TABLE Treatments ADD COLUMN notes TEXT;",
                 "ALTER TABLE Treatments ADD COLUMN created_at TEXT;",
                 "ALTER TABLE Treatments ADD COLUMN insulin REAL;",
+                "ALTER TABLE Treatments ADD COLUMN insulinJSON TEXT;",
                 "ALTER TABLE Treatments ADD COLUMN carbs REAL;",
                 "CREATE INDEX index_Treatments_timestamp on Treatments(timestamp);",
                 "CREATE UNIQUE INDEX index_Treatments_uuid on Treatments(uuid);"};
@@ -330,6 +472,13 @@ public class Treatments extends Model {
 
     public static Treatments byTimestamp(long timestamp) {
         return byTimestamp(timestamp, 1500);
+    }
+
+    public static Treatments byTimestamp(long timestamp, long plus_minus_millis) {
+        if (plus_minus_millis > Integer.MAX_VALUE) {
+            throw new RuntimeException("Treatment by TimeStamp out of range value: " + plus_minus_millis);
+        }
+        return byTimestamp(timestamp, (int) plus_minus_millis);
     }
 
     public static Treatments byTimestamp(long timestamp, int plus_minus_millis) {
@@ -450,6 +599,7 @@ public class Treatments extends Model {
                 Log.i(TAG, "Duplicate treatment for: " + mytreatment.timestamp);
 
                 if ((dupe_treatment.insulin == 0) && (mytreatment.insulin > 0)) {
+                    dupe_treatment.setInsulinJSON(mytreatment.insulinJSON);
                     dupe_treatment.insulin = mytreatment.insulin;
                     dupe_treatment.save();
                     Home.staticRefreshBGChartsOnIdle();
@@ -545,11 +695,12 @@ public class Treatments extends Model {
         return (long) (new Date().getTime() - offset);
     }
 
-    public static CobCalc cobCalc(Treatments treatment, double lastDecayedBy, double time) {
+    /// this is no longer used
+    /* public static CobCalc cobCalc(Treatments treatment, double lastDecayedBy, double time) {
 
         double delay = 20; // minutes till carbs start decaying
 
-        double delayms = delay * 60 * 1000;
+        double delayms = delay * Constants.MINUTE_IN_MS;
         if (treatment.carbs > 0) {
 
             CobCalc thisCobCalc = new CobCalc();
@@ -562,20 +713,20 @@ public class Treatments extends Model {
 
             double carbs_hr = Profile.getCarbAbsorptionRate(time);
             double carbs_min = carbs_hr / 60;
-            double carbs_ms = carbs_min / (60 * 1000);
+            double carbs_ms = carbs_min / Constants.MINUTE_IN_MS;
 
             thisCobCalc.decayedBy = thisCobCalc.carbTime; // initially set to start time for this treatment
 
-            double minutesleft = (lastDecayedBy - thisCobCalc.carbTime) / 1000 / 60;
+            double minutesleft = (lastDecayedBy - thisCobCalc.carbTime) / Constants.MINUTE_IN_MS;
             double how_long_till_carbs_start_ms = (lastDecayedBy - thisCobCalc.carbTime);
-            thisCobCalc.decayedBy += (Math.max(delay, minutesleft) + treatment.carbs / carbs_min) * 60 * 1000;
+            thisCobCalc.decayedBy += (Math.max(delay, minutesleft) + treatment.carbs / carbs_min) * Constants.MINUTE_IN_MS;
 
             if (delay > minutesleft) {
                 thisCobCalc.initialCarbs = treatment.carbs;
             } else {
                 thisCobCalc.initialCarbs = treatment.carbs + minutesleft * carbs_min;
             }
-            double startDecay = thisCobCalc.carbTime + (delay * 60 * 1000);
+            double startDecay = thisCobCalc.carbTime + (delay * Constants.MINUTE_IN_MS);
 
             if (time < lastDecayedBy || time > startDecay) {
                 thisCobCalc.isDecaying = 1;
@@ -588,17 +739,44 @@ public class Treatments extends Model {
             return null;
         }
     }
+*/
 
-    public static Iob calcTreatment(Treatments treatment, double time, double lastDecayedby) {
+    // when using multiple insulins
+    private static Pair<Double, Double> calculateIobActivityFromTreatmentAtTime(final Treatments treatment, final double time, final boolean useBasal) {
+
+        double iobContrib = 0, activityContrib = 0;
+        if (treatment.insulin > 0) {
+           // Log.d(TAG,"NEW TYPE insulin: "+treatment.insulin+ " "+treatment.insulinJSON);
+            // translate a legacy entry to be bolus insulin
+            List<InsulinInjection> injectionsList = treatment.getInsulinInjections();
+            if (injectionsList == null || injectionsList.size() == 0) {
+                Log.d(TAG,"CONVERTING LEGACY: "+treatment.insulinJSON+ " "+injectionsList);
+                injectionsList = convertLegacyDoseToBolusInjectionList(treatment.insulin);
+                treatment.insulinInjections = injectionsList; // cache but best not to save it
+            }
+
+            for (final InsulinInjection injection : injectionsList)
+                if (injection.getUnits() > 0 && (useBasal || !injection.isBasal())) {
+                    iobContrib += injection.getUnits() * abs(injection.getProfile().calculateIOB((time - treatment.timestamp) / MINUTE_IN_MS));
+                    activityContrib += injection.getUnits() * abs(injection.getProfile().calculateActivity((time - treatment.timestamp) / MINUTE_IN_MS));
+                }
+            if (iobContrib < 0) iobContrib = 0;
+            if (activityContrib < 0) activityContrib = 0;
+        }
+        return new Pair<>(iobContrib, activityContrib);
+    }
+
+    // using the original calculation
+    private static Pair<Double, Double> calculateLegacyIobActivityFromTreatmentAtTime(final Treatments treatment, final double time) {
 
         final double dia = Profile.insulinActionTime(time); // duration insulin action in hours
         final double peak = 75; // minutes in based on a 3 hour DIA - scaled proportionally (orig 75)
-        //final double sens = Profile.getSensitivity(time); // sensitivity currently in mmol
+
         double insulin_delay_minutes = 0;
 
         double insulin_timestamp = treatment.timestamp + (insulin_delay_minutes * 60 * 1000);
 
-        Iob response = new Iob();
+        //Iob response = new Iob();
 
         final double scaleFactor = 3.0 / dia;
         double iobContrib = 0;
@@ -623,8 +801,25 @@ public class Treatments extends Model {
 
         }
         if (iobContrib < 0) iobContrib = 0;
-        response.iob = iobContrib;
-        // response.activity = activityContrib;
+        //if (activityContrib < 0) activityContrib = 0;
+        return new Pair<>(iobContrib, 0d);
+    }
+
+
+
+    private static Iob calcTreatment(final Treatments treatment, final double time, final boolean useBasal) {
+        final Iob response = new Iob();
+
+        if (MultipleInsulins.isEnabled()) {
+            Pair<Double,Double> result = calculateIobActivityFromTreatmentAtTime(treatment, time, useBasal);
+            response.iob = result.first;
+            response.jActivity = result.second;
+        } else {
+            Pair<Double,Double> result = calculateLegacyIobActivityFromTreatmentAtTime(treatment, time);
+            response.iob = result.first;
+           // response.jActivity = result.second;
+        }
+
         return response;
     }
 
@@ -646,19 +841,22 @@ public class Treatments extends Model {
         } else {
             tempiob = new Iob();
             tempiob.timestamp = (long) thistime;
+         //   tempiob.date = new Date((long)thistime);
             tempiob.cob = carbs;
         }
         timeslices.put(thistime, tempiob);
     }
 
-    private static void timesliceWriter(Map<Double, Iob> timeslices, Iob thisiob, double thistime) {
+    private static void timesliceInsulinWriter(Map<Double, Iob> timeslices, Iob thisiob, double thistime) {
         if (thisiob.iob > 0) {
             if (timeslices.containsKey(thistime)) {
                 Iob tempiob = timeslices.get(thistime);
                 tempiob.iob += thisiob.iob;
+                tempiob.jActivity+= thisiob.jActivity;
                 timeslices.put(thistime, tempiob);
             } else {
                 thisiob.timestamp = (long) thistime;
+             //   thisiob.date = new Date((long)thistime);
                 timeslices.put(thistime, thisiob); // first entry at timeslice so put the record in as is
             }
         }
@@ -667,27 +865,29 @@ public class Treatments extends Model {
     // NEW NEW NEW
     public static List<Iob> ioBForGraph_new(int number, double startTime) {
 
-        Log.d(TAG, "Processing iobforgraph2: main  ");
+       // Log.d(TAG, "Processing iobforgraph2: main  ");
         JoH.benchmark_method_start();
-
+        final boolean multipleInsulins = MultipleInsulins.isEnabled();
+        final boolean useBasal = MultipleInsulins.useBasalActivity();
         // number param currently ignored
 
-        // get all treatments from 24 hours earlier than our current time
-        final double dontLookThisFar = 10 * 60 * 60 * 1000; // 10 hours max look
+        // 10 hours max look or from insulin manager if enabled
+        final double dontLookThisFar = MultipleInsulins.isEnabled() ? MINUTE_IN_MS * InsulinManager.getMaxEffect(true) : 10 * HOUR_IN_MS;
+// look back the longest effect period of all enabled insulin profiles (startTime is always 24h behind NOW)
         List<Treatments> theTreatments = latestForGraph(2000, startTime - dontLookThisFar);
+        Log.d(TAG,"TREATMENT LIST: "+theTreatments.size()+" "+JoH.dateTimeText((long)(startTime - dontLookThisFar)));
         if (theTreatments.size() == 0) return null;
-
 
         int counter = 0; // iteration counter
 
         final double step_minutes = 5;
-        final double stepms = step_minutes * 60 * 1000; // 600s = 10 mins
+        final double stepms = step_minutes * MINUTE_IN_MS; // 300s = 5 mins
         double mytime = startTime;
         double tendtime = startTime;
 
 
         final double carb_delay_minutes = Profile.carbDelayMinutes(mytime); // not likely a time dependent parameter
-        final double carb_delay_ms_stepped = ((long) (carb_delay_minutes / step_minutes)) * step_minutes * (60 * 1000);
+        final double carb_delay_ms_stepped = ((long) (carb_delay_minutes / step_minutes)) * step_minutes * MINUTE_IN_MS;
 
         Log.d(TAG, "Carb delay ms: " + carb_delay_ms_stepped);
 
@@ -695,7 +895,6 @@ public class Treatments extends Model {
 
         // linear array populated as needed and layered by each treatment etc
         SortedMap<Double, Iob> timeslices = new TreeMap<Double, Iob>();
-
         Iob calcreply;
 
         // First process all IoB calculations
@@ -703,45 +902,51 @@ public class Treatments extends Model {
             // early optimisation exclusion
 
             mytime = ((long) (thisTreatment.timestamp / stepms)) * stepms; // effects of treatment occur only after it is given / fit to slot time
-            tendtime = mytime + dontLookThisFar;
-
+            tendtime = mytime + 36 * HOUR_IN_MS;     // 36 hours max look (24h history plus 12h forecast)
+            if (tendtime > startTime + 30 * HOUR_IN_MS)
+                tendtime = startTime + 30 * HOUR_IN_MS;   // dont look more than 6h in future // TODO review time limit
             if (thisTreatment.insulin > 0) {
                 // lay down insulin on board
-                while (mytime < tendtime) {
+                do {
 
-                    calcreply = calcTreatment(thisTreatment, mytime, 0); // last param now not used - only insulin
+                    calcreply = calcTreatment(thisTreatment, mytime, useBasal);
+                    calcreply.jActivity *= step_minutes;    // has to be multiplied because derivation function of IOB calculates a step_minutes lower activity as the "old" logic
+                    calcreply.jActivity *= Profile.getSensitivity(mytime);
 
                     if (mytime >= startTime) {
-                        timesliceWriter(timeslices, calcreply, mytime);
+                        timesliceInsulinWriter(timeslices, calcreply, mytime);
                     }
                     mytime = mytime + stepms; // advance time counter
-                }
+                } while ((mytime < tendtime) &&
+                        ((calcreply.iob == 0) || (calcreply.iob > 0.01)));
             }
         } // per insulin treatment
 
+        // legacy jActivity calculation
+        if (!multipleInsulins) {
+            Log.d(TAG, "Single insulin type iteration counter: " + counter);
 
-        Log.d(TAG, "insulin iteration counter: " + counter);
-
-
-        // evaluate insulin impact
-        Iob lastiob = null;
-        for (Map.Entry<Double, Iob> entry : timeslices.entrySet()) {
-            Iob thisiob = entry.getValue();
-            if (lastiob != null) {
-                if ((thisiob.iob != 0) || (lastiob.iob != 0)) {
-                    if (thisiob.iob < lastiob.iob) {
-                        // decaying iob
-                        thisiob.jActivity = (lastiob.iob - thisiob.iob) * Profile.getSensitivity(thisiob.timestamp);
-                    } else {
-                        // more insulin added
-                        thisiob.jActivity = 0; // TODO THIS IS NOT RIGHT IT MISSES ONE DECAY STEP
+            // evaluate insulin impact
+            Iob lastiob = null;
+            for (Map.Entry<Double, Iob> entry : timeslices.entrySet()) {
+                Iob thisiob = entry.getValue();
+                if (lastiob != null) {
+                    if ((thisiob.iob != 0) || (lastiob.iob != 0)) {
+                        if (thisiob.iob < lastiob.iob) {
+                            // decaying iob
+                            thisiob.jActivity = (lastiob.iob - thisiob.iob) * Profile.getSensitivity(thisiob.timestamp);
+                        } else {
+                            // more insulin added
+                            thisiob.jActivity = 0; // TODO THIS IS NOT RIGHT IT MISSES ONE DECAY STEP
+                        }
                     }
                 }
-            }
 
-            //Log.d(TAG,"iobinfo2 iob debug: "+JoH.qs(thisiob.timestamp)+" C:"+JoH.qs(thisiob.cob,4)+" I:"+JoH.qs(thisiob.iob,4)+" CA:"+JoH.qs(thisiob.jCarbImpact)+" IA:"+JoH.qs(thisiob.jActivity));
-            counter++;
-            lastiob = thisiob;
+                //Log.d(TAG,"iobinfo2 iob debug: "+JoH.qs(thisiob.timestamp)+" C:"+JoH.qs(thisiob.cob,4)+" I:"+JoH.qs(thisiob.iob,4)+" CA:"+JoH.qs(thisiob.jCarbImpact)+" IA:"+JoH.qs(thisiob.jActivity));
+                counter++;
+                lastiob = thisiob;
+            }
+            //
         }
 
         // calculate carb treatments
@@ -750,10 +955,10 @@ public class Treatments extends Model {
             if (thisTreatment.carbs > 0) {
 
                 mytime = ((long) (thisTreatment.timestamp / stepms)) * stepms; // effects of treatment occur only after it is given / fit to slot time
-                tendtime = mytime + dontLookThisFar;
+                tendtime = mytime + 6 * HOUR_IN_MS;     // 6 hours max look
 
                 double cob_time = mytime + carb_delay_ms_stepped;
-                double stomachDiff = ((Profile.getCarbAbsorptionRate(cob_time) * stepms) / (60 * 60 * 1000)); // initial value
+                double stomachDiff = ((Profile.getCarbAbsorptionRate(cob_time) * stepms) / HOUR_IN_MS); // initial value
                 double newdelayedCarbs = 0;
                 double cob_remain = thisTreatment.carbs;
                 while ((cob_remain > 0) && (stomachDiff > 0) && (cob_time < tendtime)) {
@@ -763,7 +968,7 @@ public class Treatments extends Model {
                     }
                     cob_time += stepms;
 
-                    stomachDiff = ((Profile.getCarbAbsorptionRate(cob_time) * stepms) / (60 * 60 * 1000));
+                    stomachDiff = ((Profile.getCarbAbsorptionRate(cob_time) * stepms) / HOUR_IN_MS);
                     cob_remain -= stomachDiff;
 
                     newdelayedCarbs = (timesliceIactivityAtTime(timeslices, cob_time) * Profile.getLiverSensRatio(cob_time) / Profile.getSensitivity(cob_time)) * Profile.getCarbRatio(cob_time);
@@ -785,7 +990,7 @@ public class Treatments extends Model {
         }
 
         // evaluate carb impact
-        lastiob = null;
+        Iob lastiob = null;
         for (Map.Entry<Double, Iob> entry : timeslices.entrySet()) {
             Iob thisiob = entry.getValue();
             if (lastiob != null) {
@@ -975,7 +1180,12 @@ public class Treatments extends Model {
         if (!eventType.equals(DEFAULT_EVENT_TYPE)) {
             return eventType;
         } else {
-            return "Treatment";
+            if (hasInsulinInjections()) {
+                return getInsulinInjectionsShortString()
+                        + (noteHasContent() ? (" " + notes) : "");
+            } else {
+                return noteHasContent() ? notes : "Treatment";
+            }
         }
     }
 
@@ -984,6 +1194,7 @@ public class Treatments extends Model {
         try {
             jsonObject.put("uuid", uuid);
             jsonObject.put("insulin", insulin);
+            jsonObject.put("insulinJSON", insulinJSON);
             jsonObject.put("carbs", carbs);
             jsonObject.put("timestamp", timestamp);
             jsonObject.put("notes", notes);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NSClientReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NSClientReceiver.java
@@ -245,6 +245,9 @@ public class NSClientReceiver extends BroadcastReceiver {
             if (trt_map.containsKey("insulin")) {
                 jsonObject.put("insulin", trt_map.get("insulin"));
             }
+            if (trt_map.containsKey("insulinJSON")) {
+                jsonObject.put("insulinInjections", trt_map.get("insulinJSON"));
+            }
             if (trt_map.containsKey("notes")) {
                 jsonObject.put("notes", trt_map.get("notes"));
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/PhoneKeypadInputActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/PhoneKeypadInputActivity.java
@@ -8,10 +8,14 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.ImageButton;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
+import com.eveningoutpost.dexdrip.insulin.Insulin;
+import com.eveningoutpost.dexdrip.insulin.InsulinManager;
+import com.eveningoutpost.dexdrip.insulin.MultipleInsulins;
 import com.eveningoutpost.dexdrip.wearintegration.WatchUpdaterService;
 
 import java.util.HashMap;
@@ -33,23 +37,29 @@ public class PhoneKeypadInputActivity extends BaseActivity {
 
     private TextView mDialTextView;
     private Button zeroButton, oneButton, twoButton, threeButton, fourButton, fiveButton,
-            sixButton, sevenButton, eightButton, nineButton, starButton, backSpaceButton;
+            sixButton, sevenButton, eightButton, nineButton, starButton, backSpaceButton, multiButton1, multiButton2, multiButton3;
     private ImageButton callImageButton, backspaceImageButton, insulintabbutton, carbstabbutton,
             bloodtesttabbutton, timetabbutton, speakbutton;
 
-    private static String currenttab = "insulin";
+    private static String currenttab = "insulin-1";
     private static final String LAST_TAB_STORE = "phone-keypad-treatment-last-tab";
     private static final String TAG = "KeypadInput";
     private static Map<String, String> values = new HashMap<String, String>();
     private String bgUnits;
+    private Insulin insulinProfile1 = null;
+    private Insulin insulinProfile2 = null;
+    private Insulin insulinProfile3 = null;
+    private LinearLayout insulinTypesSection = null;
+
+    private final boolean multipleInsulins = MultipleInsulins.isEnabled();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.keypad_activity_phone);
-
         DisplayMetrics dm = new DisplayMetrics();
         getWindowManager().getDefaultDisplay().getMetrics(dm);
+
         int width = dm.widthPixels;
         int height = dm.heightPixels;
         final int refdpi = 320;
@@ -58,6 +68,10 @@ public class PhoneKeypadInputActivity extends BaseActivity {
         getWindow().setBackgroundDrawableResource(android.R.color.transparent);
         WindowManager.LayoutParams lp = getWindow().getAttributes();
         lp.dimAmount = 0.5f;
+
+        insulinProfile1 = InsulinManager.getProfile(0);
+        insulinProfile2 = InsulinManager.getProfile(1);
+        insulinProfile3 = InsulinManager.getProfile(2);
 
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
 
@@ -74,6 +88,10 @@ public class PhoneKeypadInputActivity extends BaseActivity {
         nineButton = (Button) findViewById(R.id.nine_button);
         starButton = (Button) findViewById(R.id.star_button);
         backSpaceButton = (Button) findViewById(R.id.backspace_button);
+        insulinTypesSection = (LinearLayout) findViewById(R.id.insulinTypesSection);
+        multiButton1 = (Button) findViewById(R.id.multi_button1);
+        multiButton2 = (Button) findViewById(R.id.multi_button2);
+        multiButton3 = (Button) findViewById(R.id.multi_button3);
         // callImageButton = (ImageButton) stub.findViewById(R.id.call_image_button);
         // backspaceImageButton = (ImageButton) stub.findViewById(R.id.backspace_image_button);
 
@@ -170,6 +188,30 @@ public class PhoneKeypadInputActivity extends BaseActivity {
             }
         });
 
+        multiButton1.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                currenttab = currenttab.split("-")[0] + "-1";
+                updateTab();
+            }
+        });
+
+        multiButton2.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                currenttab = currenttab.split("-")[0] + "-2";
+                updateTab();
+            }
+        });
+
+        multiButton3.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                currenttab = currenttab.split("-")[0] + "-3";
+                updateTab();
+            }
+        });
+
         starButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -227,7 +269,7 @@ public class PhoneKeypadInputActivity extends BaseActivity {
         insulintabbutton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                currenttab = "insulin";
+                currenttab = "insulin-1";
                 updateTab();
             }
         });
@@ -251,7 +293,6 @@ public class PhoneKeypadInputActivity extends BaseActivity {
         } else {
             bgUnits = "mmol/l";
         }
-
         updateTab();
     }
 
@@ -320,15 +361,22 @@ public class PhoneKeypadInputActivity extends BaseActivity {
 
         boolean nonzeroBloodValue = isNonzeroValueInTab("bloodtest");
         boolean nonzeroCarbsValue = isNonzeroValueInTab("carbs");
-        boolean nonzeroInsulinValue = isNonzeroValueInTab("insulin");
+        boolean nonzeroInsulin1Value = isNonzeroValueInTab("insulin-1");
+        boolean nonzeroInsulin2Value = isNonzeroValueInTab("insulin-2");
+        boolean nonzeroInsulin3Value = isNonzeroValueInTab("insulin-3");
 
         // The green tick is clickable even when it's hidden, so we might get here
         // without valid data.  Ignore the click if input is incomplete
-        if(!nonzeroBloodValue && !nonzeroCarbsValue && !nonzeroInsulinValue)
+        if(!nonzeroBloodValue && !nonzeroCarbsValue && !nonzeroInsulin1Value && !nonzeroInsulin2Value && !nonzeroInsulin3Value) {
+            Log.d(TAG, "All zero values in tabs - not processing button click");
             return;
+        }
 
-        if (isInvalidTime())
+        if (isInvalidTime()) {
+            Log.d(TAG,"Time value is invalid - not processing button click");
             return;
+        }
+
 
         // Add the dot to the time if it is missing
         String timeValue = getValue("time");
@@ -337,10 +385,32 @@ public class PhoneKeypadInputActivity extends BaseActivity {
         }
 
         String mystring = "";
+        double units = 0;
         if (timeValue.length() > 0) mystring += timeValue + " time ";
         if (nonzeroBloodValue) mystring += getValue("bloodtest") + " blood ";
         if (nonzeroCarbsValue) mystring += getValue("carbs") + " carbs ";
-        if (nonzeroInsulinValue) mystring += getValue("insulin") + " units ";
+        if (nonzeroInsulin1Value && (insulinProfile1 != null))
+        {
+            double d = Double.parseDouble(getValue("insulin-1"));
+            if (multipleInsulins) {
+                mystring += String.format("%.1f", d).replace(",",".") + " " + insulinProfile1.getName() + " ";
+            }
+            units += d;
+        }
+        if (multipleInsulins) {
+            if (nonzeroInsulin2Value && (insulinProfile2 != null)) {
+                double d = Double.parseDouble(getValue("insulin-2"));
+                mystring += String.format("%.1f", d).replace(",", ".") + " " + insulinProfile2.getName() + " ";
+                units += d;
+            }
+            if (nonzeroInsulin3Value && (insulinProfile3 != null)) {
+                double d = Double.parseDouble(getValue("insulin-3"));
+                mystring += String.format("%.1f", d).replace(",", ".") + " " + insulinProfile3.getName() + " ";
+                units += d;
+            }
+        }
+        if (units > 0)
+            mystring += String.format("%.1f", units).replace(",",".") + " units ";
 
         if (mystring.length() > 1) {
             //SendData(this, WEARABLE_VOICE_PAYLOAD, mystring.getBytes(StandardCharsets.UTF_8));
@@ -360,13 +430,70 @@ public class PhoneKeypadInputActivity extends BaseActivity {
         carbstabbutton.setBackgroundColor(offColor);
         timetabbutton.setBackgroundColor(offColor);
         bloodtesttabbutton.setBackgroundColor(offColor);
-
+        insulinTypesSection.setVisibility(multipleInsulins ? View.VISIBLE : View.GONE);
+        multiButton1.setBackgroundColor(offColor);
+        multiButton2.setBackgroundColor(offColor);
+        multiButton3.setBackgroundColor(offColor);
+        multiButton1.setVisibility(View.INVISIBLE);
+        multiButton2.setVisibility(View.INVISIBLE);
+        multiButton3.setVisibility(View.INVISIBLE);
+        multiButton1.setEnabled(false);
+        multiButton2.setEnabled(false);
+        multiButton3.setEnabled(false);
 
         String append = "";
-        switch (currenttab) {
+        switch (currenttab.split("-")[0]) {
             case "insulin":
                 insulintabbutton.setBackgroundColor(onColor);
-                append = " " + getString(R.string.units);
+                String insulinprofile = "";
+                if (insulinProfile1 != null) {
+                    multiButton1.setText(insulinProfile1.getName());
+                    multiButton1.setEnabled(true);
+                    multiButton1.setVisibility(View.VISIBLE);
+                } else
+                    multiButton1.setText("");
+                if (insulinProfile2 != null)
+                {
+                    multiButton2.setText(insulinProfile2.getName());
+                    multiButton2.setEnabled(true);
+                    multiButton2.setVisibility(View.VISIBLE);
+                } else
+                    multiButton2.setText("");
+                if (insulinProfile3 != null)
+                {
+                    multiButton3.setText(insulinProfile3.getName());
+                    multiButton3.setEnabled(true);
+                    multiButton3.setVisibility(View.VISIBLE);
+                } else
+                    multiButton3.setText("");
+                String multibutton = "";
+                if (currenttab.contains("-"))
+                    multibutton = currenttab.split("-")[1];
+                switch (multibutton) {
+                    case "1":
+                        multiButton1.setBackgroundColor(onColor);
+                        insulinprofile = insulinProfile1.getName();
+                        break;
+                    case "2":
+                        multiButton2.setBackgroundColor(onColor);
+                        if (insulinProfile2 == null)
+                        {
+                            currenttab = "insulin-1";
+                            updateTab();
+                        } else
+                            insulinprofile = insulinProfile2.getName();
+                        break;
+                    case "3":
+                        multiButton3.setBackgroundColor(onColor);
+                        if (insulinProfile3 == null)
+                        {
+                            currenttab = "insulin-2";
+                            updateTab();
+                        } else
+                            insulinprofile = insulinProfile3.getName();
+                        break;
+                }
+                append = " " +  getString(R.string.units) + (multipleInsulins ? (" " + insulinprofile) : "");
                 break;
             case "carbs":
                 carbstabbutton.setBackgroundColor(onColor);
@@ -390,10 +517,10 @@ public class PhoneKeypadInputActivity extends BaseActivity {
             showSubmitButton = false;
 
         else if (currenttab.equals("time"))
-            showSubmitButton = value.length() > 0 &&
-                    ( isNonzeroValueInTab("bloodtest") || isNonzeroValueInTab("carbs") || isNonzeroValueInTab("insulin"));
+            showSubmitButton = value.length() > 0 && ( isNonzeroValueInTab("bloodtest") || isNonzeroValueInTab("carbs") || isNonzeroValueInTab("insulin-1") || isNonzeroValueInTab("insulin-2") || isNonzeroValueInTab("insulin-3"));
         else
             showSubmitButton = isNonzeroValueInTab(currenttab);
+
         mDialTextView.getBackground().setAlpha(showSubmitButton ? 255 : 0);    }
 
 
@@ -401,6 +528,12 @@ public class PhoneKeypadInputActivity extends BaseActivity {
     protected void onResume() {
         final String savedtab = PersistentStore.getString(LAST_TAB_STORE);
         if (savedtab.length() > 0) currenttab = savedtab;
+        if (!multipleInsulins) {
+            // snap back to insulin-1 tab if we have saved position on multiple insulins tabs
+            if (currenttab.equals("insulin-2") || currenttab.equals("insulin-3")) {
+                currenttab = "insulin-1";
+            }
+        }
         updateTab();
         super.onResume();
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -1550,9 +1550,23 @@ public class BgGraphBuilder {
                             mylabel = mylabel + (JoH.qs(treatment.carbs, 1) + "g").replace(".0g", "g");
                         }
                         pv.setLabel(mylabel); // standard label
+
+                        // show basal dose as blue syringe icon
+                        if (treatment.isBasalOnly()) {
+                            //pv.setBitmapScale((float) (0.5f + (treatment.insulin * 5f))); // 0.1U == 100% 0.2U = 150%
+                            BitmapLoader.loadAndSetKey(pv, R.drawable.ic_eyedropper_variant_grey600_24dp, 0);
+                            pv.setBitmapTint(getCol(X.color_basal_tbr));
+                            final Pair<Float, Float> yPositions = GraphTools.bestYPosition(bgReadings, treatment.timestamp, doMgdl, false, highMark, 27d + (18d * consecutiveCloseIcons));
+                            pv.set(treatment.timestamp / FUZZER, yPositions.first);
+                            pv.note = treatment.getBestShortText();
+                            iconValues.add(pv);
+                            lastIconTimestamp = treatment.timestamp;
+                            continue;
+                        }
+
                         //Log.d(TAG, "watchkeypad pv.mylabel: " + mylabel);
                         if ((treatment.notes != null) && (treatment.notes.length() > 0)) {
-                            pv.note = treatment.notes;
+                            pv.note = treatment.getBestShortText();
                             //Log.d(TAG, "watchkeypad pv.note: " + pv.note + " mylabel: " + mylabel);
                             try {
                                 final Pattern p = Pattern.compile(".*?pos:([0-9.]+).*");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -689,6 +689,9 @@ public class NightscoutUploader {
         record.put("uuid", treatment.uuid);
         record.put("carbs", treatment.carbs);
         record.put("insulin", treatment.insulin);
+        if (treatment.insulinJSON != null) {
+            record.put("insulinInjections", treatment.insulinJSON);
+        }
         record.put("created_at", treatment.created_at);
         record.put("sysTime", format.format(treatment.timestamp));
         array.put(record);
@@ -1238,6 +1241,9 @@ public class NightscoutUploader {
                                         record.put("uuid", treatment.uuid);
                                         record.put("carbs", treatment.carbs);
                                         record.put("insulin", treatment.insulin);
+                                        if (treatment.insulinJSON != null) {
+                                            record.put("insulinInjections", treatment.insulinJSON);
+                                        }
                                         record.put("created_at", treatment.created_at);
                                         final BasicDBObject searchQuery = new BasicDBObject().append("uuid", treatment.uuid);
                                         //treatmentDb.insert(record, WriteConcern.UNACKNOWLEDGED);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/insulin/Insulin.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/insulin/Insulin.java
@@ -1,0 +1,81 @@
+package com.eveningoutpost.dexdrip.insulin;
+
+import android.util.Log;
+
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+
+public abstract class Insulin {
+    private static final String TAG = "InsulinManager";
+    private final String name;
+    private final String displayName;
+    private final ArrayList<String> pharmacyProductNumber;
+    private Boolean enabled;
+    protected double concentration;
+    protected long maxEffect;
+
+    public Insulin(String n, String dn, ArrayList<String> ppn, String c, JsonObject curveData) {
+        name = n;
+        displayName = dn;
+        pharmacyProductNumber = ppn;
+        maxEffect = 0;
+        enabled = true;
+        concentration = 1;
+        switch (c.toLowerCase()) {
+            case "u100":
+                concentration = 1;
+                break;
+            case "u200":
+                concentration = 2;
+                break;
+            case "u300":
+                concentration = 3;
+                break;
+            case "u400":
+                concentration = 4;
+                break;
+            case "u500":
+                concentration = 5;
+                break;
+            default:
+                Log.d(TAG, "unknown insulin concentration code " + c);
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void enable() {
+        enabled = true;
+    }
+
+    public void disable() {
+        enabled = false;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public long getMaxEffect() {
+        return maxEffect;
+    }
+
+    public ArrayList<String> getPharmacyProductNumber() {
+        return pharmacyProductNumber;
+    }
+
+    public double calculateIOB(double time) {
+        return -1;
+    }
+
+    public double calculateActivity(double time) {
+        return -1;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinManager.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinManager.java
@@ -1,0 +1,256 @@
+package com.eveningoutpost.dexdrip.insulin;
+
+import android.util.Log;
+
+import com.eveningoutpost.dexdrip.R;
+import com.eveningoutpost.dexdrip.UtilityModels.Pref;
+import com.eveningoutpost.dexdrip.xdrip;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+
+public class InsulinManager {
+    private static final String TAG = "InsulinManager";
+    private static ArrayList<Insulin> profiles;
+    private static Insulin basalProfile, bolusProfile;
+
+    class insulinDataWrapper {
+        public ArrayList<insulinData> profiles;
+
+        insulinDataWrapper() {
+            profiles = new ArrayList<insulinData>();
+        }
+
+        public ArrayList<Insulin> getInsulinProfiles() {
+            if (!checkUniquenessPPN())
+                return null;
+            ArrayList<Insulin> ret = new ArrayList<Insulin>();
+            for (insulinData d : profiles) {
+                Insulin insulin;
+                switch (d.Curve.type.toLowerCase()) {
+                    case "linear trapezoid":
+                        insulin = new LinearTrapezoidInsulin(d.name, d.displayName, d.PPN, d.concentration, d.Curve.data);
+                        Log.d(TAG, "initialized linear trapezoid insulin " + d.displayName);
+                        break;
+                    default:
+                        Log.d(TAG, "UNKNOWN Curve-Type " + d.Curve.type);
+                        return null;
+                }
+                ret.add(insulin);
+            }
+            return ret;
+        }
+
+        private Boolean checkUniquenessPPN() {
+            Log.d(TAG, "checking for uniqueness");
+            ArrayList<String> PPNs = new ArrayList<String>();
+            for (insulinData d : profiles)
+                for (String ppn : d.PPN)
+                    if (PPNs.contains(ppn)) {
+                        Log.d(TAG, "pharmacy product number dupplicated " + ppn + ". that's not allowed!");
+                        return false;
+                    } else PPNs.add(ppn);
+            Log.d(TAG, "pharmacy product numbers uniquee");
+            return true;
+        }
+    }
+
+    class insulinCurve {
+        public String type;
+        public JsonObject data;
+    }
+
+    class insulinData {
+        public String displayName;
+        public String name;
+        public ArrayList<String> PPN;
+        public String concentration;
+        public insulinCurve Curve;
+    }
+
+    private static String readTextFile(InputStream inputStream) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        if (inputStream != null) {
+            byte buf[] = new byte[1024];
+            int len;
+            try {
+                while ((len = inputStream.read(buf)) != -1) {
+                    outputStream.write(buf, 0, len);
+                }
+                outputStream.close();
+                inputStream.close();
+            } catch (IOException e) {
+
+            }
+        }
+        return outputStream.toString();
+    }
+
+    private static void initializeInsulinManager(InputStream in_s) {
+        Log.d(TAG, "Initialize insulin profiles");
+        insulinDataWrapper iDW;
+        try {
+            String input = readTextFile(in_s);
+            Gson gson = new Gson();
+            iDW = gson.fromJson(input, insulinDataWrapper.class);
+            profiles = iDW.getInsulinProfiles();
+            Log.d(TAG, "Loaded Insulin Profiles: " + Integer.toString(profiles.size()));
+            LoadDisabledProfilesFromPrefs();
+            Log.d(TAG, "InsulinManager initialized from config file and Prefs");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Log.d(TAG, "Got exception during insulin load: " + e.toString());
+        }
+    }
+
+    private static void checkInitialized() {
+        if (profiles == null) {
+            getDefaultInstance();
+        }
+    }
+
+    // populate the data set with predefined resource as otherwise the static reference could be lost
+    // as we are not really safely handling it
+    public static ArrayList<Insulin> getDefaultInstance() {
+        return getInstance(xdrip.getAppContext().getResources().openRawResource(R.raw.insulin_profiles));
+    }
+
+    // before this can be public, the issue of what to do if profiles is null needs to be resolved.
+    private static ArrayList<Insulin> getInstance(InputStream in_s) {
+        initializeInsulinManager(in_s);
+        return profiles;
+    }
+
+    public static Insulin getBasalProfile() {
+        return basalProfile;
+    }
+
+    public static void setBasalProfile(Insulin p) {
+        basalProfile = p;
+    }
+
+    public static Insulin getBolusProfile() {
+        checkInitialized();
+        return bolusProfile;
+    }
+
+    public static void setBolusProfile(Insulin p) {
+        bolusProfile = p;
+    }
+
+    public static ArrayList<Insulin> getAllProfiles() {
+        return profiles;
+    }
+
+    public static Insulin getProfile(int i) {
+        checkInitialized();
+        if (profiles == null) {
+            Log.d(TAG, "InsulinManager seems not load Profiles beforehand");
+            return null;
+        }
+        ArrayList<Insulin> t = new ArrayList<Insulin>();
+        for (Insulin ins : profiles)
+            if (isProfileEnabled(ins))
+                t.add(ins);
+        if (i >= t.size())
+            return null;
+        return t.get(i);
+    }
+
+    public static Insulin getProfile(String name) {
+        checkInitialized();
+        if (profiles == null) {
+            Log.d(TAG, "InsulinManager seems not load Profiles beforehand");
+            return null;
+        }
+        name = name.toLowerCase();
+        // TODO consider hashmap maybe? how many could be iterated here?
+        for (Insulin i : profiles) {
+            if (i.getName().toLowerCase().equals(name))
+                return i;
+        }
+        return null;
+    }
+
+    public static long getMaxEffect(Boolean enabled) {
+        checkInitialized();
+        long max = 0;
+        for (Insulin i : profiles)
+            if (!enabled || i.isEnabled())
+                if (max < i.getMaxEffect())
+                    max = i.getMaxEffect();
+        return max;
+    }
+
+    public static Boolean isProfileEnabled(Insulin i) {
+        return i.isEnabled();
+    }
+
+    public static void disableProfile(Insulin i) {
+        if (isProfileEnabled(i) && (countEnabledProfiles() > 1))
+            i.disable();
+    }
+
+    public static void enableProfile(Insulin i) {
+        if (!isProfileEnabled(i) && (countEnabledProfiles() < 3))
+            i.enable();
+    }
+
+    private static int countEnabledProfiles() {
+        checkInitialized();
+        int ret = 0;
+        for (Insulin ins : profiles)
+            if (isProfileEnabled(ins))
+                ret++;
+        return ret;
+    }
+
+    public static void LoadDisabledProfilesFromPrefs() {
+        checkInitialized();
+        for (Insulin i : profiles)
+            i.enable();
+        String json = Pref.getString("saved_disabled_insulinprofiles_json", "[]");
+        Log.d(TAG, "Loaded disabled Insulin Profiles from Prefs: " + json);
+        String[] disabled = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create().fromJson(json, String[].class);
+        for (String d : disabled) {
+            Insulin ins = getProfile(d);
+            if (ins != null)
+                disableProfile(ins);
+        }
+        String prof = Pref.getString("saved_basal_insulinprofiles", "");
+        Log.d(TAG, "Loaded basal Insulin Profiles from Prefs: " + prof);
+        basalProfile = getProfile(prof);
+        if (basalProfile == null)
+            basalProfile = profiles.get(0);
+        prof = Pref.getString("saved_bolus_insulinprofiles", "");
+        Log.d(TAG, "Loaded bolus Insulin Profiles from Prefs: " + prof);
+        bolusProfile = getProfile(prof);
+        if (bolusProfile == null)
+            bolusProfile = profiles.get(0);
+    }
+
+    public static void saveDisabledProfilesToPrefs() {
+        checkInitialized();
+        ArrayList<String> disabled = new ArrayList<String>();
+        for (Insulin i : profiles)
+            if (!isProfileEnabled(i))
+                disabled.add(i.getName());
+        String json = new GsonBuilder().create().toJson(disabled);
+        Pref.setString("saved_disabled_insulinprofiles_json", json);
+        Log.d(TAG, "saved disabled Insulin Profiles to Prefs: " + json);
+        if (basalProfile != null) {
+            Pref.setString("saved_basal_insulinprofiles", basalProfile.getName());
+            Log.d(TAG, "saved basal Insulin Profiles to Prefs: " + basalProfile.getName());
+        }
+        if (bolusProfile != null) {
+            Pref.setString("saved_bolus_insulinprofiles", bolusProfile.getName());
+            Log.d(TAG, "saved bolus Insulin Profiles to Prefs: " + bolusProfile.getName());
+        }
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinProfileEditor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinProfileEditor.java
@@ -1,0 +1,152 @@
+package com.eveningoutpost.dexdrip.insulin;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.Spinner;
+
+import com.eveningoutpost.dexdrip.BaseAppCompatActivity;
+import com.eveningoutpost.dexdrip.R;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Created by gruoner on 28/07/2019.
+ */
+
+public class InsulinProfileEditor extends BaseAppCompatActivity {
+
+    private static final String TAG = "insulinprofileeditor";
+
+    // TODO are these buttons actually used?
+    private Button cancelBtn;
+    private Button saveBtn;
+    private Button undoBtn;
+    private LinearLayout linearLayout;
+    private Spinner basalSpinner, bolusSpinner;
+    private HashMap<Insulin, CheckBox> checkboxes;
+    private HashMap<String, Insulin> profiles;
+
+    //private Context mContext;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        //mContext = this;
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_insulinprofile_editor);
+
+        checkboxes = new HashMap<Insulin, CheckBox>();
+        profiles = new HashMap<>();
+
+        undoBtn = (Button) findViewById(R.id.profileUndoBtn);
+        saveBtn = (Button) findViewById(R.id.profileSaveBtn);
+        cancelBtn = (Button) findViewById(R.id.profileCancelbtn);
+        linearLayout = (LinearLayout) findViewById(R.id.profile_layout_view);
+        basalSpinner = (Spinner) findViewById(R.id.basalSpinner);
+        bolusSpinner = (Spinner) findViewById(R.id.bolusSpinner);
+
+        for (Insulin i : InsulinManager.getAllProfiles()) {
+            LinearLayout v = new LinearLayout(this);
+            v.setOrientation(LinearLayout.HORIZONTAL);
+            CheckBox cb = new CheckBox(this);
+            if (InsulinManager.isProfileEnabled(i))
+                cb.setChecked(true);
+            else
+                cb.setChecked(false);
+            cb.setText(i.getDisplayName());
+            cb.setTextSize(20);
+            checkboxes.put(i, cb);
+            cb.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (InsulinManager.isProfileEnabled(i))
+                        InsulinManager.disableProfile(i);
+                    else
+                        InsulinManager.enableProfile(i);
+                    if (InsulinManager.isProfileEnabled(i))
+                        cb.setChecked(true);
+                    else
+                        cb.setChecked(false);
+                }
+            });
+            v.addView(cb);
+            linearLayout.addView(v);
+            profiles.put(i.getDisplayName(), i);
+        }
+        ArrayList<String> p = new ArrayList<String>(profiles.keySet());
+        ArrayAdapter<String> profilesAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, p);
+        profilesAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        basalSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                InsulinManager.setBasalProfile(profiles.get(adapterView.getItemAtPosition(i)));
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+
+            }
+        });
+        basalSpinner.setAdapter(profilesAdapter);
+        bolusSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                InsulinManager.setBolusProfile(profiles.get(adapterView.getItemAtPosition(i)));
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+
+            }
+        });
+        bolusSpinner.setAdapter(profilesAdapter);
+        final String basal = InsulinManager.getBasalProfile().getDisplayName();
+        final String bolus = InsulinManager.getBolusProfile().getDisplayName();
+        for (int i = 0; i < p.size(); i++) {
+            if (p.get(i).equals(basal))
+                basalSpinner.setSelection(i);
+            if (p.get(i).equals(bolus))
+                bolusSpinner.setSelection(i);
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+    }
+
+    public void profileCancelButton(View myview) {
+        InsulinManager.LoadDisabledProfilesFromPrefs();
+        finish();
+    }
+
+    public void profileSaveButton(View myview) {
+        InsulinManager.saveDisabledProfilesToPrefs();
+        finish();
+    }
+
+    public void profileUndoButton(View myview) {
+        InsulinManager.LoadDisabledProfilesFromPrefs();
+        for (Insulin i : InsulinManager.getAllProfiles())
+            if (InsulinManager.isProfileEnabled(i))
+                checkboxes.get(i).setChecked(true);
+            else
+                checkboxes.get(i).setChecked(false);
+
+        ArrayList<String> p = new ArrayList<String>(profiles.keySet());
+        final String basal = InsulinManager.getBasalProfile().getDisplayName();
+        final String bolus = InsulinManager.getBolusProfile().getDisplayName();
+        for (int i = 0; i < p.size(); i++) {
+            if (p.get(i).equals(basal))
+                basalSpinner.setSelection(i);
+            if (p.get(i).equals(bolus))
+                bolusSpinner.setSelection(i);
+        }
+    }
+}
+

--- a/app/src/main/java/com/eveningoutpost/dexdrip/insulin/LinearTrapezoidInsulin.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/insulin/LinearTrapezoidInsulin.java
@@ -1,0 +1,56 @@
+package com.eveningoutpost.dexdrip.insulin;
+
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+
+public class LinearTrapezoidInsulin extends Insulin {
+    /// curvedata and all timestamps are defined in minutes
+    private long onset;  // when does profile activity starts
+    private long t1;     // when does activity reaches max
+    private long t2;     // when does activity leaves max
+    private long t3;     // when does activity ends
+
+    private double max;
+
+    public LinearTrapezoidInsulin(String n, String dn, ArrayList<String> ppn, String c, JsonObject curveData) {
+        super(n, dn, ppn, c, curveData);
+
+        onset = curveData.get("onset").getAsLong();
+        if (curveData.get("peak").getAsString().contains("-")) {
+            t1 = Integer.parseInt(curveData.get("peak").getAsString().split("-")[0]);
+            t2 = Integer.parseInt(curveData.get("peak").getAsString().split("-")[1]);
+        } else {
+            t1 = Integer.parseInt(curveData.get("peak").getAsString());
+            t2 = t1;
+        }
+        t3 = curveData.get("duration").getAsLong();
+
+        max = 2.0 / (t2 - t1 + t3);
+        maxEffect = t3;
+    }
+
+    public double calculateIOB(double t) {
+        double time = t - onset;
+        if ((0 <= time) && (time < t1))
+            return 1.0 - time * time * max / (2 * t1);
+        else if ((t1 <= time) && (time < t2))
+            return 1.0 + 0.5 * max * t1 - max * time;
+        else if ((t2 <= time) && (time < t3))
+            return 0.5 * (time - t3) * (time - t3) * max / (t3 - t2);
+        else return 0;
+    }
+
+    public double calculateActivity(double t) {
+        double time = t - onset;
+        if ((0 <= time) && (time < t1))
+            return concentration * time * max / t2;
+        else if ((t1 <= time) && (time < t2))
+            return concentration * max;
+        else if ((t2 <= time) && (time < t3))
+            return concentration * (time - t3) * max / (t3 - t2);
+        else return 0;
+    }
+
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/insulin/MultipleInsulins.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/insulin/MultipleInsulins.java
@@ -1,0 +1,15 @@
+package com.eveningoutpost.dexdrip.insulin;
+
+import com.eveningoutpost.dexdrip.UtilityModels.Pref;
+
+public class MultipleInsulins {
+
+    public static boolean isEnabled() {
+        return Pref.getBooleanDefaultFalse("multiple_insulin_types");
+    }
+
+    public static boolean useBasalActivity() {
+        return Pref.getBooleanDefaultFalse("multiple_insulin_use_basal_activity");
+    }
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/EBolus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/EBolus.java
@@ -33,7 +33,8 @@ public class EBolus extends BaseElement {
         UserError.Log.e(TAG, "Ignoring invalid treatment " + treatment.toS());
         return false;
     }
-    
+
+    //todo grt: change EBolus Treatment to ArrayList<InsulinInjection> when tidepool may support that
     public static EBolus fromTreatment(Treatments treatment) {
         if(!IsBolusValid(treatment)) {
           return null;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/EWizard.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/EWizard.java
@@ -40,6 +40,7 @@ public class EWizard extends BaseElement {
         return true;
     }
 
+    // todo grt: change EBolus to ArrayList<InsulinInjection> when tidepool may support that
     public static EWizard fromTreatment(final Treatments treatment) {
         if(!IsEWizardValid(treatment)) {
             return null;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -695,7 +695,7 @@ public class WatchUpdaterService extends WearableListenerService implements
         }
     }
 
-    public static void sendTreatment(double carbs, double insulin, double bloodtest, double timeoffset, String timestring) {
+    public static void sendTreatment(double carbs, double insulin, double bloodtest, String injectionJSON, double timeoffset, String timestring) {
         if ((googleApiClient != null) && (googleApiClient.isConnected())) {
             PutDataMapRequest dataMapRequest = PutDataMapRequest.create(WEARABLE_TREATMENT_PAYLOAD);
             //unique content
@@ -706,6 +706,7 @@ public class WatchUpdaterService extends WearableListenerService implements
             dataMapRequest.getDataMap().putDouble("bloodtest", bloodtest);
             dataMapRequest.getDataMap().putDouble("timeoffset", timeoffset);
             dataMapRequest.getDataMap().putString("timestring", timestring);
+            dataMapRequest.getDataMap().putString("injectionJSON", injectionJSON);
             dataMapRequest.getDataMap().putBoolean("ismgdl", doMgdl(PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext())));
             PutDataRequest putDataRequest = dataMapRequest.asPutDataRequest();
             Wearable.DataApi.putDataItem(googleApiClient, putDataRequest);

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -187,19 +187,18 @@
                     android:id="@+id/btnTreatment"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_alignEnd="@+id/layoutCurrentBgValueRealTime"
                     android:layout_below="@+id/layoutCurrentBgValueRealTime"
-                    android:layout_marginBottom="1dp"
-                    android:layout_marginRight="6dp"
+                    android:layout_alignEnd="@+id/layoutCurrentBgValueRealTime"
                     android:layout_marginTop="1dp"
+                    android:layout_marginRight="6dp"
                     android:background="@android:color/transparent"
                     android:contentDescription="@string/speaktreatment"
                     android:gravity="right"
                     android:nestedScrollingEnabled="false"
-                    android:paddingBottom="1dp"
                     android:paddingLeft="2dp"
-                    android:paddingRight="4dp"
                     android:paddingTop="2dp"
+                    android:paddingRight="4dp"
+                    android:paddingBottom="1dp"
                     android:src="@drawable/ic_eyedropper_variant_grey600_24dp" />
 
                 <ImageButton
@@ -338,24 +337,90 @@
                     android:textStyle="bold" />
 
                 <ImageButton
-                    android:id="@+id/buttonInsulin"
+                    android:id="@+id/buttonInsulin0"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_alignStart="@+id/buttonCarbs"
-                    android:layout_below="@+id/buttonCarbs"
+                    android:layout_below="@+id/textCarbohydrate"
+                    android:layout_alignLeft="@+id/buttonCarbs"
                     android:src="@drawable/ic_colorize_white_48dp" />
 
+
                 <TextView
-                    android:id="@+id/textInsulinUnits"
+                    android:id="@+id/textInsulinSumUnits"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_alignBottom="@+id/buttonInsulin"
-                    android:layout_marginBottom="12dp"
-                    android:layout_toEndOf="@+id/buttonInsulin"
+                    android:layout_below="@+id/textCarbohydrate"
+                    android:layout_alignLeft="@+id/textCarbohydrate"
                     android:background="@android:color/transparent"
                     android:text="14 units"
                     android:textColor="@android:color/holo_green_light"
                     android:textSize="22dp"
+                    android:textStyle="bold" />
+
+                <ImageButton
+                    android:id="@+id/buttonInsulin1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/textInsulinSumUnits"
+                    android:layout_alignLeft="@+id/buttonCarbs"
+                    android:src="@drawable/ic_colorize_white_48dp" />
+
+                <TextView
+                    android:id="@+id/textInsulin1Units"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignBottom="@+id/buttonInsulin1"
+                    android:layout_marginStart="0dp"
+                    android:layout_marginBottom="12dp"
+                    android:layout_toEndOf="@+id/buttonInsulin1"
+                    android:background="@android:color/transparent"
+                    android:text="14 units"
+                    android:textColor="@android:color/holo_green_light"
+                    android:textSize="18dp"
+                    android:textStyle="bold" />
+
+                <ImageButton
+                    android:id="@+id/buttonInsulin2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/buttonInsulin1"
+                    android:layout_alignLeft="@+id/buttonInsulin1"
+                    android:src="@drawable/ic_colorize_white_48dp" />
+
+                <TextView
+                    android:id="@+id/textInsulin2Units"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignBottom="@+id/buttonInsulin2"
+                    android:layout_marginStart="0dp"
+                    android:layout_marginBottom="12dp"
+                    android:layout_toEndOf="@+id/buttonInsulin2"
+                    android:background="@android:color/transparent"
+                    android:text="14 units"
+                    android:textColor="@android:color/holo_green_light"
+                    android:textSize="18dp"
+                    android:textStyle="bold" />
+
+                <ImageButton
+                    android:id="@+id/buttonInsulin3"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/buttonInsulin2"
+                    android:layout_alignLeft="@+id/buttonInsulin2"
+                    android:src="@drawable/ic_colorize_white_48dp" />
+
+                <TextView
+                    android:id="@+id/textInsulin3Units"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignBottom="@+id/buttonInsulin3"
+                    android:layout_marginStart="0dp"
+                    android:layout_marginBottom="12dp"
+                    android:layout_toEndOf="@+id/buttonInsulin3"
+                    android:background="@android:color/transparent"
+                    android:text="14 units"
+                    android:textColor="@android:color/holo_green_light"
+                    android:textSize="18dp"
                     android:textStyle="bold" />
 
                 <ImageButton

--- a/app/src/main/res/layout/activity_insulinprofile_editor.xml
+++ b/app/src/main/res/layout/activity_insulinprofile_editor.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        android:fillViewport="false"
+        tools:context=".insulin.InsulinProfileEditor">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:weightSum="1"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentStart="true">
+
+            <TextView
+                android:id="@+id/Text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:inputType="textPersonName"
+                android:text="@string/pref_enable_insulinprofiles"
+                android:textSize="18sp" />
+
+            <LinearLayout
+                android:id="@+id/profile_layout_view"
+                android:layout_width="match_parent"
+                android:layout_height="230dp"
+                android:layout_gravity="top"
+                android:layout_weight="1"
+                android:fadeScrollbars="false"
+                android:orientation="vertical"
+                android:scrollbars="vertical"></LinearLayout>
+
+            <TextView
+                android:id="@+id/Text2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:scrollHorizontally="false"
+                android:text="@string/pref_select_basal_insulinprofiles"
+                android:textSize="18sp" />
+
+            <Spinner
+                android:id="@+id/basalSpinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:prompt="@string/pref_select_basal_insulinprofiles" />
+
+            <TextView
+                android:id="@+id/Text3"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:scrollHorizontally="false"
+                android:text="@string/pref_select_bolus_insulinprofiles"
+                android:textSize="18sp" />
+
+            <Spinner
+                android:id="@+id/bolusSpinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:prompt="@string/pref_select_bolus_insulinprofiles" />
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="94dp"
+                android:layout_gravity="bottom"
+                android:layout_weight="1"
+                android:gravity="bottom">
+
+                <Button
+                    style="?android:attr/buttonStyleSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="32dp"
+                    android:text="@string/cancel"
+                    android:id="@+id/profileCancelbtn"
+                    android:onClick="profileCancelButton"
+                    android:layout_alignParentBottom="true"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignTop="@+id/profileUndoBtn" />
+
+                <Button
+                    style="?android:attr/buttonStyleSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/save"
+                    android:id="@+id/profileSaveBtn"
+                    android:layout_alignParentBottom="true"
+                    android:layout_alignParentEnd="true"
+                    android:layout_alignTop="@+id/profileUndoBtn"
+                    android:onClick="profileSaveButton" />
+
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/reset"
+                    android:id="@+id/profileUndoBtn"
+                    android:layout_alignParentBottom="true"
+                    android:layout_toEndOf="@+id/profileCancelbtn"
+                    android:onClick="profileUndoButton" />
+            </RelativeLayout>
+        </LinearLayout>
+    </ScrollView>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/keypad_activity_phone.xml
+++ b/app/src/main/res/layout/keypad_activity_phone.xml
@@ -23,7 +23,7 @@
         android:fontFamily="sans-serif-condensed"
         android:gravity="center"
         android:textColor="@android:color/white"
-        android:textSize="25sp"
+        android:textSize="@dimen/keypad_top_text_size"
         tools:text="25.5 mmol/l" />
 
     <LinearLayout

--- a/app/src/main/res/layout/keypad_activity_phone.xml
+++ b/app/src/main/res/layout/keypad_activity_phone.xml
@@ -271,4 +271,41 @@
 
     </TableRow>
 
+    <LinearLayout
+        android:id="@+id/insulinTypesSection"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_weight="0.05"
+        android:visibility="gone"
+        android:gravity="center_horizontal">
+
+        <Button
+            android:id="@+id/multi_button1"
+            style="@style/KeypadButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="special1"
+            android:textSize="12sp" />
+
+        <Button
+            android:id="@+id/multi_button2"
+            style="@style/KeypadButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="special2"
+            android:textSize="12sp" />
+
+        <Button
+            android:id="@+id/multi_button3"
+            style="@style/KeypadButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="special3"
+            android:textSize="12sp" />
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/raw/initiallexicon.txt
+++ b/app/src/main/res/raw/initiallexicon.txt
@@ -33,8 +33,7 @@
 {"lexicon": "long",
     "matchWords":[
         "long",
-        "long acting",
-        "lantus"
+        "long acting"
     ]},
 
 {"lexicon": "carbs",

--- a/app/src/main/res/raw/insulin_profiles.txt
+++ b/app/src/main/res/raw/insulin_profiles.txt
@@ -1,0 +1,138 @@
+{
+  "profiles":
+  [
+    {
+      "name": "FIASP",
+      "displayName": "FIASP (ultra fast acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "FIASP-U100"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "2",
+          "peak": "45",
+          "duration": "300"
+        }
+      }
+    },
+    {
+      "name": "Novorapid",
+      "displayName": "Novorapid (rapid acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "1100558736"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "10",
+          "peak": "75",
+          "duration": "180"
+        }
+      }
+    },
+    {
+      "name": "Humalog",
+      "displayName": "Humalog (rapid acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "Humalog-U100"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "10",
+          "peak": "75",
+          "duration": "180"
+        }
+      }
+    },
+    {
+      "name": "Actrapid",
+      "displayName": "Actrapid (short acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "1102949004"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "30",
+          "peak": "60-240",
+          "duration": "480"
+        }
+      }
+    },
+    {
+      "name": "Insulatard",
+      "displayName": "Insulatard (NPH)",
+      "PPN":
+      [
+        "1105039656"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "60",
+          "peak": "120-720",
+          "duration": "1440"
+        }
+      }
+    },
+    {
+      "name": "Toujeo",
+      "displayName": "Toujeo (long acting)",
+      "PPN":
+      [
+        "ToujeoU100"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "180",
+          "peak": "480",
+          "duration": "2160"
+        }
+      }
+    },
+    {
+      "name": "Lantus",
+      "displayName": "Lantus (long acting)",
+      "PPN":
+      [
+        "LantusU100"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "60",
+          "peak": "420-1200",
+          "duration": "2160"
+        }
+      }
+    }
+  ]
+}

--- a/app/src/main/res/values-de/dimens-de.xml
+++ b/app/src/main/res/values-de/dimens-de.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+<!-- keypad text too large in de locale so reduced here -->
+    <dimen name="keypad_top_text_size">18sp</dimen>
+
+</resources>

--- a/app/src/main/res/values-de/strings-de.xml
+++ b/app/src/main/res/values-de/strings-de.xml
@@ -769,6 +769,8 @@
     <string name="notify_data_arrives_master"><![CDATA[Benachrichtigen, wenn Daten vom Master im Abstand von &gt; 20 Minuten ankommen.]]></string>
     <string name="follower_chime_new">Neuer-Follower-Läuten</string>
     <string name="carb_ratio">Kohlenhydratfaktor</string>
+    <string name="enable_dedicated_insulin_profiles">Verwaltung der Insulin-Präparate</string>
+    <string name="desc_enable_dedicated_insulin_profiles">Hiermit können Sie die verschiedenen Insulin-Präparate aktivieren oder konfigurieren</string>
     <string name="insulin_sensitivity">Insulin-Empfindlichkeit</string>
     <string name="secondary_plugin_glucose_value">Glukosewert des sekundären Plugins</string>
     <string name="step_counter_1st_color">Schrittzähler 1. Farbe</string>
@@ -1135,4 +1137,7 @@
     <string name="need_contacts_permission_to_select_message_recipients">Benötige Kontakte-Berechtigung um Nachrichtenempfänger auswählen zu können</string>
     <string name="need_storage_permission_to_access_all_ringtones">Benötige Speichermedium-Berechtigung um auf alle Klingeltöne zugreifen zu können</string>
     <string name="xdrip_needs_whitelisting_for_proper_performance">xDrip+ benötigt die Eintragung auf der \"Withelist\" damit es gut funktioniert</string>
+    <string name="pref_enable_insulinprofiles">Aktiviere mind. ein maximal drei Insulin Profile</string>
+    <string name="pref_select_basal_insulinprofiles">Wähle das basale Insulin aus.</string>
+    <string name="pref_select_bolus_insulinprofiles">wähle das Bolus-Insulin aus.\nAuch verwendet für z.B. Pumpe, Pen...</string>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -16,4 +16,6 @@ http://developer.android.com/guide/topics/appwidgets/index.html#CreatingLayout
     -->
     <dimen name="widget_margin">8dp</dimen>
 
+    <dimen name="keypad_top_text_size">25sp</dimen>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -803,6 +803,8 @@
     <string name="notify_data_arrives_master"><![CDATA[Notify when data arrives from the master if the interval is > 20 mins.]]></string>
     <string name="follower_chime_new">Follower Chime New</string>
     <string name="carb_ratio">Carb Ratio</string>
+    <string name="enable_dedicated_insulin_profiles">Config Insulin profiles</string>
+    <string name="desc_enable_dedicated_insulin_profiles">Here one can enable or configure various insulin profiles</string>
     <string name="insulin_sensitivity">Insulin Sensitivity</string>
     <string name="secondary_plugin_glucose_value">Secondary Plugin Glucose value</string>
     <string name="step_counter_1st_color">Step counter 1st Color</string>
@@ -1521,4 +1523,7 @@
     <string name="collection_summary_ob1_g5_preemptive_restart">Automatically restart a sensor before it stops</string>
     <string name="title_ob1_g5_preemptive_restart_alert">Alert on preemptive restart</string>
     <string name="summary_ob1_g5_preemptive_restart_alert">Raise an alert when preemptively restarting the session</string>
+    <string name="pref_enable_insulinprofiles">enable at least one max three profiles</string>
+    <string name="pref_select_basal_insulinprofiles">choose basal insulin profile.</string>
+    <string name="pref_select_bolus_insulinprofiles">choose bolus insulin profile. also used for pump and pen...</string>
 </resources>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -600,6 +600,35 @@
                 android:switchTextOn="@string/short_on_text_for_switches"
                 android:title="@string/predictive_simulations" />
 
+            <PreferenceScreen
+                android:title="Multiple Insulin Types"
+                android:summary="Options for working with multiple insulin types">
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:key="multiple_insulin_types"
+                    android:switchTextOff="@string/short_off_text_for_switches"
+                    android:switchTextOn="@string/short_on_text_for_switches"
+                    android:title="Multiple Insulin Types" />
+            <Preference
+                android:key="insulin_profiles"
+                android:dependency="multiple_insulin_types"
+                android:summary="@string/desc_enable_dedicated_insulin_profiles"
+                android:title="@string/enable_dedicated_insulin_profiles">
+                <intent
+                    android:action="android.intent.action.MAIN"
+                    android:targetClass="com.eveningoutpost.dexdrip.insulin.InsulinProfileEditor"
+                    android:targetPackage="@string/local_target_package" />
+            </Preference>
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="multiple_insulin_use_basal_activity"
+                    android:summary="Plot Basal activity on graph and incorporate in predictive model"
+                    android:title="Use Basal Activity"/>
+
+            </PreferenceScreen>
+
+
             <Preference
                 android:key="profile_carb_ratio_default"
                 android:summary="@string/grams_of_carbohydrate_one_unit_covers"
@@ -609,6 +638,7 @@
                     android:targetClass="com.eveningoutpost.dexdrip.profileeditor.ProfileEditor"
                     android:targetPackage="@string/local_target_package" />
             </Preference>
+
             <Preference
                 android:key="profile_insulin_sensitivity_default"
                 android:summary="@string/glucose_drop_for_one_unit"

--- a/app/src/test/java/com/eveningoutpost/dexdrip/Models/TreatmentsSyncTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/Models/TreatmentsSyncTest.java
@@ -1,0 +1,69 @@
+package com.eveningoutpost.dexdrip.Models;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TreatmentsSyncTest extends RobolectricTestWithConfig {
+
+    public class TreatmentsCompat {
+        @Expose
+        public long timestamp;
+        @Expose
+        public String eventType;
+        @Expose
+        public String enteredBy;
+        @Expose
+        public String notes;
+        @Expose
+        public String uuid;
+        @Expose
+        public double carbs;
+        @Expose
+        public double insulin;
+        @Expose
+        public String created_at;
+    }
+
+    // if this test fails then compatibility with previous xDrip versions is likely broken
+    @Test
+    public void syncCompatibilityTest() {
+        // :: Create
+        long time = Instant.now().getEpochSecond();
+        Treatments.create(55, 2, time);
+
+        // :: Read
+        Treatments lastTreatment = Treatments.last();
+        lastTreatment.notes = "Hello World";
+
+        // :: Verify
+        assertThat(lastTreatment.carbs).isEqualTo(55.0);
+        assertThat(lastTreatment.insulin).isEqualTo(2.0);
+        assertThat(lastTreatment.timestamp).isEqualTo(time);
+        assertThat(lastTreatment.enteredBy).startsWith(Treatments.XDRIP_TAG);
+
+        final String json = lastTreatment.toJSON();
+
+
+        //System.out.println(json);
+
+        assertThat(json).isNotEmpty();
+        assertThat(json.length()).isLessThan(256);
+        final TreatmentsCompat compat = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create().fromJson(json, TreatmentsCompat.class);
+        assertThat(compat.timestamp).isEqualTo(lastTreatment.timestamp);
+        assertThat(compat.enteredBy).isEqualTo(lastTreatment.enteredBy);
+        assertThat(compat.notes).isEqualTo(lastTreatment.notes);
+        assertThat(compat.uuid).isEqualTo(lastTreatment.uuid);
+        assertThat(compat.carbs).isEqualTo(lastTreatment.carbs);
+        assertThat(compat.insulin).isEqualTo(lastTreatment.insulin);
+
+
+    }
+
+}

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Simulation.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Simulation.java
@@ -193,6 +193,7 @@ public class Simulation extends Activity {
                 try {
                     Bundle treatmentBundle = intent.getBundleExtra(ListenerService.WEARABLE_TREATMENT_PAYLOAD);
                     if (treatmentBundle != null) {
+// todo gruoner: extract the injectionJSON on wearable to display and approve the treatment
                         DataMap dataMap = DataMap.fromBundle(treatmentBundle);
                         if (dataMap != null) {
                             initValues();


### PR DESCRIPTION
This is a PR for review and discussion. It builds upon the good work by @gruoner and @k2s 

What I have done here is take the contents of https://github.com/NightscoutFoundation/xDrip/pull/973 as an unmerged working set so I can see the changes clearly within the editor and then reworked it to better meet xDrip design goals.

The changes to notice are something like as follows:

- Maintain database compatibility with previous versions of xDrip. Users can still upgrade and downgrade at will without data loss. Of course downgrading to a version prior to support of this feature will result in all insulin entries being recorded just as the sum value.

- Maintain sync compatibility with different versions of xDrip acting as followers etc.

- Maintain app behavior for existing users - Multiple Insulins feature is a preference option that once enabled changes the UI and prediction simulation behavior. If the feature is not enabled everything in a new version with this feature remains identical to that which users are already using.

- Extra signatures within `Treatments` class so that previous code to create default bolus insulin treatments is preserved and so that behavior is encapsulated within the `Treatments` class to keep the interface consistent and avoid duplicating code in classes which access it.

- Lazy population of data and caching. Significantly improves the performance by avoiding repeated gson calls that utilize reflection. In benchmarking this increased performance by 100x but I don't know how accurate that is for anything more than a test data set.

- UI changes in `Home` class:  Basal doses are shown with a blue syringe icon, tapping on the icon details the basal dose. Similar textual information is given when tapping on other treatments containing multiple insulin doses.

- Predictive simulation can include Basal doses or not. I question the logic of including, for example, lantus doses in the simulation as although these will have an effect at different times of the day (as I don't believe lantus advertised flat profile) - the simulation model doesn't take in to consideration the natural rise in blood sugar that basal insulin is for so the simulation should only be displaying the net value of this and I don't think we have any calculations for that at all. This would be for future work I think, but users are given the choice with the preference option (defaults to off)

Including basal in the simulation also significantly increases the calculation complexity due to the size of the look-ahead/back that occurs. I haven't optimized this but it might be sensible to do. There are variables like `useBasal` that can be used to insert conditional logic which could affect the look-ahead/back window size.

Also in UI changes (vs the previous PR) this allows for individual doses to be applied. The xDrip keypad interface wraps the voice interface and so it is important that users can approve only parts of the treatment if they reconsider or if voice recognition misinterprets part of it. With multiple insulin entries this could also allow a user to "tick off" as they do each injection if they are doing multiple injections at the same moment in time.  The + icon approves all and this is consistent with the existing UI behavior. When the multiple insulins feature is switched off then the UI should revert to exactly how it was before this PR.

This PR also reverts the `TreatmentTest` to as they were and adds new tests for the additional method signatures which support multiple insulins. I also have added a `TreatmentsSyncTest` class to make it clear about compatibility issues that can occur if field names are changed.

Where do we go from here?

It would be great if this version of the PR can be tested to make sure that it still works correctly to support multiple insulins. I have done limited local tests but I'm outside of the use cases that this feature was designed for. It is possible I have missed or broken something. Please let me know if this seems good?

If you're happy with this PR then I can merge it to nightly. If having author attribution in the commit history is very important to the original authors then I can replay the change set but I think there may be merge conflicts and I also had to undo some of the changes so it would be cleaner to do it directly from this PR.  

