### PR TITLE
Libre2 improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     }
 }
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 //apply plugin: 'me.tatarka.retrolambda'
 //apply plugin: 'io.fabric'
 
@@ -33,6 +34,7 @@ repositories {
     flatDir {
         dirs 'libs'
     }
+    mavenCentral()
 }
 
 def generateVersionNumber = { ->
@@ -333,6 +335,7 @@ dependencies {
     // use lombok in unit tests
     testCompileOnly 'org.projectlombok:lombok:1.18.10'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.10'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 tasks.withType(Test) { 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -533,7 +533,11 @@ public class BgReading extends Model implements ShareUploadableBg {
     }
 
     public void postProcess(final boolean quick) {
-        injectNoise(true); // Add noise parameter for nightscout
+        postProcess(quick,false);
+    }
+
+    public void postProcess(final boolean quick, boolean handleLibre2Noise) {
+        injectNoise(true, handleLibre2Noise); // Add noise parameter for nightscout
         injectDisplayGlucose(BestGlucose.getDisplayGlucose()); // Add display glucose for nightscout
         BgSendQueue.handleNewBgReading(this, "create", xdrip.getAppContext(), Home.get_follower(), quick);
     }
@@ -1242,7 +1246,7 @@ public class BgReading extends Model implements ShareUploadableBg {
             return existing;
         }
     }
