### PR TITLE
render BG graph at small widget sizes

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
@@ -74,7 +74,7 @@ public class xDripWidget extends AppWidgetProvider {
             appWidgetManager.updateAppWidget(appWidgetId, views);
             // needed to catch RuntimeException and DeadObjectException
         } catch (Exception e) {
-            Log.e(TAG, "Got Rexception in widget update: " + e);
+            Log.e(TAG, "Got exception in widget update: " + e);
         }
     }
 
@@ -91,7 +91,7 @@ public class xDripWidget extends AppWidgetProvider {
             appWidgetManager.updateAppWidget(appWidgetId, views);
             // needed to catch RuntimeException and DeadObjectException
         } catch (Exception e) {
-            Log.e(TAG, "Got Rexception in widget update: " + e);
+            Log.e(TAG, "Got exception in widget update: " + e);
         }
     }
 
@@ -104,7 +104,7 @@ public class xDripWidget extends AppWidgetProvider {
         BgReading lastBgreading = BgReading.lastNoSenssor();
 
         final boolean showLines = Pref.getBoolean("widget_range_lines", false);
-        final boolean showExstraStatus = Pref.getBoolean("extra_status_line", false) && Pref.getBoolean("widget_status_line", false);
+        final boolean showExtraStatus = Pref.getBoolean("extra_status_line", false) && Pref.getBoolean("widget_status_line", false);
 
         if (lastBgreading != null) {
             double estimate = 0;
@@ -112,7 +112,7 @@ public class xDripWidget extends AppWidgetProvider {
             try {
                 int height = maxHeight == -1 ? appWidgetManager.getAppWidgetOptions(appWidgetId).getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT) : maxHeight;
                 int width = maxWidth == -1 ? appWidgetManager.getAppWidgetOptions(appWidgetId).getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH) : maxWidth;
-                if (width >= 337) {
+                if (width >= 100) {
                     // render bg graph if the widget has enough space to be useful
                     views.setImageViewBitmap(R.id.widgetGraph, new BgSparklineBuilder(context)
                             .setBgGraphBuilder(bgGraphBuilder)
@@ -219,7 +219,7 @@ public class xDripWidget extends AppWidgetProvider {
                     views.setTextColor(R.id.readingAge, Color.WHITE);
                 }
 
-                if (showExstraStatus) {
+                if (showExtraStatus) {
                     views.setTextViewText(R.id.widgetStatusLine, StatusLine.extraStatusLine());
                     views.setViewVisibility(R.id.widgetStatusLine, View.VISIBLE);
                 } else {

--- a/app/src/main/res/layout/x_drip_widget.xml
+++ b/app/src/main/res/layout/x_drip_widget.xml
@@ -83,8 +83,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:text="---"
             android:textColor="#ffffff"
-            android:textSize="13sp" />
+            android:textSize="10sp" />
     </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
PR #1024 introduced rendering the BG graph only if the widget has a certain size (https://github.com/NightscoutFoundation/xDrip/pull/1024/files#diff-ddde3c059ce7449a35352211887a9567b61470117b683eb914daf7011366962aR115). This value was chosen, arbitrary and is too large.
This PR just reduces the value more reasonable value and fixes #1560 . It is still unclear why this cutoff was introduced.