### PR TITLE
Change Stop Sensor page (second attempt)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
@@ -48,12 +48,33 @@ public class StopSensor extends ActivityWithMenu {
 
         button.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                stop();
-                JoH.startActivity(Home.class);
-                finish();
+                confirm_stop();
             }
 
         });
+    }
+
+    public void confirm_stop() {
+        final AlertDialog.Builder build_stop = new AlertDialog.Builder(this);
+        build_stop.setTitle(gs(R.string.are_you_sure));
+        build_stop.setMessage(gs(R.string.do_you_want_to_end_session));
+        build_stop.setNegativeButton(gs(R.string.no), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+                JoH.startActivity(Home.class);
+            }
+        });
+        build_stop.setPositiveButton(gs(R.string.yes), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                stop();
+                dialog.dismiss();
+                JoH.startActivity(Home.class);
+                finish();
+            }
+        });
+        build_stop.create().show();
     }
 
     public synchronized static void stop() {

--- a/app/src/main/res/layout/activity_stop_sensor.xml
+++ b/app/src/main/res/layout/activity_stop_sensor.xml
@@ -8,7 +8,6 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:weightSum="1"
-    android:background="#e8e800"
     android:id="@+id/stop_sensor_container">
     <ScrollView
         android:layout_width="fill_parent"
@@ -25,7 +24,6 @@
                 android:textAppearance="?android:attr/textAppearanceLarge"
                 android:text="@string/stop_sensor"
                 android:id="@+id/textView3"
-                android:textColor="#0000ff"
                 android:layout_gravity="center_horizontal" />
 
             <TextView
@@ -40,7 +38,6 @@
                 android:layout_gravity="right"
                 android:paddingLeft="20dp"
                 android:paddingRight="20dp"
-                android:textColor="#0000ff"
                 android:gravity="center_vertical|center_horizontal" />
 
             <Button

--- a/app/src/main/res/layout/activity_stop_sensor.xml
+++ b/app/src/main/res/layout/activity_stop_sensor.xml
@@ -40,7 +40,7 @@
                 android:layout_gravity="right"
                 android:paddingLeft="20dp"
                 android:paddingRight="20dp"
-                android:textColor="#0000ee"
+                android:textColor="#0000ff"
                 android:gravity="center_vertical|center_horizontal" />
 
             <Button

--- a/app/src/main/res/layout/activity_stop_sensor.xml
+++ b/app/src/main/res/layout/activity_stop_sensor.xml
@@ -8,6 +8,7 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:weightSum="1"
+    android:background="#e8e800"
     android:id="@+id/stop_sensor_container">
     <ScrollView
         android:layout_width="fill_parent"
@@ -17,7 +18,6 @@
             android:orientation="vertical"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:background="#e8e800"
             android:gravity="center_horizontal">
             <TextView
                 android:layout_width="wrap_content"
@@ -25,7 +25,7 @@
                 android:textAppearance="?android:attr/textAppearanceLarge"
                 android:text="@string/stop_sensor"
                 android:id="@+id/textView3"
-                android:textColor="#dd0066"
+                android:textColor="#0000ff"
                 android:layout_gravity="center_horizontal" />
 
             <TextView
@@ -35,12 +35,12 @@
                 android:text="@string/only_stop_your_sensor_when_you_actually_plan"
                 android:layout_below="@+id/textView"
                 android:layout_alignParentStart="true"
-                android:layout_marginTop="60dp"
+                android:layout_marginTop="25dp"
                 android:id="@+id/stop_sensor_instructions"
                 android:layout_gravity="right"
                 android:paddingLeft="20dp"
                 android:paddingRight="20dp"
-                android:textColor="#dd0066"
+                android:textColor="#0000ee"
                 android:gravity="center_vertical|center_horizontal" />
 
             <Button
@@ -52,7 +52,7 @@
                 android:layout_alignParentBottom="true"
                 android:layout_alignEnd="@+id/textView3"
                 android:layout_gravity="center_horizontal"
-                android:layout_marginTop="150dp" />
+                android:layout_marginTop="30dp" />
 
             <Button
                 android:text="@string/dont_stop_just_reset_all_calibrations"

--- a/app/src/main/res/layout/activity_stop_sensor.xml
+++ b/app/src/main/res/layout/activity_stop_sensor.xml
@@ -17,6 +17,7 @@
             android:orientation="vertical"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
+            android:background="#e8e800"
             android:gravity="center_horizontal">
             <TextView
                 android:layout_width="wrap_content"
@@ -24,6 +25,7 @@
                 android:textAppearance="?android:attr/textAppearanceLarge"
                 android:text="@string/stop_sensor"
                 android:id="@+id/textView3"
+                android:textColor="#dd0066"
                 android:layout_gravity="center_horizontal" />
 
             <TextView
@@ -33,11 +35,12 @@
                 android:text="@string/only_stop_your_sensor_when_you_actually_plan"
                 android:layout_below="@+id/textView"
                 android:layout_alignParentStart="true"
-                android:layout_marginTop="25dp"
+                android:layout_marginTop="60dp"
                 android:id="@+id/stop_sensor_instructions"
                 android:layout_gravity="right"
                 android:paddingLeft="20dp"
                 android:paddingRight="20dp"
+                android:textColor="#dd0066"
                 android:gravity="center_vertical|center_horizontal" />
 
             <Button
@@ -49,7 +52,7 @@
                 android:layout_alignParentBottom="true"
                 android:layout_alignEnd="@+id/textView3"
                 android:layout_gravity="center_horizontal"
-                android:layout_marginTop="30dp" />
+                android:layout_marginTop="150dp" />
 
             <Button
                 android:text="@string/dont_stop_just_reset_all_calibrations"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1495,6 +1495,7 @@
     <string name="__do_you_want_to_change_settings_or_start_sensor">\n\nDo you want to change settings or start sensor?</string>
     <string name="change_settings">Change settings</string>
     <string name="do_you_want_to_delete_and_reset_the_calibrations_for_this_sensor">Do you want to delete and reset the calibrations for this sensor?</string>
+    <string name="do_you_want_to_end_session">Do you want to stop sensor, and terminate the current session?</string>
     <string name="you_have_an_old_experimental_glucose_prediction_setting_enabled__this_is_not_recommended_and_could_mess_things_up_badly__shall_i_disable_this_for_you">You have an old experimental glucose prediction setting enabled.\n\nThis is NOT RECOMMENDED and could mess things up badly.\n\nShall I disable this for you?</string>
     <string name="settings_issue">Settings Issue!</string>
     <string name="do_you_want_to_use_this_synced_fingerstick_blood_glucose_result_to_calibrate_with__you_can_change_when_this_dialog_is_displayed_in_settings">Do you want to use this synced finger-stick blood glucose result to calibrate with?\n\n(you can change when this dialog is displayed in Settings)</string>


### PR DESCRIPTION
I closed my previous pull request because I am still learning pull requests and everything else with github:
https://github.com/NightscoutFoundation/xDrip/pull/1696

There are cases where a user accidentally stops their sensor.
#1309
This comes up occasionally on facebook as well.
The user intends to go to the system status page or another page, but, accidentally taps on "Stop Sensor" and ends up on the stop sensor page and stops sensor.
I can see how annoying it can be if I made such a mistake.

There are requests for the stop sensor button, on the main menu, to be relocated.
I believe that is an extreme change.

Instead of moving the button, I have edited the stop sensor page to make it stand out so that the user hopefully can realize that they are on a page other than the one they intended.
Currently the stop sensor page looks like this:
![1](https://user-images.githubusercontent.com/51497406/114942079-00813600-9e12-11eb-8e14-bd2a9febd298.png)


I have changed it to look this way:
![4](https://user-images.githubusercontent.com/51497406/114942118-0f67e880-9e12-11eb-8fa5-7f8d02b46eac.png)


I have intentionally picked ugly colors, different from the xDrip norm colors.
I have not changed anything else.
The intent is to give visual cues to a user who may be half sleep or hypoglycemic or riding a bicycle etc. that they are on the wrong page.