### PR TITLE
Insulin trapezoidal calculation is fixed for long-acting insulin

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/insulin/LinearTrapezoidInsulin.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/insulin/LinearTrapezoidInsulin.java
@@ -37,18 +37,18 @@ public class LinearTrapezoidInsulin extends Insulin {
         else if ((t1 <= time) && (time < t2))
             return 1.0 + 0.5 * max * t1 - max * time;
         else if ((t2 <= time) && (time < t3))
-            return 0.5 * (time - t3) * (time - t3) * max / (t3 - t2);
+            return 0.5 * (t3 - time) * (t3 - time) * max / (t3 - t2);
         else return 0;
     }
 
     public double calculateActivity(double t) {
         double time = t - onset;
         if ((0 <= time) && (time < t1))
-            return concentration * time * max / t2;
+            return concentration * time * max / t1;
         else if ((t1 <= time) && (time < t2))
             return concentration * max;
         else if ((t2 <= time) && (time < t3))
-            return concentration * (time - t3) * max / (t3 - t2);
+            return concentration * (t3 - time) * max / (t3 - t2);
         else return 0;
     }
 


### PR DESCRIPTION
Long acting insulins with a >instantaneous time at the peak value, had an incorrect calculation, which is now fixed.
A calculation with a reversed sign is corrected. This was currently a no-op as it was corrected either immediately or later in the code, but without fixing, that would not be guaranteed to be the case forever.

@gruoner
