### PR TITLE
Added Levemir to insulin types.

### DIFF
--- a/app/src/main/res/raw/insulin_profiles.txt
+++ b/app/src/main/res/raw/insulin_profiles.txt
@@ -40,6 +40,25 @@
       }
     },
     {
+          "name": "Levemir",
+          "displayName": "Levemir (long acting)",
+          "concentration": "U100",
+          "PPN":
+          [
+            "LevemirU100"
+          ],
+          "Curve":
+          {
+            "type": "linear trapezoid",
+            "data":
+            {
+              "onset": "60",
+              "peak": "480",
+              "duration": "1200"
+            }
+          }
+        },
+    {
       "name": "Humalog",
       "displayName": "Humalog (rapid acting)",
       "concentration": "U100",


### PR DESCRIPTION
For now I added Levemir. The numbers in there are based on the following websites:
https://www.ema.europa.eu/en/documents/product-information/levemir-epar-product-information_en.pdf (page 10)

www.diabetes-news.de/uebersicht-insulin-praeparate (It's in german, soory for those of you who have to use google translate)

https://www.diabetesde.org/ueber_diabetes/therapie_bei_diabetes/alles_ueber_insulin/verschiedene_insuline (Also in German, sorry for that).

Don't be scared that I may have mixed up some numbers there: I am a native german speaker, and the EMA document I've read in german. In german it's available at https://www.ema.europa.eu/en/documents/product-information/levemir-epar-product-information_de.pdf 