### PR TITLE
extended range for Libre2 intercept -40 ... 20

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -143,7 +143,7 @@ class Li2AppParameters extends SlopeParameters {
 
     @Override
     public double restrictIntercept(double intercept) {
-        return Math.min(Math.max(intercept, -20), 40);
+        return Math.min(Math.max(intercept, -40), 20);
     }
 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -143,7 +143,7 @@ class Li2AppParameters extends SlopeParameters {
 
     @Override
     public double restrictIntercept(double intercept) {
-        return Math.min(Math.max(intercept, -40), 20);
+        return Math.min(Math.max(intercept, -20), 40);
     }
 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -143,7 +143,7 @@ class Li2AppParameters extends SlopeParameters {
 
     @Override
     public double restrictIntercept(double intercept) {
-        return Math.min(Math.max(intercept, -20), 20);
+        return Math.min(Math.max(intercept, -20), 40);
     }
 }
 


### PR DESCRIPTION
User claims that the intercept limitation from -20 to 20 is too small. Having tested with a few sensors it seems to be safe to extend the upper limit from 20 to 40 to have the ablility to use L2 sensors with a bigger difference between blood and readings. As far as we know the L2 sensors will not vary over time. The difference will be constant over the whole 14 days.