### PR TITLE
Allow two versions of xDrip to work simultaneity on the same phone (using the OOP) .

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreOOPAlgorithm.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreOOPAlgorithm.java
@@ -44,6 +44,8 @@ public class LibreOOPAlgorithm {
         bundle.putByteArray(Intents.LIBRE_DATA_BUFFER, fullData);
         bundle.putLong(Intents.LIBRE_DATA_TIMESTAMP, timestamp);
         bundle.putString(Intents.LIBRE_SN, PersistentStore.getString("LibreSN"));
+        bundle.putInt(Intents.LIBRE_RAW_ID, android.os.Process.myPid());
+        
         if(patchUid != null) {
             bundle.putByteArray(Intents.LIBRE_PATCH_UID_BUFFER, patchUid);
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
@@ -102,7 +102,19 @@ public class NSEmulatorReceiver extends BroadcastReceiver {
                                                 final JSONArray json_array = new JSONArray(data);
                                                 // if this array is >1 in length then it is from OOP otherwise something like AAPS
                                                 if (json_array.length() > 1) {
-                                                    LibreOOPAlgorithm.HandleData(json_array.getString(1));
+                                                    final JSONObject json_object = json_array.getJSONObject(0);
+                                                    int process_id = -1;
+                                                    try {
+                                                        process_id = json_object.getInt("ROW_ID");
+                                                    }   catch (JSONException e) {
+                                                        // Intentionly ignoring ecxeption.
+                                                    }
+                                                    if(process_id == -1 || process_id == android.os.Process.myPid()) {
+                                                        LibreOOPAlgorithm.HandleData(json_array.getString(1));    
+                                                    } else {
+                                                        Log.d(TAG, "Ignoring OOP result since process id is wrong " + process_id);
+                                                    }
+                                                    
                                                 } else {
                                                     final JSONObject json_object = json_array.getJSONObject(0);
                                                     final String type = json_object.getString("type");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Intents.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Intents.java
@@ -60,6 +60,7 @@ public interface Intents {
 
     String LIBRE_DATA_TIMESTAMP = "com.eveningoutpost.dexdrip.Extras.TIMESTAMP";
     String LIBRE_SN = "com.eveningoutpost.dexdrip.Extras.LIBRE_SN";
+    String LIBRE_RAW_ID = "com.eveningoutpost.dexdrip.Extras.LIBRE_RAW_ID";
 
     String LIBRE2_BG = "com.librelink.app.ThirdPartyIntegration.GLUCOSE_READING";
     String LIBRE2_ACTIVATION = "com.librelink.app.ThirdPartyIntegration.SENSOR_ACTIVATE";


### PR DESCRIPTION
xDrip and OOP are using broadcast to send data to each other.
As a result, if there were two variants of xDrip installed on one phone, then data returned from the OOP was received by both of them.

With this change xDrip adds it's process id to the message sent, and verifies on the response that the same process id is used.

OOPs is passing this data for some time now.

A word about backward compatibility:
=======================================
Old versions of xDrip will not be affected by the change, as they don't check row_id when it returns.
New versions of xDrip with old OOP will not be affected since if row_id is not present in the message data is still accepted by xDrip.
So, only new versions of xDrip and new versions of the OOP will be able to use it.

Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>