### PR TITLE
enable incremental debug builds and apply changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,20 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.newrelic.agent.android:agent-gradle-plugin:5.27.1"
+        if (getGradle().getStartParameter().getTaskRequests().toString().endsWith("Release")) {
+            println("Enabling New Relic")
+            classpath "com.newrelic.agent.android:agent-gradle-plugin:5.27.1"
+        }
     }
 }
 apply plugin: 'com.android.application'
-apply plugin: 'newrelic'
+if (getGradle().getStartParameter().getTaskRequests().toString().endsWith("Release")) {
+    apply plugin: 'newrelic'
+    newrelic {
+        variantMapsEnabled false
+        uploadMapsForVariant ''
+    }
+}
 //apply plugin: 'me.tatarka.retrolambda'
 //apply plugin: 'io.fabric'
 
@@ -111,11 +120,6 @@ def generateVersionName = { ->
     stringBuilder.append((new Date()).format('yyyy.MM.dd'))
     return stringBuilder.toString()
 
-}
-
-newrelic {
-    variantMapsEnabled false
-    uploadMapsForVariant ''
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,7 +146,21 @@ android {
         //vectorDrawables.useSupportLibrary = true // broken in newer gradle versions
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
+        // workaround till #1596 gets merged
+        resValue "string", "google_maps_key", "AIzaSyDOa0FJV2h2qf0tJ-kSeX1Sk2f1-IbUOz4"
+    }
 
+    // The defaultConfig values above are fixed, so your incremental builds don't
+    // need to rebuild the manifest (and therefore the whole APK, slowing build times).
+    // But for release builds, it's okay. So the following script iterates through
+    // all the known variants, finds those that are "release" build types, and
+    // changes those properties to something dynamic.
+    applicationVariants.all { variant ->
+        if (variant.buildType.name == "release") {
+            variant.outputs.each { output ->
+                output.versionNameOverride = generateVersionName()
+            }
+        }
     }
 
     testOptions {
@@ -193,7 +207,44 @@ android {
             versionNameSuffix "-debug"
             debuggable true
         }
+        dev {
+            minifyEnabled false
+            shrinkResources false
+            useProguard false
+            ext.enableCrashlytics = false
+            ext.alwaysUpdateBuildId = false
+            versionNameSuffix "-debug"
+            debuggable true
+            signingConfig debug.signingConfig
+            matchingFallbacks = ['debug', 'release']
+        }
     }
+
+    flavorDimensions "version"
+    productFlavors {
+        // When building a variant that uses this flavor, the following configurations
+        // override those in the defaultConfig block.
+        fast {
+            // To avoid using legacy multidex when building from the command line,
+            // set minSdkVersion to 21 or higher. When using Android Studio 2.3 or higher,
+            // the build automatically avoids legacy multidex when deploying to a device running
+            // API level 21 or higher—regardless of what you set as your minSdkVersion.
+            minSdkVersion 21
+            versionNameSuffix "-dev"
+            buildConfigField "int", "buildVersion", "2021010100"
+            buildConfigField "String", "buildUUID", "\"0f79a60a-5616-99be-8eb1-a430edcfd9fd\""
+            buildConfigField "long", "buildTimestamp", "1609459200L"
+            resConfigs "en", "xxhdpi"
+        }
+
+        prod {
+            // If you've configured the defaultConfig block for the release version of
+            // your app, you can leave this block empty and Gradle uses configurations in
+            // the defaultConfig block instead. You still need to create this flavor.
+            // Otherwise, all variants use the "dev" flavor configurations.
+        }
+    }
+
 }
 
 // auto test rig

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.3'
         classpath 'com.google.gms:google-services:4.3.3'
  //       classpath 'me.tatarka:gradle-retrolambda:3.7.0'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,10 @@
 # TODO we should lowercase the package names, see https://stackoverflow.com/questions/52495124/gradle-plugin-3-2-0-with-databinding-can-not-resolve-package-name
 android.databinding.enableV2=false
 org.gradle.daemon=true
+# Enable Build Caching (https://docs.gradle.org/current/userguide/build_cache.html#build_cache)
 org.gradle.caching=true
+# Enable parallel build of modules (https://docs.gradle.org/current/userguide/performance.html#parallel_execution)
 org.gradle.parallel=true
-org.gradle.vfs.watch=true
+# Enable configure on demand (https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand)
 org.gradle.warning.mode=summary
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,8 @@
 # TODO we should lowercase the package names, see https://stackoverflow.com/questions/52495124/gradle-plugin-3-2-0-with-databinding-can-not-resolve-package-name
 android.databinding.enableV2=false
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.vfs.watch=true
+org.gradle.warning.mode=summary
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,10 @@ org.gradle.daemon=true
 org.gradle.caching=true
 # Enable parallel build of modules (https://docs.gradle.org/current/userguide/performance.html#parallel_execution)
 org.gradle.parallel=true
-# Enable configure on demand (https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand)
+# When set to all, summary or none, Gradle will use different warning type display (https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_logging)
 org.gradle.warning.mode=summary
+# Enable watching the file system (https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:daemon_watch_fs).
+org.gradle.vfs.watch=true
+# Enable configure on demand (https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand)
+org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 23 09:38:09 BST 2020
+#Tue Jan 12 16:25:42 CET 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -114,6 +114,19 @@ android {
 
     }
 
+    // The defaultConfig values above are fixed, so your incremental builds don't
+    // need to rebuild the manifest (and therefore the whole APK, slowing build times).
+    // But for release builds, it's okay. So the following script iterates through
+    // all the known variants, finds those that are "release" build types, and
+    // changes those properties to something dynamic.
+    applicationVariants.all { variant ->
+        if (variant.buildType.name == "release") {
+            variant.outputs.each { output ->
+                output.versionNameOverride = generateVersionName()
+            }
+        }
+    }
+
     testOptions {
         unitTests {
             includeAndroidResources = true
@@ -138,6 +151,31 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    
+    flavorDimensions "version"
+    productFlavors {
+        // When building a variant that uses this flavor, the following configurations
+        // override those in the defaultConfig block.
+        fast {
+            // To avoid using legacy multidex when building from the command line,
+            // set minSdkVersion to 21 or higher. When using Android Studio 2.3 or higher,
+            // the build automatically avoids legacy multidex when deploying to a device running
+            // API level 21 or higher—regardless of what you set as your minSdkVersion.
+            minSdkVersion 21
+            versionNameSuffix "-dev"
+            buildConfigField "int", "buildVersion", "2021010100"
+            buildConfigField "String", "buildUUID", "\"0f79a60a-5616-99be-8eb1-a430edcfd9fe\""
+            buildConfigField "long", "buildTimestamp", "1609459200L"
+            resConfigs "en", "xxhdpi"
+        }
+
+        prod {
+            // If you've configured the defaultConfig block for the release version of
+            // your app, you can leave this block empty and Gradle uses configurations in
+            // the defaultConfig block instead. You still need to create this flavor.
+            // Otherwise, all variants use the "dev" flavor configurations.
         }
     }
 }


### PR DESCRIPTION
This PR enables incremental debug builds and minimizes build time if "Apply changes" is executed by introducing an additional build type and a [productFlavor](https://developer.android.com/studio/build/build-variants#product-flavors) `fast`.

A cleaner way would be to disable `minifyEnabled` and `shrinkResources` in the debug buildType, which is the default and not really necessary. This would avoid the introduction of the new buildType `dev`.

The main reason that the incremental compilation did not work is the usage of timestamps and random UUIDs in the `buildConfigField`. These are not necessary for debug or development builds.