### PR TITLE
fix: searching 'multi' in preferences and selecting first item will cause exception

### DIFF
--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -613,6 +613,7 @@
                 android:title="@string/predictive_simulations" />
 
             <PreferenceScreen
+                android:key="xdrip_plus_multiple_insulin_types_settings"
                 android:title="Multiple Insulin Types"
                 android:summary="Options for working with multiple insulin types">
                 <SwitchPreference


### PR DESCRIPTION
Steps:
* go to preferences
* search for `multi`
* you will see multiple results
* select the first one
* you will get cryptic error message about exception

The reason for this error is missing `android:key` in preference screen which this pull request fixes.