### PR TITLE
Package name pre-processor to fix issues with databinding library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,28 +12,7 @@ buildscript {
     }
 }
 apply plugin: 'com.android.application'
-apply plugin: 'com.github.jamorham.android.replace.token.preprocessor'
-
-replaceAndroidTokenPreprocessorSettings {
-
-    // Adjust package names
-    replace 'com.eveningoutpost.dexdrip.Services': "com.eveningoutpost.dexdrip.services"
-    replace 'com.eveningoutpost.dexdrip.UtilityModels': "com.eveningoutpost.dexdrip.utilitymodels"
-    replace 'com.eveningoutpost.dexdrip.Models': "com.eveningoutpost.dexdrip.models"
-    replace 'com.eveningoutpost.dexdrip.Tables': "com.eveningoutpost.dexdrip.tables"
-    replace 'com.eveningoutpost.dexdrip.G5Model': "com.eveningoutpost.dexdrip.g5model"
-    replace 'com.eveningoutpost.dexdrip.GlucoseMeter': "com.eveningoutpost.dexdrip.glucosemeter"
-    replace 'com.eveningoutpost.dexdrip.localeTasker': "com.eveningoutpost.dexdrip.localetasker"
-    replace 'com.eveningoutpost.dexdrip.ImportedLibraries': "com.eveningoutpost.dexdrip.importedlibraries"
-
-    // For AndroidManifest shorthand format
-    replace '".UtilityModels.': '".utilitymodels.'
-    replace '".localeTasker.': '".localetasker.'
-    replace '".GlucoseMeter.': '".glucosemeter.'
-    replace '".Services.': '".services.'
-    replace '".Models.': '".models.'
-
-}
+apply from: 'token-replace.gradle'
 
 if (project.file('local.gradle').exists()) {
     apply from: 'local.gradle'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,29 @@ buildscript {
     }
 }
 apply plugin: 'com.android.application'
+apply plugin: 'com.github.jamorham.android.replace.token.preprocessor'
 
