### PR TITLE
 Improved the collapsed notifications layout for enlarge BG graph

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -24,6 +24,7 @@ import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.text.SpannableString;
+import android.widget.RemoteViews;
 
 import com.eveningoutpost.dexdrip.AddCalibration;
 import com.eveningoutpost.dexdrip.BestGlucose;
@@ -614,7 +615,7 @@ public class Notifications extends IntentService {
                 .setSmallIcon(R.drawable.ic_action_communication_invert_colors_on)
                 .setUsesChronometer(false);
 
-        boolean setLargeIcon = false;
+        Bitmap numberIcon = null;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             // in case the graphic crashes the system-ui we wont do it immediately after reboot so the
@@ -630,21 +631,11 @@ public class Notifications extends IntentService {
 
                 if (NumberGraphic.largeWithArrowEnabled()) {
                     if ((dg != null) && (!dg.isStale())) {
-                        final Bitmap icon_bitmap = NumberGraphic.getLargeWithArrowBitmap(dg.unitized, dg.delta_arrow);
-                        //if (icon_bitmap != null) b.setSmallIcon(Icon.createWithBitmap(icon_bitmap));
-                        if (icon_bitmap != null) {
-                            b.setLargeIcon(Icon.createWithBitmap(icon_bitmap));
-                            setLargeIcon = true;
-                        }
+                        numberIcon = NumberGraphic.getLargeWithArrowBitmap(dg.unitized, dg.delta_arrow);
                     }
                 } else if (NumberGraphic.largeNumberIconEnabled()) {
                     if ((dg != null) && (!dg.isStale())) {
-                        final Bitmap icon_bitmap = NumberGraphic.getLargeIconBitmap(dg.unitized);
-                        //if (icon_bitmap != null) b.setSmallIcon(Icon.createWithBitmap(icon_bitmap));
-                        if (icon_bitmap != null) {
-                            b.setLargeIcon(Icon.createWithBitmap(icon_bitmap));
-                            setLargeIcon = true;
-                        }
+                        numberIcon = NumberGraphic.getLargeIconBitmap(dg.unitized);
                     }
                 }
             }
@@ -657,15 +648,7 @@ public class Notifications extends IntentService {
                     : bgGraphBuilder.unitizedDeltaString(true, true)));
 
             b.setContentText(deltaString);
-            iconBitmap = new BgSparklineBuilder(mContext)
-                    .setHeight(64)
-                    .setWidth(64)
-                    .setStart(System.currentTimeMillis() - 60000 * 60 * 3)
-                    .setBgGraphBuilder(bgGraphBuilder)
-                    .setBackgroundColor(getCol(X.color_notification_chart_background))
-                    .build();
-            if (!setLargeIcon) b.setLargeIcon(iconBitmap);
-            Notification.BigPictureStyle bigPictureStyle = new Notification.BigPictureStyle();
+
             notifiationBitmap = new BgSparklineBuilder(mContext)
                     .setBgGraphBuilder(bgGraphBuilder)
                     .showHighLine()
