### PR TITLE
Adjustable Grace (Interval added to refresh Interval)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -128,7 +128,7 @@ public class NightscoutFollowService extends ForegroundService {
         final BgReading lastBg = BgReading.lastNoSenssor();
         final long last = lastBg != null ? lastBg.timestamp : 0;
 
-        final long grace = Constants.SECOND_IN_MS * 10;
+        final long grace = Constants.SECOND_IN_MS * getGrace();
         final long next = Anticipate.next(JoH.tsl(), last, SAMPLE_PERIOD, grace) + grace;
         wakeup_time = next;
         UserError.Log.d(TAG, "Anticipate next: " + JoH.dateTimeText(next) + "  last: " + JoH.dateTimeText(last));
@@ -140,7 +140,9 @@ public class NightscoutFollowService extends ForegroundService {
     private static boolean shouldServiceRun() {
         return DexCollectionType.getDexCollectionType() == NSFollow;
     }
-
+    private static int getGrace(){
+        return Integer.valueOf(Pref.getString("nsfollow_grace", "10"));
+    }
     /**
      * MegaStatus for Nightscout Follower
      */
@@ -202,6 +204,7 @@ public class NightscoutFollowService extends ForegroundService {
         statuses.add(new StatusItem());
         statuses.add(new StatusItem("Last poll", lastPollText + (lastPoll > 0 ? " ago" : "")));
         statuses.add(new StatusItem("Next poll in", JoH.niceTimeScalar(wakeup_time - JoH.tsl())));
+        statuses.add(new StatusItem("Interval addition",getGrace()+" Seconds"));
         if (lastBg != null) {
             statuses.add(new StatusItem("Last BG time", JoH.dateTimeText(lastBg.timestamp)));
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1028,6 +1028,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             final Preference nsFollowDownload = findPreference("nsfollow_download_treatments");
             final Preference nsFollowUrl = findPreference("nsfollow_url");
+            final Preference nsFollowGrace = findPreference("nsfollow_grace");
             try {
                 nsFollowUrl.setOnPreferenceChangeListener((preference, newValue) -> {
                     NightscoutFollow.resetInstance();
@@ -1388,6 +1389,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 try {
                     collectionCategory.removePreference(nsFollowUrl);
                     collectionCategory.removePreference(nsFollowDownload);
+                    collectionCategory.removePreference(nsFollowGrace);
                 } catch (Exception e) {
                     //
                 }
@@ -2014,6 +2016,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     if (collectionType == DexCollectionType.NSFollow) {
                         collectionCategory.addPreference(nsFollowUrl);
                         collectionCategory.addPreference(nsFollowDownload);
+                        collectionCategory.addPreference(nsFollowGrace);
                     }
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1254,6 +1254,7 @@
     <string name="title_nsfollow_url">Nightscout Follow URL</string>
     <string name="summary_nsfollow_download_treatments">Also download treatments from Nightscout as follower</string>
     <string name="title_nsfollow_download_treatments">Download Treatments</string>
+    <string name="title_nsfollow_grace">Interval addition</string>
     <string name="title_ob1_options">OB1 G5/G6 Collector Settings</string>
     <string name="summary_use_ob1_g5_collector_service">Complete re-write, should work on Android 4.4-9, supports native mode and more</string>
     <string name="title_use_ob1_g5_collector_service">Use the OB1 Collector</string>

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -115,6 +115,12 @@
             android:summary="@string/summary_nsfollow_download_treatments"
             android:title="@string/title_nsfollow_download_treatments"
             />
+        <EditTextPreference
+            android:defaultValue="10"
+            android:inputType="number"
+            android:key="nsfollow_grace"
+            android:summary="Delay after 5 minute Interval in seconds"
+            android:title="@string/title_nsfollow_grace" />
 
         <EditTextPreference
             android:defaultValue=""


### PR DESCRIPTION
Hello,
i had an [issue](https://github.com/NightscoutFoundation/xDrip/issues/1302) which i solved with this, you can now change the [grace](https://github.com/NightscoutFoundation/xDrip/blob/master/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java#L131) (which is an addition to the refresh interval)
The value can be set via preferences in the app, and can be seen in the System Status
My issue was, that xdrip polled the data from Nightscout, before my Uploader could upload it, and this "update" can delay the poll, so that the uploader uploads the data and xdrip can poll it after that