### PR TITLE
Update arrays.xml to add a lower threshold for the fast rising and fast falling alarms

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -152,11 +152,13 @@
     </string-array>
 
     <string-array name="risingEntries">
-        <item>2 mgdl (0.1 mmol)</item>
-        <item>3 mgdl (0.16 mmol)</item>
+        <item>1 mgdl (0.06 mmol)</item>
+        <item>2 mgdl (0.11 mmol)</item>
+        <item>3 mgdl (0.17 mmol)</item>
     </string-array>
 
     <string-array name="risingValues">
+        <item>1</item>
         <item>2</item>
         <item>3</item>
     </string-array>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -152,9 +152,9 @@
     </string-array>
 
     <string-array name="risingEntries">
-        <item>1 mgdl (0.06 mmol)</item>
-        <item>2 mgdl (0.11 mmol)</item>
-        <item>3 mgdl (0.17 mmol)</item>
+        <item>1 mg/dl (0.06 mmol/l)</item>
+        <item>2 mg/dl (0.11 mmol/l)</item>
+        <item>3 mg/dl (0.17 mmol/l)</item>
     </string-array>
 
     <string-array name="risingValues">


### PR DESCRIPTION

![Screenshot_20210331-223319](https://user-images.githubusercontent.com/51497406/113236034-1ddecd80-9272-11eb-8725-9654a8923fd4.png)
Issues addressed: https://github.com/NightscoutFoundation/xDrip/issues/907
https://github.com/NightscoutFoundation/xDrip/issues/1351

This makes it easier for those who use a low-carb diet (not me) to use the fast rising (and fast falling) alarm for their needs.
It is a very old issue.  And seems like a legitimate request to me.

It is quite possible that I have overlooked requirements for a pull request.  Thanks for any feedback in advance.