### PR TITLE
Allow xdrip to upload based on MDNS names.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -28,6 +28,7 @@ import com.eveningoutpost.dexdrip.Services.DexCollectionService;
 import com.eveningoutpost.dexdrip.Services.ActivityRecognizedService;
 import com.eveningoutpost.dexdrip.utils.CipherUtils;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
+import com.eveningoutpost.dexdrip.utils.Mdns;
 import com.eveningoutpost.dexdrip.xdrip;
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
@@ -48,6 +49,7 @@ import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -290,7 +292,45 @@ public class NightscoutUploader {
 
         return mongoStatus;
     }
-
+    
+    private String TryResolveName(String baseURI) {
+        Log.d(TAG,  "Resolveing name" );
+        URI uri;
+        try {
+            uri = new URI(baseURI);
+        } catch (URISyntaxException e) {
+            Log.e(TAG, "Error URISyntaxException for " + baseURI, e);
+            return baseURI;
+        }
+        String host = uri.getHost();
+        Log.d(TAG, "host = " + host);
+        // Host has either to end with .local, or be one word (with no dots) for us to try and resolve it.
+        if (host == null ||  (host.contains(".") && (!host.endsWith(".local")))) {
+            return baseURI;
+        }
+        // So, we need to resolve this name
+        String fullHost = host;
+        try {
+            if(!fullHost.endsWith(".local")) {
+                fullHost += ".local";
+            }
+            String ip = Mdns.genericResolver(fullHost);
+            if(ip == null) {
+                Log.d(TAG, "Recieved null resolving " + fullHost);
+                return baseURI;
+            }
+            // Resolve succeeded, replace host, with the resovled address.
+            String newUri = baseURI.replace(host, ip);
+            Log.d(TAG, "Returning new uri " + newUri);
+            return newUri;
+            
+            
+        } catch (UnknownHostException e) {
+            Log.w(TAG, "UnknownHostException error nanme not resovled" + fullHost);
+            return baseURI;
+        }
+    }
+    
     private synchronized boolean doRESTtreatmentDownload(SharedPreferences prefs) {
         final String baseURLSettings = prefs.getString("cloud_storage_api_base", "");
         final ArrayList<String> baseURIs = new ArrayList<>();
@@ -314,6 +354,7 @@ public class NightscoutUploader {
         // process a list of base uris
         for (String baseURI : baseURIs) {
             try {
+                baseURI = TryResolveName(baseURI);
                 int apiVersion = 0;
                 URI uri = new URI(baseURI);
                 if ((uri.getHost().startsWith("192.168.")) && prefs.getBoolean("skip_lan_uploads_when_no_lan", true) && (!JoH.isLANConnected())) {
@@ -413,6 +454,7 @@ public class NightscoutUploader {
             boolean any_successes = false;
             for (String baseURI : baseURIs) {
                 try {
+                    baseURI = TryResolveName(baseURI);
                     int apiVersion = 0;
                     URI uri = new URI(baseURI);
                     if ((uri.getHost().startsWith("192.168.")) && prefs.getBoolean("skip_lan_uploads_when_no_lan", true) && (!JoH.isLANConnected()))

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Mdns.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Mdns.java
@@ -69,6 +69,10 @@ public class Mdns {
     private static final long NORMAL_RESOLVE_TIMEOUT_MS = 5000;
     private static final long WAIT_FOR_REPLIES_TIMEOUT_MS = 10000;
 
+    // In order for this to work on a rpi do:
+    // On the file /etc/avahi/avahi-daemon.conf change
+    // publish-workstation=yes
+    // and restart the service (sudo /etc/init.d/avahi-daemon restart)
     private static final String SERVICE_TYPE = "_workstation._tcp.";
     private static final String TAG = "Mdns-discovery";
     private static final boolean d = true;
@@ -214,6 +218,7 @@ public class Mdns {
 
                 final String type = service.getServiceType();
 
+                UserError.Log.d(TAG, "onServiceFound " + type + service.getServiceName());
                 if (type.equals(SERVICE_TYPE)) {
                     final String name = service.getServiceName();
                     final LookUpInfo li = iplookup.get(shortenName(name));


### PR DESCRIPTION
This is needed for openaps offline setup.

In order to enable this feature, on the rpi do:
On the file /etc/avahi/avahi-daemon.conf change
publish-workstation=yes

and restart the service (sudo /etc/init.d/avahi-daemon restart)

This was tested with the following code:
    void SingleTest(String a) {
        String b = TryResolveName(a);
        Log.e(TAG," xxxx " + a + " was resolved to " + b);

    }

    private void resolveTest() {
        SingleTest("http://apisec@sss.herukapp.com/api/v1");
        SingleTest("https://apisec@sss.herukapp.com:5000/api/v1");
        SingleTest("http://apisec@192.168.1.2/api/v1");
        SingleTest("http://apisec@oapsasd1/api/v1:5000");
        SingleTest("https://apisec@oapsad4/api/v1:5000");
        SingleTest("https://apisec@oapsad4.local/api/v1:5000");
        SingleTest("https://apisec,oapsad4.local/api/v1:5000");

    }