### PR TITLE
add foregroundServiceType to services using Bluetooth

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -107,7 +107,9 @@
         <service
             android:name=".Services.DexCollectionService"
             android:enabled="true"
-            android:exported="true" />
+            android:exported="true"
+            android:foregroundServiceType="connectedDevice|location"
+            />
         <service
             android:name=".Services.WifiCollectionService"
             android:enabled="true"
@@ -359,11 +361,15 @@
         <service
             android:name=".insulin.pendiq.PendiqService"
             android:enabled="true"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice|location"
+            />
         <service
             android:name=".cgm.medtrum.MedtrumCollectionService"
             android:enabled="true"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice|location"
+            />
 
         <activity
             android:name=".ShareTest"
@@ -427,7 +433,9 @@
         <service
             android:name=".UtilityModels.pebble.PebbleWatchSync"
             android:enabled="true"
-            android:exported="true" />
+            android:exported="true"
+            android:foregroundServiceType="connectedDevice|location"
+            />
         <service
             android:name=".Services.DailyIntentService"
             android:exported="false" />
@@ -596,7 +604,9 @@
         <service
             android:name=".Services.DoNothingService"
             android:enabled="true"
-            android:exported="true" />
+            android:exported="true"
+            android:foregroundServiceType="connectedDevice|location"
+            />
 
         <activity android:name=".HelpActivity" />
         <activity
@@ -687,10 +697,16 @@
             android:name=".wearintegration.Amazfitservice"
             android:enabled="true"
             android:exported="true" />
-        <service android:name=".watch.lefun.LeFunService" />
-        <service android:name=".watch.miband.MiBandService" />
+        <service android:name=".watch.lefun.LeFunService"
+            android:foregroundServiceType="connectedDevice|location"
+            />
+        <service android:name=".watch.miband.MiBandService"
+            android:foregroundServiceType="connectedDevice|location"
+            />
         <service android:name=".cgm.nsfollow.NightscoutFollowService" />
-        <service android:name=".insulin.inpen.InPenService" />
+        <service android:name=".insulin.inpen.InPenService"
+            android:foregroundServiceType="connectedDevice|location"
+            />
         <service android:name=".cgm.sharefollow.ShareFollowService" />
 
         <activity


### PR DESCRIPTION
With Android 10+ some privacy features have been [implemented](https://developer.android.com/about/versions/10/privacy/changes), especially, background services accessing Bluetooth devices also need [location permissions](https://developer.android.com/about/versions/10/privacy/changes#app-access-device-location).

If this permission is not granted, exceptions are thrown as reported with #1566 and as I discovered with InPen authorization. Because we are using compileSdkVersion 29 (even if our targetSdkVersion is 23) we have to the foregroundServiceType.

This PR adds this to all services using Bluetooth and this should fix #1566.