### PR TITLE
Tzachi libre all house coverage.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -331,4 +331,12 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:1.18.10"
 }
 
+tasks.withType(Test) { 
+  testLogging {
+    exceptionFormat "full"
+    events "started", "skipped", "passed", "failed"
+    showStandardStreams true
+  }
+}
+
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
@@ -795,7 +795,7 @@ public class GcmActivity extends FauxActivity {
         if (!Home.get_master()) {
             return;
         }
-        if (!JoH.ratelimit("libre-allhouse", 5)) {
+        if (!JoH.pratelimit("libre-allhouse", 5)) {
             // Do not create storm of packets.
             Log.e(TAG, "Rate limited start libre-allhouse");
             return;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
@@ -688,6 +688,13 @@ public class GcmActivity extends FauxActivity {
             GcmActivity.sendMessage(myIdentity(), "cal2", json);
         }
     }
+    public static void pushLibreBlock(String libreBlock) {
+        Log.i(TAG, "libreBlock called: " + libreBlock);
+        if (!Home.get_master()) {
+            return;
+        }
+        GcmActivity.sendMessage(myIdentity(), "libreBlock", libreBlock);
+    }
 
     public static void clearLastCalibration(String uuid) {
         sendMessage(myIdentity(), "clc", uuid);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
@@ -279,6 +279,10 @@ public class GcmActivity extends FauxActivity {
             UserError.Log.wtf(TAG, "Cannot sync null bgreading - should never occur");
             return;
         }
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending syncBGReading since this is libre allhouse collector.");
+            return;
+        }
         Log.d(TAG, "syncBGReading called");
         if (JoH.ratelimit("gcm-bgs-batch", 15)) {
             GcmActivity.sendMessage("bgs", bgReading.toJSON(true));
@@ -292,6 +296,10 @@ public class GcmActivity extends FauxActivity {
     // called only from interactive or evaluated new data
     public synchronized static void syncBloodTests() {
         Log.d(TAG, "syncBloodTests called");
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending syncBloodTests since this is libre allhouse collector.");
+            return;
+        }
         if (Home.get_master_or_follower()) {
             if (JoH.ratelimit("gcm-btmm-send", 4)) {
                 final byte[] this_btmm = BloodTest.toMultiMessage(BloodTest.last(12));
@@ -308,6 +316,10 @@ public class GcmActivity extends FauxActivity {
     private synchronized static void processBgsBatch(boolean send_now) {
         final byte[] value = PersistentStore.getBytes("gcm-bgs-batch-queue");
         Log.d(TAG, "Processing BgsBatch: length: " + value.length + " now:" + send_now);
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending processBgsBatch since this is libre allhouse collector.");
+            return;
+        }
         if ((send_now) || (value.length > (RELIABLE_MAX_BINARY_PAYLOAD - 100))) {
             if (value.length > 0) {
                 PersistentStore.setString("gcm-bgs-batch-queue", "");
@@ -332,6 +344,10 @@ public class GcmActivity extends FauxActivity {
         Log.i(TAG, "syncSensor called");
         if (sensor == null) {
             Log.e(TAG, "syncSensor sensor is null");
+            return;
+        }
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending syncSensor since this is libre allhouse collector.");
             return;
         }
         if ((!forceSend) && !JoH.pratelimit("GcmSensorCalibrationsUpdate", 300)) {
@@ -386,18 +402,30 @@ public class GcmActivity extends FauxActivity {
     }
 
     static void sendLocation(final String location) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending sendLocation since this is libre allhouse collector.");
+            return;
+        }
         if (JoH.pratelimit("gcm-plu", 180)) {
             GcmActivity.sendMessage("plu", location);
         }
     }
 
     public static void sendSensorBattery(final int battery) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending sendSensorBattery since this is libre allhouse collector.");
+            return;
+        }
         if (JoH.pratelimit("gcm-sbu", 3600)) {
             GcmActivity.sendMessage("sbu", Integer.toString(battery));
         }
     }
 
     public static void sendBridgeBattery(final int battery) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending sendBridgeBattery since this is libre allhouse collector.");
+            return;
+        }
         if (battery != last_bridge_battery) {
             if (JoH.pratelimit("gcm-bbu", 1800)) {
                 GcmActivity.sendMessage("bbu", Integer.toString(battery));
@@ -407,6 +435,10 @@ public class GcmActivity extends FauxActivity {
     }
 
     public static void sendParakeetBattery(final int battery) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending sendParakeetBattery since this is libre allhouse collector.");
+            return;
+        }
         if (battery != last_parakeet_battery) {
             if (JoH.pratelimit("gcm-pbu", 1800)) {
                 GcmActivity.sendMessage("pbu", Integer.toString(battery));
@@ -416,6 +448,11 @@ public class GcmActivity extends FauxActivity {
     }
 
     public static void sendNotification(String title, String message) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending sendNotification since this is libre allhouse collector.");
+            return;
+        }
+
         if (JoH.pratelimit("gcm-not", 30)) {
             GcmActivity.sendMessage("not", title.replaceAll("\\^", "") + "^" + message.replaceAll("\\^", ""));
         }
@@ -496,18 +533,30 @@ public class GcmActivity extends FauxActivity {
     }
 
     public static void sendMotionUpdate(final long timestamp, final int activity) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending sendMotionUpdate since this is libre allhouse collector.");
+            return;
+        }
         if (JoH.pratelimit("gcm-amu", 5)) {
             sendMessage("amu", Long.toString(timestamp) + "^" + Integer.toString(activity));
         }
     }
 
     public static void sendPumpStatus(String json) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending sendPumpStatus since this is libre allhouse collector.");
+            return;
+        }
         if (JoH.pratelimit("gcm-psu", 180)) {
             sendMessage("psu", json);
         }
     }
 
     public static void sendNanoStatusUpdate(final String json) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending sendNanoStatusUpdate since this is libre allhouse collector.");
+            return;
+        }
         if (JoH.pratelimit("gcm-nscu", 180)) {
             UserError.Log.d(TAG, "Sending nano status update: " + json);
             sendMessage("nscu", json);
@@ -515,6 +564,10 @@ public class GcmActivity extends FauxActivity {
     }
 
     public static void sendMimeoGraphUpdate(final String json) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending sendMimeoGraphUpdate since this is libre allhouse collector.");
+            return;
+        }
         if (JoH.pratelimit("gcm-mimg", 180)) {
             UserError.Log.d(TAG, "Sending mimeograph key update: " + json);
             sendMessage("mimg", json);
@@ -523,6 +576,11 @@ public class GcmActivity extends FauxActivity {
 
 
     public static void requestBGsync() {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending requestBGsync since this is libre allhouse collector.");
+            return;
+        }
+
         if (token != null) {
             if ((JoH.tsl() - last_sync_request) > (60 * 1000 * (5 + bg_sync_backoff))) {
                 last_sync_request = JoH.tsl();
@@ -583,6 +641,10 @@ public class GcmActivity extends FauxActivity {
 
     // callback function
     public static void backfillLink(String id, String key) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending backfillLink since this is libre allhouse collector.");
+            return;
+        }
         Log.d(TAG, "sending bfb message: " + id);
         sendMessage("bfb", id + "^" + key);
     }
@@ -597,6 +659,10 @@ public class GcmActivity extends FauxActivity {
     }
 
     static void requestSensorBatteryUpdate() {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending requestSensorBatteryUpdate since this is libre allhouse collector.");
+            return;
+        }
         if (Home.get_follower() && JoH.pratelimit("SensorBatteryUpdateRequest", 1200)) {
             Log.d(TAG, "Requesting Sensor Battery Update");
             GcmActivity.sendMessage("sbr", ""); // request sensor battery update
@@ -604,6 +670,10 @@ public class GcmActivity extends FauxActivity {
     }
 
     public static void requestSensorCalibrationsUpdate() {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending requestSensorCalibrationsUpdate since this is libre allhouse collector.");
+            return;
+        }
         if (Home.get_follower() && JoH.pratelimit("SensorCalibrationsUpdateRequest", 300)) {
             Log.d(TAG, "Requesting Sensor and calibrations Update");
             GcmActivity.sendMessage("sensor_calibrations_update", "");
@@ -612,6 +682,10 @@ public class GcmActivity extends FauxActivity {
 
     public static void pushTreatmentAsync(final Treatments thistreatment) {
         if ((thistreatment.uuid == null) || (thistreatment.uuid.length() < 5)) return;
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending pushTreatmentAsync since this is libre allhouse collector.");
+            return;
+        }
         final String json = thistreatment.toJSON();
         sendMessage(myIdentity(), "nt", json);
     }
@@ -622,24 +696,44 @@ public class GcmActivity extends FauxActivity {
     }
 
     public static void push_delete_all_treatments() {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending push_delete_all_treatments since this is libre allhouse collector.");
+            return;
+        }
         Log.i(TAG, "Sending push for delete all treatments");
         sendMessage(myIdentity(), "dat", "");
     }
 
     public static void push_delete_treatment(Treatments treatment) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending push_delete_treatment since this is libre allhouse collector.");
+            return;
+        }
         Log.i(TAG, "Sending push for specific treatment");
         sendMessage(myIdentity(), "dt", treatment.uuid);
     }
 
     public static void push_stop_master_sensor() {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending push_stop_master_sensor since this is libre allhouse collector.");
+            return;
+        }
         sendMessage("ssom", "challenge string");
     }
 
     public static void push_start_master_sensor() {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending push_start_master_sensor since this is libre allhouse collector.");
+            return;
+        }
         sendMessage("rsom", JoH.tsl() + "");
     }
 
     public static void push_external_status_update(long timestamp, String statusLine) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending external_status_update since this is libre allhouse collector.");
+            return;
+        }
         if (JoH.ratelimit("gcm-esup", 30)) {
             sendMessage("esup", timestamp + "^" + statusLine);
         }
@@ -662,6 +756,10 @@ public class GcmActivity extends FauxActivity {
             // For master, we now send the entire table, no need to send this specific table each time
             return;
         }
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending pushCalibration since this is libre allhouse collector.");
+            return;
+        }
         if (Home.get_follower()) {
             final String currenttime = Double.toString(new Date().getTime());
             final String tosend = currenttime + " " + bg_value + " " + seconds_ago;
@@ -671,6 +769,10 @@ public class GcmActivity extends FauxActivity {
 
     static void pushCalibration2(double bgValue, String uuid, long offset) {
         Log.i(TAG, "pushCalibration2 called: " + JoH.qs(bgValue, 1) + " " + uuid + " " + offset);
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending pushCalibration2 since this is libre allhouse collector.");
+            return;
+        }
         if (Home.get_master_or_follower()) {
             final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
             final String unit = prefs.getString("units", "mgdl");
@@ -703,6 +805,10 @@ public class GcmActivity extends FauxActivity {
     }
 
     public static void clearLastCalibration(String uuid) {
+        if(Home.get_is_libre_whole_house_collector()) {
+            Log.w(TAG, "Not sending clearLastCalibration since this is libre allhouse collector.");
+            return;
+        }
         sendMessage(myIdentity(), "clc", uuid);
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
@@ -693,6 +693,12 @@ public class GcmActivity extends FauxActivity {
         if (!Home.get_master()) {
             return;
         }
+        if (!JoH.ratelimit("libre-allhouse", 5)) {
+            // Do not create storm of packets.
+            Log.e(TAG, "Rate limited start libre-allhouse");
+            return;
+        }
+
         GcmActivity.sendMessage(myIdentity(), "libreBlock", libreBlock);
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
@@ -26,6 +26,7 @@ import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.LibreBlock;
 import com.eveningoutpost.dexdrip.Models.RollCall;
 import com.eveningoutpost.dexdrip.Models.Sensor;
+import com.eveningoutpost.dexdrip.Models.SensorSanity;
 import com.eveningoutpost.dexdrip.Models.TransmitterData;
 import com.eveningoutpost.dexdrip.Models.Treatments;
 import com.eveningoutpost.dexdrip.Models.UserError;
@@ -584,8 +585,13 @@ public class GcmListenerSvc extends JamListenerSvc {
         Pref.setInt("bridge_battery", lb.bridge_battery);
         PersistentStore.setString("Tomatobattery", Integer.toString(lb.Tomatobattery));
         PersistentStore.setString("Bubblebattery", Integer.toString(lb.Bubblebattery));
+        PersistentStore.setString("LibreSN", lb.reference);
         
         if(Home.get_master()) {
+            if (SensorSanity.checkLibreSensorChangeIfEnabled(lb.reference)) {
+                Log.e(TAG, "Problem with Libre Serial Number - not processing");
+            }
+            
             NFCReaderX.HandleGoodReading(lb.reference, lb.blockbytes, lb.timestamp, false, lb.patchUid,  lb.patchInfo);
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip;
 
+import android.R.integer;
+
 /**
  * Created by jamorham on 11/01/16.
  */
@@ -32,6 +34,7 @@ import com.eveningoutpost.dexdrip.Services.ActivityRecognizedService;
 import com.eveningoutpost.dexdrip.UtilityModels.AlertPlayer;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.NanoStatus;
+import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.PumpStatus;
 import com.eveningoutpost.dexdrip.UtilityModels.StatusItem;
@@ -577,10 +580,14 @@ public class GcmListenerSvc extends JamListenerSvc {
             return;
         }
         LibreBlock.Save(lb);
+        
+        Pref.setInt("bridge_battery", lb.bridge_battery);
+        PersistentStore.setString("Tomatobattery", Integer.toString(lb.Tomatobattery));
+        PersistentStore.setString("Bubblebattery", Integer.toString(lb.Bubblebattery));
+        
         if(Home.get_master()) {
             NFCReaderX.HandleGoodReading(lb.reference, lb.blockbytes, lb.timestamp, false, lb.patchUid,  lb.patchInfo);
         }
-    
     }
 
     private void sendNotification(String body, String title) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
@@ -572,7 +572,7 @@ public class GcmListenerSvc extends JamListenerSvc {
     }
 
     private void HandleLibreBlock(String payload) {
-        LibreBlock lb = LibreBlock.createFromJson(payload);
+        LibreBlock lb = LibreBlock.createFromExtendedJson(payload);
         if(lb == null) {
             return;
         }
@@ -582,9 +582,6 @@ public class GcmListenerSvc extends JamListenerSvc {
         }
         LibreBlock.Save(lb);
         
-        Pref.setInt("bridge_battery", lb.bridge_battery);
-        PersistentStore.setString("Tomatobattery", Integer.toString(lb.Tomatobattery));
-        PersistentStore.setString("Bubblebattery", Integer.toString(lb.Bubblebattery));
         PersistentStore.setString("LibreSN", lb.reference);
         
         if(Home.get_master()) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
@@ -21,6 +21,7 @@ import com.eveningoutpost.dexdrip.Models.BloodTest;
 import com.eveningoutpost.dexdrip.Models.Calibration;
 import com.eveningoutpost.dexdrip.Models.DesertSync;
 import com.eveningoutpost.dexdrip.Models.JoH;
+import com.eveningoutpost.dexdrip.Models.LibreBlock;
 import com.eveningoutpost.dexdrip.Models.RollCall;
 import com.eveningoutpost.dexdrip.Models.Sensor;
 import com.eveningoutpost.dexdrip.Models.TransmitterData;
@@ -552,7 +553,8 @@ public class GcmListenerSvc extends JamListenerSvc {
                             UserError.Log.wtf(TAG, "Exception processing rsom timestamp");
                         }
                     }
-
+                } else if (action.equals("libreBlock")) {
+                    HandleLibreBlock(payload);
                 } else {
                     Log.e(TAG, "Received message action we don't know about: " + action);
                 }
@@ -565,6 +567,21 @@ public class GcmListenerSvc extends JamListenerSvc {
         }
     }
 
+    private void HandleLibreBlock(String payload) {
+        LibreBlock lb = LibreBlock.createFromJson(payload);
+        if(lb == null) {
+            return;
+        }
+        if (LibreBlock.getForTimestamp(lb.timestamp) != null) {
+            // We already seen this one.
+            return;
+        }
+        LibreBlock.Save(lb);
+        if(Home.get_master()) {
+            NFCReaderX.HandleGoodReading(lb.reference, lb.blockbytes, lb.timestamp, false, lb.patchUid,  lb.patchInfo);
+        }
+    
+    }
 
     private void sendNotification(String body, String title) {
         Intent intent = new Intent(this, Home.class);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2097,6 +2097,10 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         if (!has_libreblock_set) setHasLibreblock();
         return has_libreblock;
     }
+    
+    public static boolean get_is_libre_whole_house_collector() {
+        return Pref.getBooleanDefaultFalse("libre_whole_house_collector");
+    }
 
     public static boolean get_engineering_mode() {
         return Pref.getBooleanDefaultFalse("engineering_mode");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2775,7 +2775,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         }
 
         final int sensor_age = Pref.getInt("nfc_sensor_age", 0);
-        if ((sensor_age > 0) && (DexCollectionType.hasLibre())) {
+        if (sensor_age > 0 && (DexCollectionType.hasLibre() || hasLibreblock())) {
             final String age_problem = (Pref.getBooleanDefaultFalse("nfc_age_problem") ? " \u26A0\u26A0\u26A0" : "");
             if (Pref.getBoolean("nfc_show_age", true)) {
                 sensorAge.setText("Age: " + JoH.qs(((double) sensor_age) / 1440, 1) + "d" + age_problem);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -3039,7 +3039,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         menu.findItem(R.id.showreminders).setVisible(Pref.getBoolean("plus_show_reminders", true) && !is_newbie);
 
         LibreBlock libreBlock = null;
-        if (DexCollectionType.hasLibre()) {
+        if (DexCollectionType.hasLibre() || get_follower()) {
             libreBlock = LibreBlock.getLatestForTrend();
         }
         if (libreBlock == null) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -297,6 +297,8 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
     private ActivityHomeBinding binding;
     private boolean is_newbie;
     private boolean checkedeula;
+    private static boolean has_libreblock = false;
+    private static boolean has_libreblock_set = false;
 
     @Inject
     BaseShelf homeShelf;
@@ -2086,6 +2088,16 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         return Home.is_follower;
     }
 
+    private static void setHasLibreblock() {
+        has_libreblock =  LibreBlock.getLatestForTrend() != null;
+        has_libreblock_set = true;
+    }
+
+    public static boolean hasLibreblock() {
+        if (!has_libreblock_set) setHasLibreblock();
+        return has_libreblock;
+    }
+
     public static boolean get_engineering_mode() {
         return Pref.getBooleanDefaultFalse("engineering_mode");
     }
@@ -3038,11 +3050,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
 
         menu.findItem(R.id.showreminders).setVisible(Pref.getBoolean("plus_show_reminders", true) && !is_newbie);
 
-        LibreBlock libreBlock = null;
-        if (DexCollectionType.hasLibre() || get_follower()) {
-            libreBlock = LibreBlock.getLatestForTrend();
-        }
-        if (libreBlock == null) {
+        if (!hasLibreblock()) {
             menu.findItem(R.id.libreLastMinutes).setVisible(false);
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
@@ -214,7 +214,7 @@ public class LibreAlarmReceiver extends BroadcastReceiver {
                 // reading, and then BT disconnects and connects after a few seconds, and we have a new reading (where 
                 // sensor did not advance). This does not mean that a sensor is not advancing. Only if this is happening
                 // for a few minutes, this is a problem.
-                if(BgReading.getTimeSinceLastReading() > 4.5*60*1000) {
+                if(BgReading.getTimeSinceLastReading() > 11 * 60 * 1000) {
                     Log.wtf(TAG, "Sensor age has not advanced: " + sensorAge);
                     JoH.static_toast_long(gs(R.string.sensor_clock_has_not_advanced));
                     Pref.setBoolean("nfc_age_problem", true);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
@@ -210,9 +210,15 @@ public class LibreAlarmReceiver extends BroadcastReceiver {
                 Pref.setBoolean("nfc_age_problem", false);
                 Log.d(TAG, "Sensor age advanced to: " + thisSensorAge);
             } else if (thisSensorAge == sensorAge) {
-                Log.wtf(TAG, "Sensor age has not advanced: " + sensorAge);
-                JoH.static_toast_long(gs(R.string.sensor_clock_has_not_advanced));
-                Pref.setBoolean("nfc_age_problem", true);
+                // This is only a problem if we don't have a recent reading. It could happen that we have a recent
+                // reading, and then BT disconnects and connects after a few seconds, and we have a new reading (where 
+                // sensor did not advance). This does not mean that a sensor is not advancing. Only if this is happening
+                // for a few minutes, this is a problem.
+                if(BgReading.getTimeSinceLastReading() > 4.5*60*1000) {
+                    Log.wtf(TAG, "Sensor age has not advanced: " + sensorAge);
+                    JoH.static_toast_long(gs(R.string.sensor_clock_has_not_advanced));
+                    Pref.setBoolean("nfc_age_problem", true);
+                }
                 return; // do not try to insert again
             } else {
                 Log.wtf(TAG, "Sensor age has gone backwards!!! " + sensorAge);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Bubble.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Bubble.java
@@ -82,6 +82,11 @@ public class Bubble {
             patchUid = Arrays.copyOfRange(buffer, 2, 10);
             String SensorSn = LibreUtils.decodeSerialNumberKey(patchUid);
             PersistentStore.setString("LibreSN", SensorSn);
+            
+            if (SensorSanity.checkLibreSensorChangeIfEnabled(SensorSn)) {
+                Log.e(TAG, "Problem with Libre Serial Number - not processing");
+            }
+            
             return reply;
         }
         if (first == 0xC1) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreBlock.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreBlock.java
@@ -209,11 +209,13 @@ public class LibreBlock  extends PlusModel {
      class ExtendedLibreBlock {
          @Expose
          public int bridge_battery;
-          @Expose
+         @Expose
          public int Tomatobattery;
-          @Expose
+         @Expose
          public int Bubblebattery;
-          @Expose
+         @Expose
+         public int nfc_sensor_age;
+         @Expose
          public LibreBlock libreBlock;
      }
 
@@ -222,6 +224,7 @@ public class LibreBlock  extends PlusModel {
         elb.bridge_battery = Pref.getInt("bridge_battery", 0);
         elb.Tomatobattery = PersistentStore.getStringToInt("Tomatobattery", 0);
         elb.Bubblebattery = PersistentStore.getStringToInt("Bubblebattery", 0);
+        elb.nfc_sensor_age = Pref.getInt("nfc_sensor_age", 0);
         elb.libreBlock = this;
         return JoH.defaultGsonInstance().toJson(elb);
     }
@@ -242,6 +245,7 @@ public class LibreBlock  extends PlusModel {
         Pref.setInt("bridge_battery", elb.bridge_battery);
         PersistentStore.setString("Tomatobattery", Integer.toString(elb.Tomatobattery));
         PersistentStore.setString("Bubblebattery", Integer.toString(elb.Bubblebattery));
+        Pref.setInt("nfc_sensor_age", elb.nfc_sensor_age);
         return elb.libreBlock;
     }
     

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreBlock.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreBlock.java
@@ -7,6 +7,8 @@ import com.activeandroid.annotation.Table;
 import com.activeandroid.query.Select;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
+import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
+import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.UploaderQueue;
 import com.google.gson.annotations.Expose;
 
@@ -76,6 +78,11 @@ public class LibreBlock extends PlusModel {
     @Expose
     @Column(name = "patchInfo")
     public byte[] patchInfo;
+    
+    // Fields to store battery value. Not persistent in the DB.
+    public int bridge_battery;
+    public int Tomatobattery;
+    public int Bubblebattery;
     
     // Only called by blucon with partial data.
     public static LibreBlock createAndSave(String reference, long timestamp, byte[] blocks, int byte_start) {
@@ -185,6 +192,9 @@ public class LibreBlock extends PlusModel {
     private static final boolean d = false;
 
     public String toJson() {
+        bridge_battery = Pref.getInt("bridge_battery", 0);
+        Tomatobattery = PersistentStore.getStringToInt("Tomatobattery", 0);
+        Bubblebattery = PersistentStore.getStringToInt("Bubblebattery", 0);
         return JoH.defaultGsonInstance().toJson(this);
     }
     

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreBlock.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreBlock.java
@@ -13,6 +13,8 @@ import com.google.gson.annotations.Expose;
 import java.text.DecimalFormat;
 import java.util.List;
 import java.util.UUID;
+
+import org.json.JSONObject;
 /**
  * Created by jamorham on 19/10/2017.
  */
@@ -75,6 +77,7 @@ public class LibreBlock extends PlusModel {
     @Column(name = "patchInfo")
     public byte[] patchInfo;
     
+    // Only called by blucon with partial data.
     public static LibreBlock createAndSave(String reference, long timestamp, byte[] blocks, int byte_start) {
         return createAndSave(reference, timestamp, blocks, byte_start, false, null, null);
     }
@@ -91,8 +94,12 @@ public class LibreBlock extends PlusModel {
         }
         return lb;
     }
+    
+    public static void Save(LibreBlock lb){
+        lb.save();
+    }
 
-    private static LibreBlock create(String reference, long timestamp, byte[] blocks, int byte_start, byte[] patchUid, byte[] patchInfo) {
+    public static LibreBlock create(String reference, long timestamp, byte[] blocks, int byte_start, byte[] patchUid, byte[] patchInfo) {
         UserError.Log.e(TAG,"Backtrack: "+JoH.backTrace());
         if (reference == null) {
             UserError.Log.e(TAG, "Cannot save block with null reference");
@@ -177,6 +184,25 @@ public class LibreBlock extends PlusModel {
     
     private static final boolean d = false;
 
+    public String toJson() {
+        return JoH.defaultGsonInstance().toJson(this);
+    }
+    
+    public static LibreBlock createFromJson(String json) {
+        if (json == null) {
+            return null;
+        }
+        LibreBlock fresh;
+        try {
+            fresh = JoH.defaultGsonInstance().fromJson(json, LibreBlock.class);
+        } catch (Exception e) {
+            Log.e(TAG, "Got exception processing json msg: " + e );
+            return null;
+        }
+        Log.e(TAG, "Successfuly created LibreBlock value " + json);
+        return fresh;
+    }
+    
     public static void updateDB() {
         fixUpTable(schema, false);
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreBlock.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreBlock.java
@@ -11,7 +11,6 @@ import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.UploaderQueue;
 import com.google.gson.annotations.Expose;
-
 import java.text.DecimalFormat;
 import java.util.List;
 import java.util.UUID;
@@ -22,7 +21,7 @@ import org.json.JSONObject;
  */
 
 @Table(name = "LibreBlock", id = BaseColumns._ID)
-public class LibreBlock extends PlusModel {
+public class LibreBlock  extends PlusModel {
 
     private static final String TAG = "LibreBlock";
     static final String[] schema = {
@@ -80,10 +79,7 @@ public class LibreBlock extends PlusModel {
     public byte[] patchInfo;
     
     // Fields to store battery value. Not persistent in the DB.
-    public int bridge_battery;
-    public int Tomatobattery;
-    public int Bubblebattery;
-    
+
     // Only called by blucon with partial data.
     public static LibreBlock createAndSave(String reference, long timestamp, byte[] blocks, int byte_start) {
         return createAndSave(reference, timestamp, blocks, byte_start, false, null, null);
@@ -192,12 +188,9 @@ public class LibreBlock extends PlusModel {
     private static final boolean d = false;
 
     public String toJson() {
-        bridge_battery = Pref.getInt("bridge_battery", 0);
-        Tomatobattery = PersistentStore.getStringToInt("Tomatobattery", 0);
-        Bubblebattery = PersistentStore.getStringToInt("Bubblebattery", 0);
-        return JoH.defaultGsonInstance().toJson(this);
+        return JoH.defaultGsonInstance().toJson(this);        
     }
-    
+
     public static LibreBlock createFromJson(String json) {
         if (json == null) {
             return null;
@@ -211,6 +204,45 @@ public class LibreBlock extends PlusModel {
         }
         Log.e(TAG, "Successfuly created LibreBlock value " + json);
         return fresh;
+    }
+
+     class ExtendedLibreBlock {
+         @Expose
+         public int bridge_battery;
+          @Expose
+         public int Tomatobattery;
+          @Expose
+         public int Bubblebattery;
+          @Expose
+         public LibreBlock libreBlock;
+     }
+
+     public String toExtendedJson() {
+        ExtendedLibreBlock elb = new ExtendedLibreBlock();
+        elb.bridge_battery = Pref.getInt("bridge_battery", 0);
+        elb.Tomatobattery = PersistentStore.getStringToInt("Tomatobattery", 0);
+        elb.Bubblebattery = PersistentStore.getStringToInt("Bubblebattery", 0);
+        elb.libreBlock = this;
+        return JoH.defaultGsonInstance().toJson(elb);
+    }
+    
+    // This also saves the batteries data to the global state.
+    public static LibreBlock createFromExtendedJson(String json) {
+        if (json == null) {
+            return null;
+        }
+        ExtendedLibreBlock elb;
+        try {
+            elb = JoH.defaultGsonInstance().fromJson(json, ExtendedLibreBlock.class);
+        } catch (Exception e) {
+            Log.e(TAG, "Got exception processing json msg: " + e );
+            return null;
+        }
+        Log.e(TAG, "Successfuly created LibreBlock value " + json);
+        Pref.setInt("bridge_battery", elb.bridge_battery);
+        PersistentStore.setString("Tomatobattery", Integer.toString(elb.Tomatobattery));
+        PersistentStore.setString("Bubblebattery", Integer.toString(elb.Bubblebattery));
+        return elb.libreBlock;
     }
     
     public static void updateDB() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/SensorSanity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/SensorSanity.java
@@ -98,6 +98,12 @@ public class SensorSanity {
     private static final String PREF_LIBRE_SN = "SensorSanity-LibreSN";
     private static final String PREF_LIBRE_SENSOR_UUID = "SensorSanity-LibreSensor";
 
+    // This function is intended to be used by unit tests only.
+    public static void clearEnviorment() {
+        PersistentStore.setString(PREF_LIBRE_SENSOR_UUID, "");
+        PersistentStore.setString(PREF_LIBRE_SN, "");
+    }
+    
     public static boolean checkLibreSensorChangeIfEnabled(final String sn) {
         return Pref.getBoolean("detect_libre_sn_changes", true) && checkLibreSensorChange(sn);
     }
@@ -154,57 +160,5 @@ public class SensorSanity {
             }
         }
     }
-
-    // This is a test for the CheckLibreSensorChange function.
-    public static void testCheckLibreSensorChange() {
-        // Take us to a known state:
-        Log.e("xxxxx", "testCheckLibreSensorChange starting");
-        Sensor this_sensor = Sensor.currentSensor();
-        if (this_sensor != null) {
-            Sensor.stopSensor();
-        }
-        PersistentStore.setString(PREF_LIBRE_SENSOR_UUID, "");
-        PersistentStore.setString(PREF_LIBRE_SN, "");
-        
-        // Start testing: create a sensor, call checkLibreSensorChange twice with same sensor, and once with a new
-        // sn, and verify it is closed.
-        Sensor.create(JoH.tsl());
-        checkLibreSensorChange("SN111");
-        checkLibreSensorChange("SN111");
-        checkLibreSensorChange("SN222");
-        this_sensor = Sensor.currentSensor();
-        Log.e("xxxxx", "Expectingthis_sensor to be null, actually " + this_sensor);
-        if (this_sensor != null) {
-            Sensor.stopSensor();
-        }
-        // Continue testing: create new one, call with the second sn twice. now call with third sn, sensor should be stopped.
-        Sensor.create(JoH.tsl());
-        checkLibreSensorChange("SN222");
-        checkLibreSensorChange("SN222");
-        checkLibreSensorChange("SN333");
-        this_sensor = Sensor.currentSensor();
-        Log.e("xxxxx", "Expectingthis_sensor to be null, actually " + this_sensor);
-        if (this_sensor != null) {
-            Sensor.stopSensor();
-        }
-        
-        // Create a new sensor, call check, then stop it and start another, all should be well.
-        Sensor.create(JoH.tsl());
-        checkLibreSensorChange("SN333");
-        checkLibreSensorChange("SN333");
-        checkLibreSensorChange("SN333");
-        this_sensor = Sensor.currentSensor();
-        Log.e("xxxxx", "Expectingthis_sensor not to be null, actually " + this_sensor);
-        if (this_sensor != null) {
-            Sensor.stopSensor();
-        }
-        Sensor.create(JoH.tsl());
-        checkLibreSensorChange("SN333");
-        checkLibreSensorChange("SN333");
-        this_sensor = Sensor.currentSensor();
-        Log.e("xxxxx", "Expectingthis_sensor not to be null, actually " + this_sensor);
-        
-    }
-    
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Tomato.java
@@ -182,6 +182,8 @@ public class Tomato {
         }
         Log.d(TAG, "patchUid = " + HexDump.dumpHexString(patchUid));
         Log.d(TAG, "patchInfo = " + HexDump.dumpHexString(patchInfo));
+        PersistentStore.setString("Tomatobattery", Integer.toString(s_full_data[13]));
+        Pref.setInt("bridge_battery", s_full_data[13]);
         boolean checksum_ok = NFCReaderX.HandleGoodReading(SensorSn, data, now, true, patchUid, patchInfo);
         Log.e(TAG, "We have all the data that we need " + s_acumulatedSize + " checksum_ok = " + checksum_ok + HexDump.dumpHexString(data));
 
@@ -194,8 +196,6 @@ public class Tomato {
             throw new RuntimeException(SERIAL_FAILED);
         }
 
-        PersistentStore.setString("Tomatobattery", Integer.toString(s_full_data[13]));
-        Pref.setInt("bridge_battery", s_full_data[13]);
         PersistentStore.setString("TomatoHArdware",HexDump.toHexString(s_full_data,16,2));
         PersistentStore.setString("TomatoFirmware",HexDump.toHexString(s_full_data,14,2));
         PersistentStore.setString("LibreSN", SensorSn);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -241,7 +241,7 @@ public class NFCReaderX {
             Log.e(TAG, "Error could not create libreBlock for libre-allhouse");
             return;
         }
-        final String json = libreBlock.toJson();
+        final String json = libreBlock.toExtendedJson();
         
         GcmActivity.pushLibreBlock(json);
     

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -26,6 +26,7 @@ import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.LibreBlock;
 import com.eveningoutpost.dexdrip.Models.LibreOOPAlgorithm;
 import com.eveningoutpost.dexdrip.Models.ReadingData;
+import com.eveningoutpost.dexdrip.Models.SensorSanity;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.UtilityModels.LibreUtils;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
@@ -311,6 +312,10 @@ public class NFCReaderX {
                 if (succeeded) {
                     long now = JoH.tsl();
                     String SensorSn = LibreUtils.decodeSerialNumberKey(tag.getId());
+                    
+                    if (SensorSanity.checkLibreSensorChangeIfEnabled(SensorSn)) {
+                        Log.e(TAG, "Problem with Libre Serial Number - not processing");
+                    }
                     boolean checksum_ok = HandleGoodReading(SensorSn, data, now, false, tag.getId(), patchInfo);
                     if(checksum_ok == false) {
                         Log.e(TAG, "Read data but checksum is wrong");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -62,9 +62,6 @@ public class NFCReaderX {
     private static final boolean useReaderMode = true;
     private static boolean nfc_enabled = false;
 
-    // An object that is used to sync the processReadData
-    private static final Object processReadDataLock = new Object();
-
     public static void stopNFC(Activity context) {
         if (foreground_enabled) {
             try {
@@ -232,11 +229,6 @@ public class NFCReaderX {
             // We already have this one, so we have already sent it, so let's not crate storms.
             return;
         }
-        if (!JoH.ratelimit("libre-allhouse", 5)) {
-            // Do not create storm of packets.
-            Log.e(TAG, "Rate limited start libre-allhouse");
-            return;
-        }
         // Create the object to send
         libreBlock = LibreBlock.create(tagId, CaptureDateTime, data1, 0, patchUid, patchInfo);
         if(libreBlock == null) {
@@ -279,7 +271,7 @@ public class NFCReaderX {
                     final PowerManager.WakeLock wl = JoH.getWakeLock("processTransferObject", 60000);
                     try {
                         // Protect against wifi reader and gmc reader coming at the same time.
-                        synchronized (processReadDataLock) {
+                        synchronized (NFCReaderX.class) {
                             mResult.CalculateSmothedData();
                             LibreAlarmReceiver.processReadingDataTransferObject(new ReadingData.TransferObject(1, mResult), CaptureDateTime, tagId, allowUpload, patchUid, patchInfo );
                             Home.staticRefreshBGCharts();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
@@ -58,6 +58,9 @@ public class LibreWifiReader extends AsyncTask<String, Void, Void> {
     private static final Gson gson = JoH.defaultGsonInstance();
 
     private final static long DEXCOM_PERIOD = 300000;
+    
+    // An object that is used to sync the readData
+    private static final Object readDataLock = new Object();
 
     // This variables are for fake function only
     static int i = 0;
@@ -407,8 +410,9 @@ public class LibreWifiReader extends AsyncTask<String, Void, Void> {
     public Void doInBackground(String... urls) {
         final PowerManager.WakeLock wl = JoH.getWakeLock("LibreWifiReader", 120000);
         try {
-            //getwakelock();
-            readData();
+            synchronized (readDataLock) {
+                readData();
+            }
         } finally {
             JoH.releaseWakeLock(wl);
            // Log.d(TAG, "wakelock released " + lockCounter);
@@ -464,7 +468,6 @@ public class LibreWifiReader extends AsyncTask<String, Void, Void> {
         for (LibreWifiData LastReading : LibreWifiDataArr) {
             // Last in the array is the most updated reading we have.
             //TransmitterRawData LastReading = LastReadingArr[LastReadingArr.length -1];
-
 
             //if (LastReading.CaptureDateTime > LastReportedReading + 5000) {
             // Make sure we do not report packets from the far future...

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
@@ -59,9 +59,6 @@ public class LibreWifiReader extends AsyncTask<String, Void, Void> {
 
     private final static long DEXCOM_PERIOD = 300000;
     
-    // An object that is used to sync the readData
-    private static final Object readDataLock = new Object();
-
     // This variables are for fake function only
     static int i = 0;
     static int added = 5;
@@ -410,7 +407,7 @@ public class LibreWifiReader extends AsyncTask<String, Void, Void> {
     public Void doInBackground(String... urls) {
         final PowerManager.WakeLock wl = JoH.getWakeLock("LibreWifiReader", 120000);
         try {
-            synchronized (readDataLock) {
+            synchronized (LibreWifiReader.class) {
                 readData();
             }
         } finally {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
@@ -14,6 +14,7 @@ import com.eveningoutpost.dexdrip.Models.Calibration;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.LibreBlock;
 import com.eveningoutpost.dexdrip.Models.Sensor;
+import com.eveningoutpost.dexdrip.Models.SensorSanity;
 import com.eveningoutpost.dexdrip.Models.TransmitterData;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.ParakeetHelper;
@@ -493,6 +494,10 @@ public class LibreWifiReader extends AsyncTask<String, Void, Void> {
                     PersistentStore.setString("TomatoFirmware",LastReading.FwVersion);
                     Log.i(TAG, "LastReading.SensorId " + LastReading.SensorId);
                     PersistentStore.setString("LibreSN", LastReading.SensorId);
+                    
+                    if (SensorSanity.checkLibreSensorChangeIfEnabled(LastReading.SensorId)) {
+                        Log.e(TAG, "Problem with Libre Serial Number - not processing");
+                    }
                     
                     
                 } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/PersistentStore.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/PersistentStore.java
@@ -32,6 +32,18 @@ public class PersistentStore {
     public static String getString(final String name) {
         return prefs.getString(name, "");
     }
+    
+    public static String getString(final String name, String defaultValue) {
+        return prefs.getString(name, defaultValue);
+    }
+    
+    public static int getStringToInt(final String name, final int defaultValue) {
+        try {
+            return Integer.parseInt(getString(name, Integer.toString(defaultValue)));
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
 
     public static boolean removeItem(final String pref) {
         if (prefs != null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1385,6 +1385,8 @@
     <string name="title_plus_accept_follower_actions">Accept follower actions</string>
     <string name="summary_plus_whole_house">Participate in a Whole House Network</string>
     <string name="title_plus_whole_house">Whole House</string>
+    <string name="summary_libre_whole_house_collector">This phone will be a collector in a whole house network</string>
+    <string name="title_libre_whole_house_collector">Libre Whole House</string>
     <string name="summary_xdrip_plus_desert_sync_settings">Off-Grid following</string>
     <string name="title_xdrip_plus_desert_sync_settings">Desert Sync</string>
     <string name="summary_desert_sync_enabled">Enabled local non-internet sync facilities</string>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -758,6 +758,14 @@
                 android:switchTextOff="@string/short_off_text_for_switches"
                 android:switchTextOn="@string/short_on_text_for_switches"
                 android:title="@string/title_plus_whole_house" />
+            <SwitchPreference
+                android:defaultValue="false"
+                android:dependency="plus_follow_master"
+                android:key="libre_whole_house_collector"
+                android:summary="@string/summary_libre_whole_house_collector"
+                android:switchTextOff="@string/short_off_text_for_switches"
+                android:switchTextOn="@string/short_on_text_for_switches"
+                android:title="@string/title_libre_whole_house_collector" />
             <CheckBoxPreference
                 android:defaultValue="true"
                 android:dependency="plus_follow_master"

--- a/app/src/test/java/com/eveningoutpost/dexdrip/Models/SensorSanityTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/Models/SensorSanityTest.java
@@ -2,6 +2,7 @@ package com.eveningoutpost.dexdrip.Models;
 
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
+import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 
 import org.junit.Test;
 
@@ -92,5 +93,52 @@ public class SensorSanityTest extends RobolectricTestWithConfig {
         } else {
             assertWithMessage(checkName + " sensor result not null").that(sensor).isNotNull();
         }
+    }
+
+    @Test
+    public void checkLibreSensorChangeTestRepeatStarting() {
+        // Take us to a known state:
+
+        Sensor.shutdownAllSensors();
+
+        Sensor this_sensor = Sensor.currentSensor();
+        assertWithMessage("Expecting this_sensor to be null after shutdownAllSensors").that(this_sensor).isNull();
+
+        SensorSanity.clearEnviorment();
+        
+        // Start testing: create a sensor, call checkLibreSensorChange twice with same sensor, and once with a new
+        // sn, and verify it is closed.
+        Sensor.create(JoH.tsl());
+        SensorSanity.checkLibreSensorChange("SN111");
+        SensorSanity.checkLibreSensorChange("SN111");
+        SensorSanity.checkLibreSensorChange("SN222");
+        this_sensor = Sensor.currentSensor();
+
+        assertWithMessage("Expecting this_sensor to be null after serial change").that(this_sensor).isNull();
+
+        // Continue testing: create new one, call with the second sn twice. now call with third sn, sensor should be stopped.
+        Sensor.create(JoH.tsl());
+        SensorSanity.checkLibreSensorChange("SN222");
+        SensorSanity.checkLibreSensorChange("SN222");
+        boolean retVal = SensorSanity.checkLibreSensorChange("SN333");
+        assertWithMessage("Expecting true after serial change").that(retVal).isEqualTo(true);
+        this_sensor = Sensor.currentSensor();
+        assertWithMessage("Expecting this_sensor to be null after serial change").that(this_sensor).isNull();
+
+        // Create a new sensor, call check, then stop it and start another, all should be well.
+        Sensor.create(JoH.tsl());
+        SensorSanity.checkLibreSensorChange("SN333");
+        SensorSanity.checkLibreSensorChange("SN333");
+        SensorSanity.checkLibreSensorChange("SN333");
+        this_sensor = Sensor.currentSensor();
+        assertWithMessage("Expecting this_sensor not to be null without serial change").that(this_sensor).isNotNull();
+        if (this_sensor != null) {
+            Sensor.stopSensor();
+        }
+        Sensor.create(JoH.tsl());
+        SensorSanity.checkLibreSensorChange("SN333");
+        SensorSanity.checkLibreSensorChange("SN333");
+        this_sensor = Sensor.currentSensor();
+        assertWithMessage("Expecting this_sensor not to be null without serial change").that(this_sensor).isNotNull();
     }
 }


### PR DESCRIPTION
This pr does the following:
1) Allow more than one phone to be used as a collector in a whole house network for libre (miaomiao/blucon/bubble). This is based on (almost) zero setup on xdrip normal channels.

2) Allow xDrip followers to see libre trend and bridge battery level.

3) Stop the sensor in a case a new sensor is detected also for bubble/direct scan/and libre wifi.

To add another receiver one has to do the following:
On the new phone:
1) Use source wizard to connect to libre. (until the new sensor has been scanned).
2) Use qr code to get security settings from current master.
3) Set the phone to master.
4) One should not start a new sensor on the new phone.

There is one improvement that I'm thinking of doing:
If the user will start a new sensor, and the user has also a follower phone on the network, the follower phone will receive BG messages from both phones.
To prevent this I'm thinking of adding a new button that will say something like: This phone is a libre receiver only. If this is set, the phone will only send messages of libreblock, and snooze alerts but not other messages (such as calibrations and BG).
Does this improvement looks good? Any suggestions for a better method?