### PR TITLE
Fix Android 10 connection issues

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexShareCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexShareCollectionService.java
@@ -418,7 +418,7 @@ public class DexShareCollectionService extends Service {
                 Log.v(TAG, "Device found, already bonded, going to connect");
                if(mBluetoothAdapter.getRemoteDevice(bluetoothDevice.getAddress()) != null) {
                    device = bluetoothDevice;
-                   mBluetoothGatt = device.connectGatt(getApplicationContext(), false, mGattCallback);
+                   mBluetoothGatt = device.connectGatt(getApplicationContext(), true, mGattCallback);
                    return true;
                }
             }
@@ -430,7 +430,7 @@ public class DexShareCollectionService extends Service {
             return false;
         }
         Log.i(TAG, "Trying to create a new connection.");
-        mBluetoothGatt = device.connectGatt(getApplicationContext(), false, mGattCallback);
+        mBluetoothGatt = device.connectGatt(getApplicationContext(), true, mGattCallback);
         mConnectionState = STATE_CONNECTING;
         return true;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5CollectionService.java
@@ -976,7 +976,7 @@ public class G5CollectionService extends G5BaseService {
             waitFor(600);
             Log.e(TAG, "connectGatt() delay completed");
         }
-        mGatt = mDevice.connectGatt(getApplicationContext(), false, gattCallback);
+        mGatt = mDevice.connectGatt(getApplicationContext(), true, gattCallback);
     }
 
 


### PR DESCRIPTION
See #1061.

I read some pages in the android documentation and tried to enable automatic reconnection for BLE devices.
With the changes from this PR my Android 10 phone sucessfully reconnected on its own after being out of range and losing connection.

I can't test for backward compatibility though.

@jamorham 
Why was auto-reconnect disabled in the first place?