### PR TITLE
avoids unbonding of Dexcom receiver at every read request

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -261,7 +261,7 @@ dependencies {
     implementation 'io.reactivex:rxjava:1.3.3'
     implementation 'com.activeandroid:thread-safe-active-android:3.1.1'
     //implementation 'com.github.lecho:hellocharts-android:v1.5.8'
-    implementation "com.polidea.rxandroidble2:rxandroidble:1.11.0"
+    implementation "com.polidea.rxandroidble2:rxandroidble:1.11.1"
     implementation 'com.google.guava:guava:24.1-android'
     implementation 'com.embarkmobile:zxing-android-minimal:2.0.0@aar'
     implementation 'com.embarkmobile:zxing-android-integration:2.0.0@aar'

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
@@ -317,10 +317,6 @@ public class Ob1G5CollectionService extends G5BaseService {
                             UserError.Log.d(TAG, "Skipping Scanning! : Changing state due to minimize_scanning flags");
                             changeState(CONNECT_NOW);
                         } else {
-                            if (Build.VERSION.SDK_INT >= 29) { // TODO add preference option for this
-                                UserError.Log.d(TAG, "Attempting Android 10+ workaround unbonding");
-                                unBond();
-                            }
                             scan_for_device();
                         }
                         break;

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -179,7 +179,7 @@ dependencies {
     implementation 'com.activeandroid:thread-safe-active-android:3.1.1'
     implementation 'com.google.guava:guava:24.1-jre'
     implementation 'io.reactivex:rxjava:1.3.3'
-    implementation 'com.polidea.rxandroidble2:rxandroidble:1.10.1'
+    implementation 'com.polidea.rxandroidble2:rxandroidble:1.11.1'
     implementation 'org.apache.commons:commons-math3:3.6'
     testImplementation "org.robolectric:robolectric:4.2.1"
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
Fixes #1494 

There is no way around reverting commit b0bb827. During every bond, Android 8.0 onwards with the [Android Security Bulletin—November 2020](https://source.android.com/security/bulletin/2020-11-01?hl=en) installed, shows a Bluetooth pairing request consent dialog (see fixes of CVE-2020-12856, specifically [A-157038281 [3]](https://android.googlesource.com/platform/system/bt/+/b3f12befdc4def7d695b6f1049cd02238eb1e4a8)).

Issue #1061 has to be fixed differently.