@@ -675,12 +658,50 @@ public class Notifications extends IntentService {
                     .setBackgroundColor(getCol(X.color_notification_chart_background))
                     .setShowFiltered(DexCollectionType.hasFiltered() && Pref.getBooleanDefaultFalse("show_filtered_curve"))
                     .build();
-            bigPictureStyle.bigPicture(notifiationBitmap)
-                    .setSummaryText(deltaString)
-                    .setBigContentTitle(titleString);
-            b.setStyle(bigPictureStyle);
 
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                Notification.DecoratedCustomViewStyle customViewStyle = new Notification.DecoratedCustomViewStyle();
+
+                iconBitmap = numberIcon != null ? numberIcon : new BgSparklineBuilder(mContext)
+                        .setHeight(64)
+                        .showLowLine()
+                        .showHighLine()
+                        .setStart(System.currentTimeMillis() - 60000 * 60 * 3)
+                        .setBgGraphBuilder(bgGraphBuilder)
+                        .setBackgroundColor(getCol(X.color_notification_chart_background))
+                        .build();
+
+                RemoteViews collapsedViews = new RemoteViews(context.getPackageName(), R.layout.notification_bg_collapsed);
+                collapsedViews.setImageViewBitmap(R.id.notification_image, iconBitmap);
+                collapsedViews.setTextViewText(R.id.notification_title, titleString);
+                collapsedViews.setTextViewText(R.id.notification_summary, deltaString);
+
+                RemoteViews expandedViews = new RemoteViews(context.getPackageName(), R.layout.notification_bg_expanded);
+                expandedViews.setImageViewBitmap(R.id.notification_image, notifiationBitmap);
+                expandedViews.setTextViewText(R.id.notification_title, titleString);
+                expandedViews.setTextViewText(R.id.notification_summary, deltaString);
+
+                b.setStyle(customViewStyle)
+                        .setCustomContentView(collapsedViews)
+                        .setCustomBigContentView(expandedViews);
+            } else {
+                iconBitmap = numberIcon != null ? numberIcon : new BgSparklineBuilder(mContext)
+                        .setHeight(64)
+                        .setWidth(64)
+                        .setStart(System.currentTimeMillis() - 60000 * 60 * 3)
+                        .setBgGraphBuilder(bgGraphBuilder)
+                        .setBackgroundColor(getCol(X.color_notification_chart_background))
+                        .build();
+                b.setLargeIcon(iconBitmap);
+
+                Notification.BigPictureStyle bigPictureStyle = new Notification.BigPictureStyle();
+                bigPictureStyle.bigPicture(notifiationBitmap)
+                        .setSummaryText(deltaString)
+                        .setBigContentTitle(titleString);
+                b.setStyle(bigPictureStyle);
+            }
         }
+
         b.setContentIntent(resultPendingIntent);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
             b.setLocalOnly(true);

--- a/app/src/main/res/layout/notification_bg_collapsed.xml
+++ b/app/src/main/res/layout/notification_bg_collapsed.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/notification_image"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="0dp"
+        android:adjustViewBounds="true"
+        android:contentDescription="Blood Glucose Graph"
+        android:scaleType="fitEnd" />
+
+    <TextView
+        android:id="@+id/notification_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
+        android:textAppearance="@style/TextAppearance.Compat.Notification.Title" />
+
+    <TextView
+        android:id="@+id/notification_summary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/notification_title"
+        android:layout_alignParentStart="true"
+        android:textAppearance="@style/TextAppearance.Compat.Notification.Media" />
+</RelativeLayout>

--- a/app/src/main/res/layout/notification_bg_expanded.xml
+++ b/app/src/main/res/layout/notification_bg_expanded.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/notification_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.Compat.Notification.Title" />
+
+    <TextView
+        android:id="@+id/notification_summary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.Compat.Notification.Media" />
+
+    <ImageView
+        android:id="@+id/notification_image"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="13dp"
+        android:layout_marginEnd="8dp"
+        android:layout_weight="1"
+        android:adjustViewBounds="true"
+        android:contentDescription="Blood Glucose Graph"
+        android:scaleType="centerCrop" />
+
+</LinearLayout>


### PR DESCRIPTION
Reopen the old pull-request https://github.com/NightscoutFoundation/xDrip/pull/880

[Show BG graph on MIUI LockScreen](https://github.com/NightscoutFoundation/xDrip/issues/879)

What do you think about this solution?
I change collapsed notification layout to enlarge image on it.

Actual(old) layout | New layout
------------------------- | ---------------
![Screenshot from 2019-05-19 20-52-42](https://user-images.githubusercontent.com/8264069/57986018-3081fc00-7a78-11e9-9e9c-a1cd1a9ecb51.png) | ![Screenshot from 2019-05-19 20-51-20](https://user-images.githubusercontent.com/8264069/57986022-3677dd00-7a78-11e9-92a4-4d07ad5a4ddc.png)

Sorry. Looks like I missed the backwards compatibility issue.
DecoratedCustomViewStyle is not supported under API26.
I've fixed it. And renew review patch.
Now on androids under 8.0 will work the same as before

![Screenshot from 2019-09-12 00-50-35](https://user-images.githubusercontent.com/8264069/64738603-51270380-d4f8-11e9-85db-f60d138ac376.png)
I have tested at Android 4.4 emulator. It works as before