### PR TITLE
Fixed problem with nightscout follow - Entry.date

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/Entry.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/Entry.java
@@ -14,7 +14,7 @@ public class Entry extends BaseMessage {
     @Expose
     public String _id;
     @Expose
-    public long date;
+    public double date;
     @Expose
     public String dateString;
     @Expose
@@ -40,7 +40,7 @@ public class Entry extends BaseMessage {
 
     public long getTimeStamp() {
         if (date > 1000000) {
-            return date;
+            return Math.round(date);
         }
         if (sysTime != null) {
             try {


### PR DESCRIPTION
xDrip had Entry.date set as long, but nightscout is allowing
double values to be added. For example loop is uploading bg entries
with dates as doubles with decimals. This makes it impossible to use
the nightscout follow feature when uploading bg through loop.

This commit changes the datatype to double and rounds it back to long
when asking Entry for the timestamp. This way no changes are made
to the internal workings of xdrip, but nightscout follow started working
again.

The change is tested with nightscout sites which are both in dexcom
follow mode and loop upload mode.