### PR TITLE
replace "yes" and "no" with resource strings

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -736,7 +736,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                     dialog.dismiss();
                 });
 
-                builder.setNegativeButton("NO", (dialog, which) -> dialog.dismiss());
+                builder.setNegativeButton(gs(R.string.no), (dialog, which) -> dialog.dismiss());
 
                 AlertDialog alert = builder.create();
                 alert.show();
@@ -776,7 +776,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                     dialog.dismiss();
                 });
 
-                builder.setNegativeButton("NO", (dialog, which) -> {
+                builder.setNegativeButton(gs(R.string.no), (dialog, which) -> {
                     // TODO make this a blood test entry xx
                     calintent.putExtra("note_only", "true");
                     startIntentThreadWithDelayedRefresh(calintent);
@@ -803,7 +803,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                         dialog.dismiss();
                     });
 
-                    builder.setNegativeButton("NO", (dialog, which) -> dialog.dismiss());
+                    builder.setNegativeButton(gs(R.string.no), (dialog, which) -> dialog.dismiss());
 
                     final AlertDialog alert = builder.create();
                     alert.show();
@@ -1046,7 +1046,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                                 staticRefreshBGCharts();
                                 JoH.static_toast_short(gs(R.string.deleted));
                             });
-                            builder1.setNegativeButton("No", (dialog1, which1) -> dialog1.dismiss());
+                            builder1.setNegativeButton(gs(R.string.no), (dialog1, which1) -> dialog1.dismiss());
                             final AlertDialog alert = builder1.create();
                             alert.show();
                         });
@@ -2504,7 +2504,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                     final Context context = this;
                     builder.setTitle(gs(R.string.restore_backup));
                     builder.setMessage(gs(R.string.do_you_want_to_restore_the_backup_file_) + Pref.getString("last-saved-database-zip", "ERROR").replaceFirst("^.*/", ""));