-    public static synchronized BgReading bgReadingInsertLibre2(double calculated_value, long timestamp, double raw_data) {
+    public static synchronized BgReading bgReadingInsertLibre2(double calculated_value, long timestamp, double raw_data, double noise) {
 
         final Sensor sensor = Sensor.currentSensor();
         if (sensor == null) {
@@ -1260,18 +1264,24 @@ public class BgReading extends Model implements ShareUploadableBg {
                 bgReading.sensor_uuid = sensor.uuid;
                 bgReading.raw_data = raw_data;
                 bgReading.age_adjusted_raw_value = raw_data;
-                bgReading.filtered_data = raw_data;
+                bgReading.filtered_data = calculated_value;
                 bgReading.timestamp = timestamp;
                 bgReading.uuid = UUID.randomUUID().toString();
                 bgReading.calculated_value = calculated_value;
                 bgReading.calculated_value_slope = 0;
-                bgReading.hide_slope = false;
+
+                // hide slope if noise is too high
+                bgReading.hide_slope = (!Double.isNaN(noise)) && noise >= BgGraphBuilder.NOISE_HIGH;
+
+                // this is a hack, but there is no way to store the raw noise estimate in BgReading
+                bgReading.noise = String.valueOf(noise);
+
                 bgReading.appendSourceInfo("Libre2 Native");
                 bgReading.find_slope();
 
                 bgReading.save();
                 bgReading.perform_calculations();
-                bgReading.postProcess(false);
+                bgReading.postProcess(false, true);
 
             } else {
                 Log.d(TAG, "Calibrations, so doing everything bgReading = " + bgReading);
@@ -1281,7 +1291,7 @@ public class BgReading extends Model implements ShareUploadableBg {
                 bgReading.calibration_uuid = calibration.uuid;
                 bgReading.raw_data = raw_data ;
                 bgReading.age_adjusted_raw_value = raw_data;
-                bgReading.filtered_data = raw_data;
+                bgReading.filtered_data = calculated_value;
                 bgReading.timestamp = timestamp;
                 bgReading.uuid = UUID.randomUUID().toString();
 
@@ -1289,7 +1299,13 @@ public class BgReading extends Model implements ShareUploadableBg {
                 bgReading.filtered_calculated_value = ((calibration.slope * bgReading.ageAdjustedFiltered()) + calibration.intercept);
 
                 bgReading.calculated_value_slope = 0;
-                bgReading.hide_slope = false;
+
+                // hide slope if noise is too high
+                bgReading.hide_slope = (!Double.isNaN(noise)) && noise >= BgGraphBuilder.NOISE_HIGH;
+
+                // this is a hack, but there is no way to store the raw noise estimate in BgReading
+                bgReading.noise = String.valueOf(noise);
+
                 bgReading.appendSourceInfo("Libre2 Native");
 
                 BgReading.updateCalculatedValueToWithinMinMax(bgReading);
@@ -1297,7 +1313,7 @@ public class BgReading extends Model implements ShareUploadableBg {
                 bgReading.find_slope();
                 bgReading.save();
 
-                bgReading.postProcess(false);
+                bgReading.postProcess(false, true);
 
             }
 
@@ -1834,11 +1850,36 @@ public class BgReading extends Model implements ShareUploadableBg {
     }
 
     public BgReading injectNoise(boolean save) {
+        return injectNoise(save,false);
+    }
+
+    public BgReading injectNoise(boolean save, boolean handleLibre2Noise) {
         final BgReading bgReading = this;
-        if (JoH.msSince(bgReading.timestamp) > Constants.MINUTE_IN_MS * 20) {
+        // Get our raw noise estimate back from our temporary stashing location
+        double libre2Noise = handleLibre2Noise ? Double.valueOf(bgReading.noise) : Double.NaN;
+        if (!handleLibre2Noise && JoH.msSince(bgReading.timestamp) > Constants.MINUTE_IN_MS * 20) {
             bgReading.noise = "0";
         } else {
             BgGraphBuilder.refreshNoiseIfOlderThan(bgReading.timestamp);
+            if (handleLibre2Noise) {
+                // We weren't able to determine a noise level
+                if (libre2Noise == Double.NaN) {
+                    // I don't like the way this is handled, but it mirrors the Dexcom way of doing things
+                    BgGraphBuilder.last_noise = -9999;
+
+                    // Storing data here creates a weird UI layout, so don't write the estimates
+                    // BgGraphBuilder.last_bg_estimate = -9999;
+                    // BgGraphBuilder.best_bg_estimate = -9999;
+                } else {
+                    BgGraphBuilder.last_noise = libre2Noise;
+
+                    // Storing data here creates a weird UI layout, so don't write the estimates
+                    // BgGraphBuilder.best_bg_estimate = bgReading.calculated_value;
+                    // BgGraphBuilder.last_bg_estimate = bgReading.calculated_value;
+                }
+                // restore the original value of the field
+                bgReading.noise = "0";
+            }
             if (BgGraphBuilder.last_noise > BgGraphBuilder.NOISE_HIGH) {
                 bgReading.noise = "4";
             } else if (BgGraphBuilder.last_noise > BgGraphBuilder.NOISE_TOO_HIGH_FOR_PREDICT) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Libre2RawValue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Libre2RawValue.java
@@ -29,7 +29,11 @@ public class Libre2RawValue extends PlusModel {
     public double glucose;
 
     public static List<Libre2RawValue> last20Minutes() {
-        double timestamp = (new Date().getTime()) - (60000 * 20);
+        return lastMinutes(20);
+    }
+
+    public static List<Libre2RawValue> lastMinutes(int minutes) {
+        double timestamp = (new Date().getTime()) - (60000 * minutes);
         return new Select()
                 .from(Libre2RawValue.class)
                 .where("ts >= " + timestamp)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/math/AdaptiveSavitzkyGolay.kt
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/math/AdaptiveSavitzkyGolay.kt
@@ -1,11 +1,12 @@
 package com.eveningoutpost.dexdrip.utils.math
 
 import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
+import java.lang.IllegalArgumentException
 import java.lang.IllegalStateException
 import kotlin.math.abs
 import kotlin.math.pow
 
-const val DEFAULT_TICKS_PER_MINUTE = 1000.0 * 60;
+const val DEFAULT_TICKS_PER_MINUTE = 1000.0 * 60
 const val LAG_TOLERANCE = 0.5
 
 class AdaptiveSavitzkyGolay @JvmOverloads constructor(

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/math/AdaptiveSavitzkyGolay.kt
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/math/AdaptiveSavitzkyGolay.kt
@@ -1,0 +1,108 @@
+package com.eveningoutpost.dexdrip.utils.math
+
+import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
+import java.lang.IllegalStateException
+import kotlin.math.abs
+import kotlin.math.pow
+
+const val DEFAULT_TICKS_PER_MINUTE = 1000.0 * 60;
+
+class AdaptiveSavitzkyGolay @JvmOverloads constructor(
+        val lag: Int,
+        val polynomialOrder: Int,
+        val curvaturePenalty: Double = 0.0,
+        val ticksPerUnitTime : Double = DEFAULT_TICKS_PER_MINUTE
+) {
+
+    data class RawMeasurement(val time: Long, val glucose: Double)
+
+    private val rawMeasurements = mutableListOf<RawMeasurement>()
+
+    val measurementCount get() = if (curvaturePenalty > 0) maxOf(rawMeasurements.size - 1,0) else rawMeasurements.size
+
+    fun addMeasurement(time: Long, glucose: Double) {
+        if (rawMeasurements.isNotEmpty() && time <= rawMeasurements.last().time) {
+            TODO("error handling!")
+        }
+        rawMeasurements.add(RawMeasurement(time,glucose))
+    }
+
+    private data class WeightsResult(val w : DoubleArray, val t : DoubleArray, val y : DoubleArray)
+
+    private fun calculateCurvaturePenalizedData(t: DoubleArray, y: DoubleArray) : WeightsResult {
+        val dt = (t.asSequence() + sequenceOf(t.last() + 1.0)).zipWithNext { t1, t2 -> t2 - t1}
+        val dy = (y.asSequence() + sequenceOf(y.last())).zipWithNext { y1, y2 -> y2 - y1}
+
+        val dydt = dy.zip(dt){dy,dt -> dy/dt}
+
+        val d_diff = dydt.zipWithNext { d1, d2 -> abs(d2 - d1) }.toList().toDoubleArray()
+        val d_diff_max = d_diff.max() ?: Double.NaN
+
+        val w = d_diff.map { it -> 1.0 - curvaturePenalty * it / d_diff_max}.toDoubleArray()
+        w[w.size - 1] = 1.0
+
+        return WeightsResult(
+                w,
+                t.drop(1).toDoubleArray(),
+                y.drop(1).toDoubleArray()
+        )
+    }
+
+    fun calculateCoefficients(x: DoubleArray, w: DoubleArray? = null) : DoubleArray {
+
+        var A = arrayOf<DoubleArray>()
+
+        if (w != null) {
+            for (i in x.indices) {
+                val row = DoubleArray(polynomialOrder + 1)
+                for (j in 0..polynomialOrder)
+                    row[j] = x[i].pow(j) * w[i]
+                A += row
+            }
+        } else {
+            for (i in x.indices) {
+                val row = DoubleArray(polynomialOrder + 1)
+                for (j in 0..polynomialOrder)
+                    row[j] = x[i].pow(j)
+                A += row
+            }
+        }
+
+        val ols = OLSMultipleLinearRegression()
+        ols.newSampleData(x,A)
+        val coefficients = ols.estimateRegressionParameters()
+
+        w?.forEachIndexed { i, w -> coefficients[i] *= w }
+
+        return coefficients
+    }
+
+    fun estimateValue() : Double {
+
+        if (lag >= measurementCount - 2) {
+            throw IllegalStateException("Not enough measurements for specified lag")
+        }
+
+        if (polynomialOrder > measurementCount) {
+            throw IllegalStateException("Not enough measurements for polynomial order")
+        }
+
+        val zeroTime = rawMeasurements[rawMeasurements.size - lag].time
+        var t = rawMeasurements.map{ (it.time - zeroTime) / ticksPerUnitTime }.toDoubleArray()
+        var y = rawMeasurements.map { it.glucose }.toDoubleArray()
+
+        var w : DoubleArray? = null
+
+        if (curvaturePenalty > 0) {
+            val (w,t,y) = calculateCurvaturePenalizedData(t,y)
+
+            // calculate scalar products
+            return calculateCoefficients(t,w).asSequence().zip(y.asSequence()) { c,y -> c*y }.sum();
+        } else {
+            // calculate scalar products
+            return calculateCoefficients(t,w).asSequence().zip(y.asSequence()) { c,y -> c*y }.sum();
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/math/PolynomialFitErrorEstimator.kt
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/math/PolynomialFitErrorEstimator.kt
@@ -1,0 +1,135 @@
+package com.eveningoutpost.dexdrip.utils.math
+
+import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
+import java.lang.RuntimeException
+import kotlin.math.pow
+
+/**
+ * General error estimator measuring a least-squares fit to a polynomial based on two separate
+ * data sets.
+ *
+ * This error estimator takes a set of filtered measurements and fits a polynomial of [order] to
+ * those data points. It then estimates the error variance of a second set of raw measurements
+ * w.r.t. the fitted polynomial, optionally debiasing the raw data using the method given by [bias].
+ * It returns the error variance as defined by dot(r,r) / (size(r) - order - 1), where r is the vector
+ * of (possibly debiased) residuals of the raw data set when compared to the predicted values of the
+ * fitted polynomial.
+ *
+ * This error estimator is derived from the one used for noise estimation in the Dexcom codepath and
+ * uses the same [OLSMultipleLinearRegression] class. The original implementation is not well suited
+ * to the Libre2 sensor, which produces a raw reading every minute, and the estimated noise for that
+ * sensor should take the characteristics of the raw data into account. At the same time, the polynomial
+ * approximation curve should be based on the filtered data (produced once every five minutes), as that
+ * is the primary data presented to the user and possibly downstream apps like Nightscout or AAPS.
+ *
+ * The filtered data will typically exhibit some time lag when compared to the raw data, which artificially
+ * inflates for rising / falling BG curves. In order to eliminate this artifical error, the algorithm
+ * can optionally debias the residuals of the raw data by subtracting either the mean or the median
+ * residual.
+ */
+class PolynomialFitErrorEstimator @JvmOverloads constructor(
+        val order : Int,
+        val bias : Bias = Bias.MEDIAN,
+        val ticksPerUnitTime : Double = DEFAULT_TICKS_PER_MINUTE
+) {
+
+    init {
+        if (order < 1) {
+            throw IllegalArgumentException("polynomial order must be >= 1")
+        }
+    }
+
+    enum class Bias {
+        NONE, MEAN, MEDIAN
+    }
+
+    data class Measurement(val time: Long, val glucose: Double)
+
+    private val rawMeasurements = mutableListOf<Measurement>()
+    private val filteredMeasurements = mutableListOf<Measurement>()
+
+    fun addRawMeasurement(time: Long, glucose: Double) {
+        if (rawMeasurements.isNotEmpty() && time <= rawMeasurements.last().time) {
+            TODO("error handling!")
+        }
+        rawMeasurements.add(Measurement(time,glucose))
+    }
+
+    fun addFilteredMeasurement(time: Long, glucose: Double) {
+        if (filteredMeasurements.isNotEmpty() && time <= filteredMeasurements.last().time) {
+            TODO("error handling!")
+        }
+        filteredMeasurements.add(Measurement(time,glucose))
+    }
+
+    private fun median(a : DoubleArray) : Double {
+        val a_s = a.sortedArray()
+        val midpoint = a_s.size / 2
+        if (a_s.size % 2 == 0) {
+            return 0.5 * (a_s[midpoint - 1] + a_s[midpoint])
+        } else {
+            return a_s[midpoint]
+        }
+    }
+
+    private fun mean(a : DoubleArray) : Double {
+        return a.sum() / a.size;
+    }
+
+    fun estimateError() : Double {
+
+        val zeroTime = filteredMeasurements.first().time
+
+        val t_f = filteredMeasurements.map{ (it.time - zeroTime) / ticksPerUnitTime }.toDoubleArray()
+        val y_f = filteredMeasurements.map{ it.glucose }.toDoubleArray()
+
+        var A = arrayOf<DoubleArray>()
+
+        for (i in t_f.indices) {
+            val row = DoubleArray(order)
+            for (j in 1..order)
+                row[j-1] = t_f[i].pow(j)
+            A += row
+        }
+
+        // we have to skip the first column in the matrix and set isNoIntercept = false. That makes
+        // the OLSMultipleLinearRegression class add the first intercept column (which is all 1s).
+        // There is a bug in the validation code inside OLSMultipleLinearRegression that trips otherwise
+        // if we have the minimum viable number of data points (order + 1).
+        val ols = OLSMultipleLinearRegression()
+        ols.isNoIntercept = false
+
+        try {
+            ols.newSampleData(y_f, A)
+
+            val params = ols.estimateRegressionParameters()
+
+            val predictions = DoubleArray(rawMeasurements.size)
+            val t_r = rawMeasurements.map{ (it.time - zeroTime) / ticksPerUnitTime }.toDoubleArray()
+            val y_r = rawMeasurements.map{ it.glucose }.toDoubleArray()
+
+            for (i in predictions.indices) {
+                predictions[i] = 0.0
+                for (j in 0..order)
+                    predictions[i] += params[j] * t_r[i].pow(j)
+            }
+
+            val r = y_r.zip(predictions) { y, p -> y - p }.toDoubleArray()
+            val b = when(bias) {
+                Bias.MEAN -> mean(r)
+                Bias.MEDIAN -> median(r)
+                else -> 0.0
+            }
+
+            for (i in r.indices)
+                r[i] -= b
+
+            // formula copied from OLS.estimateErrorVariance()
+            return r.asSequence().map{ it * it }.sum() / (r.size - order - 1)
+
+        } catch (e : RuntimeException) {
+            return Double.NaN;
+        }
+
+    }
+}

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1383,14 +1383,6 @@
                     android:title="Savitzky-Golay polynomial order" />
                 <EditTextPreference
                     android:dependency="engineering_mode"
-                    android:defaultValue="0.0"
-                    android:key="Libre2_sgDiffJumpPenalty"
-                    android:selectAllOnFocus="true"
-                    android:singleLine="true"
-                    android:summary="The polynomial order of the Savitzky-Golay smoother"
-                    android:title="Savitzky-Golay finite difference jump penalty" />
-                <EditTextPreference
-                    android:dependency="engineering_mode"
                     android:defaultValue="0.333"
                     android:key="Libre2_sgWeightedAverageFraction"
                     android:selectAllOnFocus="true"

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1352,6 +1352,75 @@
                     android:key="Libre2_showSensors"
                     android:summary="switch to On to show additional Information's in Status for Libre 2 Sensors"
                     android:title="show Sensors Infos in Status" />
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:key="Libre2_useSavitzkyGolay"
+                    android:summary="switch to On to use Savitzky-Golay filter for smoothing raw BG values"
+                    android:title="Use Savitzky-Golay filter" />
+                <EditTextPreference
+                    android:dependency="engineering_mode"
+                    android:defaultValue="25"
+                    android:key="Libre2_sgHorizon"
+                    android:selectAllOnFocus="true"
+                    android:singleLine="true"
+                    android:summary="The number of minutes that the Savitzky-Golay smoother looks back in time"
+                    android:title="Savitzky-Golay smoothing horizon" />
+                <EditTextPreference
+                    android:dependency="engineering_mode"
+                    android:defaultValue="2"
+                    android:key="Libre2_sgLag"
+                    android:selectAllOnFocus="true"
+                    android:singleLine="true"
+                    android:summary="The lag (in number of raw values) from the most recent value at which the Savitzky-Golay smoother is evaluated"
+                    android:title="Savitzky-Golay Smoothing Lag" />
+                <EditTextPreference
+                    android:dependency="engineering_mode"
+                    android:defaultValue="3"
+                    android:key="Libre2_sgPolynomialOrder"
+                    android:selectAllOnFocus="true"
+                    android:singleLine="true"
+                    android:summary="The polynomial order of the Savitzky-Golay smoother"
+                    android:title="Savitzky-Golay polynomial order" />
+                <EditTextPreference
+                    android:dependency="engineering_mode"
+                    android:defaultValue="0.0"
+                    android:key="Libre2_sgDiffJumpPenalty"
+                    android:selectAllOnFocus="true"
+                    android:singleLine="true"
+                    android:summary="The polynomial order of the Savitzky-Golay smoother"
+                    android:title="Savitzky-Golay finite difference jump penalty" />
+                <EditTextPreference
+                    android:dependency="engineering_mode"
+                    android:defaultValue="0.333"
+                    android:key="Libre2_sgWeightedAverageFraction"
+                    android:selectAllOnFocus="true"
+                    android:singleLine="true"
+                    android:summary="Savitzky-Golay computes the final value as a linear combination of its result and a weighted average with the fraction given here."
+                    android:title="Savitzky-Golay weighted average fraction of final value" />
+                <EditTextPreference
+                    android:dependency="engineering_mode"
+                    android:defaultValue="15"
+                    android:key="Libre2_sgWeightedAverageHorizon"
+                    android:selectAllOnFocus="true"
+                    android:singleLine="true"
+                    android:summary="The time horizon in minutes used for the weighted average. Must be smaller than the Savitzky-Golay horizon."
+                    android:title="Savitzky-Golay weighted average horizon" />
+                <EditTextPreference
+                    android:dependency="engineering_mode"
+                    android:defaultValue="16"
+                    android:key="noiseHorizon"
+                    android:selectAllOnFocus="true"
+                    android:singleLine="true"
+                    android:summary="The time horizon in minutes used for Libre2 noise estimation."
+                    android:title="Noise estimation horizon" />
+                <EditTextPreference
+                    android:dependency="engineering_mode"
+                    android:defaultValue="16"
+                    android:key="noisePolynomialOrder"
+                    android:selectAllOnFocus="true"
+                    android:singleLine="true"
+                    android:summary="The polyonmial order used for fitting the filtered values."
+                    android:title="Noise estimation polynomial order" />
             </PreferenceScreen>
 
             <CheckBoxPreference

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()
@@ -14,6 +15,7 @@ buildscript {
 
         apply plugin: 'java'
         apply plugin: 'maven'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
# Intro

This MR improves the current support for Libre2 data based on the patched Libre app.
It contains the following changes:

- Adds Kotlin support to the project (required for the math utilities in the MR)
- Adds an alternative smoothing algorithm based on a Savitzky-Golay filter, optionally mixed with a weighted average
- Adds a noise estimator for Libre2 data which is based on the estimation idea of the Dexcom code, but takes advantage
  of the higher-frequency raw data of the Libre2 sensor.

# Filtering

The Savitzky-Golay filter is based on the Wikipedia description at https://en.wikipedia.org/wiki/Savitzky%E2%80%93Golay_filter. The filtering coefficients are recalculated every time we generate a smoothed value, because the standard Savitzky-Golay coefficients assume a regular spacing of the data points, which we cannot guarantee as points will often be missing. The filter works by fitting the data in a window to a given polynomial. Standard Savitzky-Golay uses a centered window, i.e. it produces a value for the middle of the window. We are more interested in a value to the right of the window (as that is closer to the current time). I have done a bit of data science on my own raw Libre2 values as stored in the app, and for me the optimum parameters are a window length of 25 minutes, a cubic polynomial and a delay of 2 minutes. If someone is interested in testing the parameters on their own data, I can share the Jupyter notebook that directly works on the exported xDrip db.
My experiments have also shown that it might be better to calculate a linear combination of the Savitzky-Golay filter and a weighted average like the one that is currently in use, as that provides the best combination of quick response and smooth curves, at least for my data. As a result, the code as posted mixes 2/3 of Savitzky-Golay with 1/3 of a weighted average with a horizon of 15 minutes.
The Savitzky-Golay algorithm can be enabled in the preferences under advanced Libre2 settings and is disabled by default. All of its parameters can also be adjusted, but are gated by the engineering mode.

# Noise Estimation

People are interested in using Libre2 data with SMB in AndroidAPS (and I might be too, once I get my pumped approved by the insurance and have collected enough experience), but doing so requires noise filtering of the data sent to AAPS. This MR also contains a noise estimator built on the same principles as the one for Dexcom, but it makes use of the raw data in addition to the filtered data. Looking at my own Libre2 data again, the noise estimator tends to react quicker than the Dexcom approach of just operating on the filtered data, but it is of course different. Again, I can provide a Jupyter notebook so that people can verify the algorithm on their own data.