+replaceAndroidTokenPreprocessorSettings {
+
+    // Adjust package names
+    replace 'com.eveningoutpost.dexdrip.Services': "com.eveningoutpost.dexdrip.services"
+    replace 'com.eveningoutpost.dexdrip.UtilityModels': "com.eveningoutpost.dexdrip.utilitymodels"
+    replace 'com.eveningoutpost.dexdrip.Models': "com.eveningoutpost.dexdrip.models"
+    replace 'com.eveningoutpost.dexdrip.Tables': "com.eveningoutpost.dexdrip.tables"
+    replace 'com.eveningoutpost.dexdrip.G5Model': "com.eveningoutpost.dexdrip.g5model"
+    replace 'com.eveningoutpost.dexdrip.GlucoseMeter': "com.eveningoutpost.dexdrip.glucosemeter"
+    replace 'com.eveningoutpost.dexdrip.localeTasker': "com.eveningoutpost.dexdrip.localetasker"
+    replace 'com.eveningoutpost.dexdrip.ImportedLibraries': "com.eveningoutpost.dexdrip.importedlibraries"
+    replace 'com.eveningoutpost.dexdrip.ImportedLibraries': "com.eveningoutpost.dexdrip.importedlibraries"
+
+    // For AndroidManifest shorthand format
+    replace '".UtilityModels.': '".utilitymodels.'
+    replace '".localeTasker.': '".localetasker.'
+    replace '".GlucoseMeter.': '".glucosemeter.'
+    replace '".Services.': '".services.'
+    replace '".Models.': '".models.'
+
+}
 
 if (project.file('local.gradle').exists()) {
     apply from: 'local.gradle'
@@ -276,11 +298,11 @@ dependencies {
 
     // use specific version of data binding until google resolves the bugs with mixed case package names
     //noinspection GradleDependency
-    implementation 'com.android.databinding:adapters:3.1.4'
+    //implementation 'com.android.databinding:adapters:3.1.4'
     //noinspection GradleDependency
-    implementation 'com.android.databinding:library:3.1.4'
+    //implementation 'com.android.databinding:library:3.1.4'
     //noinspection GradleDependency
-    implementation 'com.android.databinding:baseLibrary:3.1.4'
+    //implementation 'com.android.databinding:baseLibrary:3.1.4'
     //////
 
     implementation 'com.android.support:appcompat-v7:26.1.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,6 @@ replaceAndroidTokenPreprocessorSettings {
     replace 'com.eveningoutpost.dexdrip.GlucoseMeter': "com.eveningoutpost.dexdrip.glucosemeter"
     replace 'com.eveningoutpost.dexdrip.localeTasker': "com.eveningoutpost.dexdrip.localetasker"
     replace 'com.eveningoutpost.dexdrip.ImportedLibraries': "com.eveningoutpost.dexdrip.importedlibraries"
-    replace 'com.eveningoutpost.dexdrip.ImportedLibraries': "com.eveningoutpost.dexdrip.importedlibraries"
 
     // For AndroidManifest shorthand format
     replace '".UtilityModels.': '".utilitymodels.'

--- a/app/token-replace.gradle
+++ b/app/token-replace.gradle
@@ -1,0 +1,24 @@
+
+apply plugin:  'com.github.jamorham.android.replace.token.preprocessor'
+
+replaceAndroidTokenPreprocessorSettings {
+
+    // Adjust package names
+    replace 'com.eveningoutpost.dexdrip.Services': "com.eveningoutpost.dexdrip.services"
+    replace 'com.eveningoutpost.dexdrip.UtilityModels': "com.eveningoutpost.dexdrip.utilitymodels"
+    replace 'com.eveningoutpost.dexdrip.Models': "com.eveningoutpost.dexdrip.models"
+    replace 'com.eveningoutpost.dexdrip.Tables': "com.eveningoutpost.dexdrip.tables"
+    replace 'com.eveningoutpost.dexdrip.G5Model': "com.eveningoutpost.dexdrip.g5model"
+    replace 'com.eveningoutpost.dexdrip.GlucoseMeter': "com.eveningoutpost.dexdrip.glucosemeter"
+    replace 'com.eveningoutpost.dexdrip.localeTasker': "com.eveningoutpost.dexdrip.localetasker"
+    replace 'com.eveningoutpost.dexdrip.ImportedLibraries': "com.eveningoutpost.dexdrip.importedlibraries"
+
+    // For AndroidManifest shorthand format
+    replace '".UtilityModels.': '".utilitymodels.'
+    replace '".localeTasker.': '".localetasker.'
+    replace '".GlucoseMeter.': '".glucosemeter.'
+    replace '".Services.': '".services.'
+    replace '".Models.': '".models.'
+
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.3'
+        classpath 'com.android.tools.build:gradle:3.5.4'
         classpath 'com.google.gms:google-services:4.3.3'
  //       classpath 'me.tatarka:gradle-retrolambda:3.7.0'
         classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,14 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
+        maven { url "https://jitpack.io" }
 
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.3'
         classpath 'com.google.gms:google-services:4.3.3'
  //       classpath 'me.tatarka:gradle-retrolambda:3.7.0'
+        classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.1'
 
         apply plugin: 'java'
         apply plugin: 'maven'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.5.4'
         classpath 'com.google.gms:google-services:4.3.3'
  //       classpath 'me.tatarka:gradle-retrolambda:3.7.0'
-        classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.1'
+        classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.2'
 
         apply plugin: 'java'
         apply plugin: 'maven'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.5.4'
         classpath 'com.google.gms:google-services:4.3.3'
  //       classpath 'me.tatarka:gradle-retrolambda:3.7.0'
-        classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.3'
+        classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.5'
 
         apply plugin: 'java'
         apply plugin: 'maven'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.5.4'
         classpath 'com.google.gms:google-services:4.3.3'
  //       classpath 'me.tatarka:gradle-retrolambda:3.7.0'
-        classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.2'
+        classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.3'
 
         apply plugin: 'java'
         apply plugin: 'maven'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # TODO we should lowercase the package names, see https://stackoverflow.com/questions/52495124/gradle-plugin-3-2-0-with-databinding-can-not-resolve-package-name
-android.databinding.enableV2=false
+android.databinding.enableV2=true
 org.gradle.daemon=true
 # Enable Build Caching (https://docs.gradle.org/current/userguide/build_cache.html#build_cache)
 org.gradle.caching=true

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -83,28 +83,7 @@ def generateVersionName = { ->
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'com.github.jamorham.android.replace.token.preprocessor'
-
-replaceAndroidTokenPreprocessorSettings {
-
-    // Adjust package names
-    replace 'com.eveningoutpost.dexdrip.Services': "com.eveningoutpost.dexdrip.services"
-    replace 'com.eveningoutpost.dexdrip.UtilityModels': "com.eveningoutpost.dexdrip.utilitymodels"
-    replace 'com.eveningoutpost.dexdrip.Models': "com.eveningoutpost.dexdrip.models"
-    replace 'com.eveningoutpost.dexdrip.Tables': "com.eveningoutpost.dexdrip.tables"
-    replace 'com.eveningoutpost.dexdrip.G5Model': "com.eveningoutpost.dexdrip.g5model"
-    replace 'com.eveningoutpost.dexdrip.GlucoseMeter': "com.eveningoutpost.dexdrip.glucosemeter"
-    replace 'com.eveningoutpost.dexdrip.localeTasker': "com.eveningoutpost.dexdrip.localetasker"
-    replace 'com.eveningoutpost.dexdrip.ImportedLibraries': "com.eveningoutpost.dexdrip.importedlibraries"
-
-    // For AndroidManifest shorthand format
-    replace '".UtilityModels.': '".utilitymodels.'
-    replace '".localeTasker.': '".localetasker.'
-    replace '".GlucoseMeter.': '".glucosemeter.'
-    replace '".Services.': '".services.'
-    replace '".Models.': '".models.'
-
-}
+apply from: '../app/token-replace.gradle'
 //apply plugin: 'me.tatarka.retrolambda'
 //apply plugin: 'io.fabric'
 

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -244,4 +244,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.10'
 //    compileOnly 'javax.annotation:javax.annotation-api:1.3.1'
     annotationProcessor "org.projectlombok:lombok:1.18.10"
+      // use lombok in unit tests
+    testCompileOnly 'org.projectlombok:lombok:1.18.10'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.10'
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -83,6 +83,28 @@ def generateVersionName = { ->
 }
 
 apply plugin: 'com.android.application'
+apply plugin: 'com.github.jamorham.android.replace.token.preprocessor'
+
+replaceAndroidTokenPreprocessorSettings {
+
+    // Adjust package names
+    replace 'com.eveningoutpost.dexdrip.Services': "com.eveningoutpost.dexdrip.services"
+    replace 'com.eveningoutpost.dexdrip.UtilityModels': "com.eveningoutpost.dexdrip.utilitymodels"
+    replace 'com.eveningoutpost.dexdrip.Models': "com.eveningoutpost.dexdrip.models"
+    replace 'com.eveningoutpost.dexdrip.Tables': "com.eveningoutpost.dexdrip.tables"
+    replace 'com.eveningoutpost.dexdrip.G5Model': "com.eveningoutpost.dexdrip.g5model"
+    replace 'com.eveningoutpost.dexdrip.GlucoseMeter': "com.eveningoutpost.dexdrip.glucosemeter"
+    replace 'com.eveningoutpost.dexdrip.localeTasker': "com.eveningoutpost.dexdrip.localetasker"
+    replace 'com.eveningoutpost.dexdrip.ImportedLibraries': "com.eveningoutpost.dexdrip.importedlibraries"
+
+    // For AndroidManifest shorthand format
+    replace '".UtilityModels.': '".utilitymodels.'
+    replace '".localeTasker.': '".localetasker.'
+    replace '".GlucoseMeter.': '".glucosemeter.'
+    replace '".Services.': '".services.'
+    replace '".Models.': '".models.'
+
+}
 //apply plugin: 'me.tatarka.retrolambda'
 //apply plugin: 'io.fabric'
 


### PR DESCRIPTION
This PR uses a gradle pre-processor plugin to adjust package names within the source tree during compilation to use lower case.

The reason for doing this is that later versions of the Android databinding library cannot handle mixed case package names (despite this being part of previous versions test suites). Cosmetic refactoring of the code creates additional work for many unmerged feature branches and so this is intended as a pragmatic alternative.

In tests, the plugin takes less <1 second to run. Indeed tests showed it at around 80-330ms execution time. This may vary depending on the machine hardware, ssd etc.  The plugin is intelligent in terms of only rewriting changed code and so is significantly faster after the first build. 

To demonstrate that it works, this PR also raises the gradle android build tools version to `3.5.4` and sets `android.databinding.enableV2=true` although in fact only V2 is possible with this newer build tools version anyway. 

Only very limited testing at this stage has been done on the resultant app which has been tested only in as far as specimen databinding screens within the app appear to function correctly. Further testing is needed and also with the Wear microapk.

An additional question is whether this in any way negatively affects the build process or development cycle/consistency. Summed up really as, does everything else still work? 