-                    builder.setNegativeButton("No", (dialog, which) -> dialog.dismiss());
+                    builder.setNegativeButton(gs(R.string.no), (dialog, which) -> dialog.dismiss());
                     builder.setPositiveButton(gs(R.string.restore), (dialog, which) -> {
                         dialog.dismiss();
                         startActivity(new Intent(context, ImportDatabaseActivity.class).putExtra("importit", Pref.getString("last-saved-database-zip", "")).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
@@ -2659,7 +2659,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             final Context context = this;
             builder.setTitle(gs(R.string.calibrate_sensor));
             builder.setMessage(gs(R.string.we_have_some_readings__next_we_need_the_first_calibration_blood_test__ready_to_calibrate_now));
-            builder.setNegativeButton("No", (dialog, which) -> {
+            builder.setNegativeButton(gs(R.string.no), (dialog, which) -> {
                 dialog.dismiss();
                 helper_dialog = null;
             });
@@ -3288,7 +3288,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                     staticRefreshBGCharts();
                     JoH.static_toast_short(gs(R.string.deleted));
                 });
-                builder.setNegativeButton("No", (dialog12, which) -> dialog12.dismiss());
+                builder.setNegativeButton(gs(R.string.no), (dialog12, which) -> dialog12.dismiss());
                 final AlertDialog alert = builder.create();
                 alert.show();
             });

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5CollectionService.java
@@ -61,6 +61,7 @@ import com.eveningoutpost.dexdrip.Models.Sensor;
 import com.eveningoutpost.dexdrip.Models.TransmitterData;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
+import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.NotificationChannels;
@@ -95,6 +96,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 import static com.eveningoutpost.dexdrip.G5Model.BluetoothServices.getUUIDName;
 import static com.eveningoutpost.dexdrip.utils.bt.Helper.getStatusName;
+import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class G5CollectionService extends G5BaseService {
@@ -1896,7 +1898,7 @@ public class G5CollectionService extends G5BaseService {
             if (static_device_address != null) {
                 if (Home.get_engineering_mode())
                     l.add(new StatusItem("Bluetooth Device", static_device_address));
-                l.add(new StatusItem("Bonded", static_is_bonded ? "Yes" : "No", static_is_bonded ? StatusItem.Highlight.GOOD : StatusItem.Highlight.NOTICE));
+                l.add(new StatusItem("Bonded", static_is_bonded ? gs(R.string.yes) : gs(R.string.no), static_is_bonded ? StatusItem.Highlight.GOOD : StatusItem.Highlight.NOTICE));
             } else {
                 l.add(new StatusItem("Bluetooth Device", "Not yet found"));
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
@@ -79,14 +79,14 @@ public class StopSensor extends ActivityWithMenu {
         builder.setTitle(gs(R.string.are_you_sure));
         builder.setMessage(gs(R.string.do_you_want_to_delete_and_reset_the_calibrations_for_this_sensor));
 
-        builder.setNegativeButton("No", new DialogInterface.OnClickListener() {
+        builder.setNegativeButton(gs(R.string.no), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();
 
             }
         });
 
-        builder.setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+        builder.setPositiveButton(gs(R.string.yes), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 Calibration.invalidateAllForSensor();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static com.eveningoutpost.dexdrip.xdrip.gs;
+
 
 public class BgReadingTable extends BaseListActivity implements NavigationDrawerFragment.NavigationDrawerCallbacks {
     private String menu_name = "BG Data Table";
@@ -136,8 +138,8 @@ public class BgReadingTable extends BaseListActivity implements NavigationDrawer
                     };
 
                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
-                    builder.setMessage("Flag reading as \"bad\".\nFlagged readings have no impact on the statistics.").setPositiveButton("Yes", dialogClickListener)
-                            .setNegativeButton("No", dialogClickListener).show();
+                    builder.setMessage("Flag reading as \"bad\".\nFlagged readings have no impact on the statistics.").setPositiveButton(gs(R.string.yes), dialogClickListener)
+                            .setNegativeButton(gs(R.string.no), dialogClickListener).show();
                     return true;
                 }
             });

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Tables/CalibrationDataTable.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Tables/CalibrationDataTable.java
@@ -1,7 +1,6 @@
 package com.eveningoutpost.dexdrip.Tables;
 
 import android.app.AlertDialog;
-import android.app.ListActivity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
@@ -22,6 +21,8 @@ import com.eveningoutpost.dexdrip.UtilityModels.BgGraphBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 
 public class CalibrationDataTable extends BaseListActivity implements NavigationDrawerFragment.NavigationDrawerCallbacks {
@@ -130,8 +131,8 @@ public class CalibrationDataTable extends BaseListActivity implements Navigation
                     };
 
                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
-                    builder.setMessage("Disable this calibration?\nFlagged calibrations will no longer have an effect.").setPositiveButton("Yes", dialogClickListener)
-                            .setNegativeButton("No", dialogClickListener).show();
+                    builder.setMessage("Disable this calibration?\nFlagged calibrations will no longer have an effect.").setPositiveButton(gs(R.string.yes), dialogClickListener)
+                            .setNegativeButton(gs(R.string.no), dialogClickListener).show();
                     return true;
                 }
             });

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/pebble/watchface/InstallPebbleWatchFace.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/pebble/watchface/InstallPebbleWatchFace.java
@@ -14,8 +14,6 @@ import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.LinearLayoutCompat;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -152,7 +150,7 @@ public class InstallPebbleWatchFace extends BaseAppCompatActivity {
         builder.setTitle("Pebble Install");
         builder.setMessage("Install Pebble Watchface?");
 
-        builder.setPositiveButton("YES", new DialogInterface.OnClickListener() {
+        builder.setPositiveButton(gs(R.string.yes), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();
                 installFile();
@@ -160,7 +158,7 @@ public class InstallPebbleWatchFace extends BaseAppCompatActivity {
             }
         });
 
-        builder.setNegativeButton("NO", new DialogInterface.OnClickListener() {
+        builder.setNegativeButton(gs(R.string.no), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -10,9 +10,9 @@ import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.Treatments;
 import com.eveningoutpost.dexdrip.Models.UserError;
+import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.Inevitable;
-import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.StatusItem;
 import com.eveningoutpost.dexdrip.UtilityModels.StatusItem.Highlight;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.utils.Anticipate;
@@ -25,11 +25,11 @@ import com.eveningoutpost.dexdrip.xdrip;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static com.eveningoutpost.dexdrip.UtilityModels.BgGraphBuilder.DEXCOM_PERIOD;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.NSFollow;
+import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 /**
  * jamorham
@@ -207,8 +207,8 @@ public class NightscoutFollowService extends ForegroundService {
         }
         statuses.add(new StatusItem("Next poll time", JoH.dateTimeText(wakeup_time)));
         statuses.add(new StatusItem());
-        statuses.add(new StatusItem("Buggy Samsung", JoH.buggy_samsung ? "Yes" : "No"));
-        statuses.add(new StatusItem("Download treatments", NightscoutFollow.treatmentDownloadEnabled() ? "Yes" : "No"));
+        statuses.add(new StatusItem("Buggy Samsung", JoH.buggy_samsung ? gs(R.string.yes) : gs(R.string.no)));
+        statuses.add(new StatusItem("Download treatments", NightscoutFollow.treatmentDownloadEnabled() ? gs(R.string.yes) : gs(R.string.no)));
 
         if (StringUtils.isNotBlank(lastState)) {
             statuses.add(new StatusItem());

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareFollowService.java
@@ -9,6 +9,7 @@ import android.text.SpannableString;
 import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.UserError;
+import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.Inevitable;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
@@ -30,6 +31,7 @@ import static com.eveningoutpost.dexdrip.cgm.sharefollow.ShareConstants.MAX_RECO
 import static com.eveningoutpost.dexdrip.cgm.sharefollow.ShareConstants.NON_US_SHARE_BASE_URL;
 import static com.eveningoutpost.dexdrip.cgm.sharefollow.ShareConstants.US_SHARE_BASE_URL;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.SHFollow;
+import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 /**
  * jamorham
@@ -215,7 +217,7 @@ public class ShareFollowService extends ForegroundService {
         }
         megaStatus.add(new StatusItem("Next poll time", JoH.dateTimeText(wakeup_time)));
         megaStatus.add(new StatusItem());
-        megaStatus.add(new StatusItem("Buggy Samsung", JoH.buggy_samsung ? "Yes" : "No"));
+        megaStatus.add(new StatusItem("Buggy Samsung", JoH.buggy_samsung ? gs(R.string.yes) : gs(R.string.no)));
 
         return megaStatus;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Mdns.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Mdns.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.eveningoutpost.dexdrip.xdrip.gs;
+
 /**
  * Created by jamorham on 18/02/2017.
  */
@@ -350,7 +352,7 @@ public class Mdns {
                                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
                                     builder.setTitle("Add " + JoH.ucFirst(entry.getKey()) + " to list of receivers?");
                                     builder.setMessage("Is this device running a collector?\n\n" + entry.getKey() + ".local can be automatically added to list of receivers").setPositiveButton("Add", dialogClickListener)
-                                            .setNegativeButton("No", dialogClickListener).show();
+                                            .setNegativeButton(gs(R.string.no), dialogClickListener).show();
                                 } else {
                                     // remove item
                                     final DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
@@ -369,7 +371,7 @@ public class Mdns {
                                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
                                     builder.setTitle("Remove " + JoH.ucFirst(entry.getKey()) + " from list of receivers?");
                                     builder.setPositiveButton("Remove", dialogClickListener)
-                                            .setNegativeButton("No", dialogClickListener).show();
+                                            .setNegativeButton(gs(R.string.no), dialogClickListener).show();
                                 }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -122,6 +122,8 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
+import static com.eveningoutpost.dexdrip.xdrip.gs;
+
 /**
  * A {@link PreferenceActivity} that presents a set of application settings. On
  * handset devices, settings are presented as a single list. On tablets,
@@ -2429,7 +2431,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 }
 
 
-            builder.setPositiveButton("YES", new DialogInterface.OnClickListener() {
+            builder.setPositiveButton(gs(R.string.yes), new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int which) {
                     dialog.dismiss();
 
@@ -2455,13 +2457,13 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                             builder.setTitle("Snooze Control Install");
                             builder.setMessage("Install Pebble Snooze Button App?");
                             // inner
-                            builder.setPositiveButton("YES", new DialogInterface.OnClickListener() {
+                            builder.setPositiveButton(gs(R.string.yes), new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int which) {
                                     dialog.dismiss();
                                     context.startActivity(new Intent(context, InstallPebbleSnoozeControlApp.class));
                                 }
                             });
-                            builder.setNegativeButton("NO", new DialogInterface.OnClickListener() {
+                            builder.setNegativeButton(gs(R.string.no), new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialog, int which) {
                                     dialog.dismiss();
@@ -2473,7 +2475,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 // outer
                 }});
 
-            builder.setNegativeButton("NO", new DialogInterface.OnClickListener() {
+            builder.setNegativeButton(gs(R.string.no), new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
                     dialog.dismiss();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/watch/lefun/LeFunService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/watch/lefun/LeFunService.java
@@ -10,6 +10,7 @@ import com.eveningoutpost.dexdrip.ImportedLibraries.usbserial.util.HexDump;
 import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.UserError;
+import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.Services.JamBaseBluetoothSequencer;
 import com.eveningoutpost.dexdrip.UtilityModels.AlertPlayer;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
@@ -61,6 +62,7 @@ import static com.eveningoutpost.dexdrip.watch.lefun.LeFunService.LeFunState.PRO
 import static com.eveningoutpost.dexdrip.watch.lefun.LeFunService.LeFunState.QUEUE_MESSAGE;
 import static com.eveningoutpost.dexdrip.watch.lefun.LeFunService.LeFunState.SEND_SETTINGS;
 import static com.eveningoutpost.dexdrip.watch.lefun.LeFunService.LeFunState.SET_TIME;
+import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 /**
  * Jamorham
@@ -523,7 +525,7 @@ public class LeFunService extends JamBaseBluetoothSequencer {
         l.add(new StatusItem("Model", LeFun.getModel()));
         l.add(new StatusItem("Mac address", LeFun.getMac()));
 
-        l.add(new StatusItem("Connected", II.isConnected ? "Yes" : "No"));
+        l.add(new StatusItem("Connected", II.isConnected ? gs(R.string.yes) : gs(R.string.no)));
         if (II.wakeup_time != 0) {
             final long till = msTill(II.wakeup_time);
             if (till > 0) l.add(new StatusItem("Wake Up", niceTimeScalar(till)));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/watch/miband/MiBandService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/watch/miband/MiBandService.java
@@ -83,6 +83,7 @@ import static com.eveningoutpost.dexdrip.watch.miband.message.OperationCodes.AUT
 import static com.eveningoutpost.dexdrip.watch.miband.message.OperationCodes.AUTH_SUCCESS;
 import static com.eveningoutpost.dexdrip.watch.miband.message.OperationCodes.COMMAND_ACK_FIND_PHONE_IN_PROGRESS;
 import static com.eveningoutpost.dexdrip.watch.miband.message.OperationCodes.COMMAND_DISABLE_CALL;
+import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 /**
  * <p>
@@ -1501,8 +1502,8 @@ public class MiBandService extends JamBaseBluetoothSequencer {
         l.add(new StatusItem("Software version", MiBand.getVersion()));
 
         l.add(new StatusItem("Mac address", MiBand.getMac()));
-        l.add(new StatusItem("Connected", II.isConnected ? "Yes" : "No"));
-        l.add(new StatusItem("Is authenticated", MiBand.isAuthenticated() ? "Yes" : "No"));
+        l.add(new StatusItem("Connected", II.isConnected ? gs(R.string.yes) : gs(R.string.no)));
+        l.add(new StatusItem("Is authenticated", MiBand.isAuthenticated() ? gs(R.string.yes) : gs(R.string.no)));
         if (II.isConnected) {
             int levelInPercent = batteryInfo.getLevelInPercent();
             String levelInPercentText;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/watch/thinjam/BlueJayService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/watch/thinjam/BlueJayService.java
@@ -16,6 +16,7 @@ import com.eveningoutpost.dexdrip.ImportedLibraries.usbserial.util.HexDump;
 import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.UserError;
+import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.Services.JamBaseBluetoothSequencer;
 import com.eveningoutpost.dexdrip.Services.Ob1G5CollectionService;
 import com.eveningoutpost.dexdrip.UtilityModels.AlertPlayer;
@@ -126,6 +127,7 @@ import static com.eveningoutpost.dexdrip.watch.thinjam.Const.THINJAM_WRITE;
 import static com.eveningoutpost.dexdrip.watch.thinjam.firmware.BlueJayFirmware.parse;
 import static com.eveningoutpost.dexdrip.watch.thinjam.firmware.BlueJayFirmware.split;
 import static com.eveningoutpost.dexdrip.watch.thinjam.messages.NotifyTx.getPacketStreamForNotification;
+import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 // jamorham
 
@@ -1939,7 +1941,7 @@ public class BlueJayService extends JamBaseBluetoothSequencer {
             l.add(new StatusItem("Identity", "Not Identified! Tap to pair", CRITICAL, "long-press", () -> ThinJamActivity.requestQrCode()));
         }
 
-        l.add(new StatusItem("Connected", II.isConnected ? "Yes" : "No"));
+        l.add(new StatusItem("Connected", II.isConnected ? gs(R.string.yes) : gs(R.string.no)));
         if (II.wakeup_time != 0 && !II.isConnected) {
             final long till = msTill(II.wakeup_time);
             if (till > 0) l.add(new StatusItem("Retry Wake Up", niceTimeScalar(till)));

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
@@ -1,12 +1,9 @@
 package com.eveningoutpost.dexdrip.Tables;
 
-import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.app.ListActivity;
 import android.content.Context;
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.v4.widget.DrawerLayout;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,7 +13,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.eveningoutpost.dexdrip.Models.BgReading;
-//import com.eveningoutpost.dexdrip.NavigationDrawerFragment;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.R;
@@ -25,6 +21,8 @@ import com.eveningoutpost.dexdrip.xdrip;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
+//import com.eveningoutpost.dexdrip.NavigationDrawerFragment;
 
 
 public class BgReadingTable extends ListActivity {//implements NavigationDrawerFragment.NavigationDrawerCallbacks {
@@ -148,8 +146,8 @@ public class BgReadingTable extends ListActivity {//implements NavigationDrawerF
                     };
 
                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
-                    builder.setMessage("Flag reading as \"bad\".\nFlagged readings have no impact on the statistics.").setPositiveButton("Yes", dialogClickListener)
-                            .setNegativeButton("No", dialogClickListener).show();
+                    builder.setMessage("Flag reading as \"bad\".\nFlagged readings have no impact on the statistics.").setPositiveButton(gs(R.string.yes), dialogClickListener)
+                            .setNegativeButton(gs(R.string.no), dialogClickListener).show();
                     return true;
                 }
             });*/

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Tables/BloodTestTable.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Tables/BloodTestTable.java
@@ -136,8 +136,8 @@ public class BloodTestTable extends ListActivity {
                     };
 
                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
-                    builder.setMessage("Flag reading as \"bad\".\nFlagged readings have no impact on the statistics.").setPositiveButton("Yes", dialogClickListener)
-                            .setNegativeButton("No", dialogClickListener).show();
+                    builder.setMessage("Flag reading as \"bad\".\nFlagged readings have no impact on the statistics.").setPositiveButton(gs(R.string.yes), dialogClickListener)
+                            .setNegativeButton(gs(R.string.no), dialogClickListener).show();
                     return true;
                 }
             });*/

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Tables/CalibrationDataTable.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Tables/CalibrationDataTable.java
@@ -1,9 +1,7 @@
 package com.eveningoutpost.dexdrip.Tables;
 
-import android.app.AlertDialog;
 import android.app.ListActivity;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -129,8 +127,8 @@ public class CalibrationDataTable extends ListActivity {//implements NavigationD
                     };
 
                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
-                    builder.setMessage("Disable this calibration?\nFlagged calibrations will no longer have an effect.").setPositiveButton("Yes", dialogClickListener)
-                            .setNegativeButton("No", dialogClickListener).show();
+                    builder.setMessage("Disable this calibration?\nFlagged calibrations will no longer have an effect.").setPositiveButton(gs(R.string.yes), dialogClickListener)
+                            .setNegativeButton(gs(R.string.no), dialogClickListener).show();
                     return true;
                 }
             });*/

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Tables/TreatmentsTable.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Tables/TreatmentsTable.java
@@ -134,8 +134,8 @@ public class TreatmentsTable extends ListActivity {
                     };
 
                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
-                    builder.setMessage("Flag reading as \"bad\".\nFlagged readings have no impact on the statistics.").setPositiveButton("Yes", dialogClickListener)
-                            .setNegativeButton("No", dialogClickListener).show();
+                    builder.setMessage("Flag reading as \"bad\".\nFlagged readings have no impact on the statistics.").setPositiveButton(gs(R.string.yes), dialogClickListener)
+                            .setNegativeButton(gs(R.string.no), dialogClickListener).show();
                     return true;
                 }
             });*/


### PR DESCRIPTION
All UI-related hard-coded single word strings of "Yes" and "No" were replaced by their resource strings.

fixes #1608