### PR TITLE
Allow to load us sensors data.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -1179,12 +1179,10 @@ public class NightscoutUploader {
                         for (LibreBlock libreBlockEntry : libreBlock) {
                             
                             
-                            Log.d(TAG, "uploading new item to monog");
+                            Log.d(TAG, "uploading new item to mongo");
+                            // Checksum might be wrong, for libre 2 or libre us 14 days.
                             boolean ChecksumOk = LibreUtils.verify(libreBlockEntry.blockbytes);
-                            if(!ChecksumOk) {
-                                Log.e(TAG, "Not uploading packet with badchecksum");
-                                continue;
-                            }
+                            
                             // make db object
                             BasicDBObject testData = new BasicDBObject();
                             testData.put("SensorId", PersistentStore.getString("LibreSN"));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/UploaderQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/UploaderQueue.java
@@ -197,6 +197,9 @@ public class UploaderQueue extends Model {
     		return;
     	}
     	newEntry(action, obj);
+    	// For libre us sensors, we have a reading, it might not create a BG entry, but we still need
+    	// to upload it.
+    	startSyncService(3000); // sync in 3 seconds
     }
     
     // TODO remove duplicated functionality, replace with generic multi-purpose method

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
@@ -20,7 +20,6 @@ import com.eveningoutpost.dexdrip.Services.ActivityRecognizedService;
 import com.eveningoutpost.dexdrip.Services.BluetoothGlucoseMeter;
 import com.eveningoutpost.dexdrip.Services.MissedReadingService;
 import com.eveningoutpost.dexdrip.Services.PlusSyncService;
-import com.eveningoutpost.dexdrip.Services.SyncService;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.IdempotentMigrations;
 import com.eveningoutpost.dexdrip.UtilityModels.PlusAsyncExecutor;


### PR DESCRIPTION
This is a fix for the case that xdrip is used to capture data of us sensors and upload it to a mongodb.
It is needed on phones that do not have support for the OOP.
There have been two things that prevented this from working:
1) For us 14 days sensors we don't know how to calculate the checksum (It will later be calculated by the oop).
2) Since no BG is created locally for this libre-data the uploader did not start.

Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>