### PR TITLE
add Hungarian and Ukrainian language to menu

### DIFF
--- a/app/src/main/res/values/locales.xml
+++ b/app/src/main/res/values/locales.xml
@@ -1,45 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="LocaleChoices">
-        <item>English</item>
-        <item>Français</item>
-        <item>Deutsch</item>
-        <item>русский</item>
-        <item>Español</item>
-        <item>Svenska</item>
         <item>Bokmal</item>
-        <item>Norsk</item>
-        <item>Română</item>
-        <item>Polski</item>
-        <item>한국어</item>
-        <item>Português</item>
         <item>čeština</item>
-        <item>Nederlands</item>
-        <item>Italiano</item>
-        <item>Suomi</item>
+        <item>Deutsch</item>
+        <item>English</item>
+        <item>Español</item>
+        <item>Français</item>
         <item>Hrvatski</item>
-        <item>עברית</item>
+        <item>Italiano</item>
+        <item>magyar</item>
+        <item>Nederlands</item>
+        <item>Norsk</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
         <item>Slovenčina</item>
+        <item>Suomi</item>
+        <item>Svenska</item>
+        <item>русский</item>
+        <item>עברית</item>
+        <item>한국어</item>
     </string-array>
     <string-array name="LocaleChoicesValues">
-        <item>en</item>
-        <item>fr</item>
-        <item>de</item>
-        <item>ru</item>
-        <item>es</item>
-        <item>sv</item>
         <item>nb</item>
-        <item>no</item>
-        <item>ro</item>
-        <item>pl</item>
-        <item>ko</item>
-        <item>pt</item>
         <item>cs</item>
-        <item>nl</item>
-        <item>it</item>
-        <item>fi</item>
+        <item>de</item>
+        <item>en</item>
+        <item>es</item>
+        <item>fr</item>
         <item>hr</item>
-        <item>iw</item>
+        <item>it</item>
+        <item>hu</item>
+        <item>nl</item>
+        <item>no</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
         <item>sk</item>
+        <item>fi</item>
+        <item>sv</item>
+        <item>ru</item>
+        <item>iw</item>
+        <item>ko</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/locales.xml
+++ b/app/src/main/res/values/locales.xml
@@ -21,6 +21,7 @@
         <item>русский</item>
         <item>עברית</item>
         <item>한국어</item>
+        <item>Українська</item>
     </string-array>
     <string-array name="LocaleChoicesValues">
         <item>nb</item>
@@ -43,5 +44,6 @@
         <item>ru</item>
         <item>iw</item>
         <item>ko</item>
+        <item>uk</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Add hungarian to the "Chose a specific language" menu and sorts the language entries.
Hungarian is currently in [translation](https://crowdin.com/project/xdrip/hu).