### PR TITLE
Statistics linebreak

### DIFF
--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -5,14 +5,14 @@
 
     <ScrollView
         android:id="@+id/scrollView5"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent">
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
         <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:orientation="vertical"
-            android:layout_gravity="center_horizontal">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_horizontal"
+            android:orientation="vertical">
 
             <LinearLayout
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -41,163 +41,177 @@
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="left"
                 android:orientation="horizontal"
-                android:padding="5dp"
-                android:layout_gravity="center_horizontal">
+                android:padding="5dp">
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:padding="5dp"
                     android:text="@string/absolute_s"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
                 <TextView
                     android:id="@+id/textView_ranges_absolute"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:maxLines="1"
                     android:padding="5dp"
                     android:text="--/--/--"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="left"
                 android:orientation="horizontal"
-                android:padding="5dp"
-                android:layout_gravity="center_horizontal">
+                android:padding="5dp">
 
                 <TextView
                     android:id="@+id/textView11"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:padding="5dp"
                     android:text="@string/median_bg"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
                 <TextView
                     android:id="@+id/textView_median"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:maxLines="1"
                     android:padding="5dp"
                     android:text="---"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="left"
                 android:orientation="horizontal"
-                android:padding="5dp"
-                android:layout_gravity="center_horizontal">
+                android:padding="5dp">
 
                 <TextView
                     android:id="@+id/textView13"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:padding="5dp"
                     android:text="@string/mean_bg"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
                 <TextView
                     android:id="@+id/textView_mean"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:maxLines="1"
                     android:padding="5dp"
                     android:text="---"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="left"
                 android:orientation="horizontal"
-                android:padding="5dp"
-                android:layout_gravity="center_horizontal">
+                android:padding="5dp">
 
                 <TextView
                     android:id="@+id/textView14"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:padding="5dp"
                     android:text="@string/hba1c_est"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
                 <TextView
                     android:id="@+id/textView_a1c"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:maxLines="2"
                     android:padding="5dp"
                     android:text= "-- mmol/mol\n --%"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="left"
                 android:orientation="horizontal"
-                android:padding="5dp"
-                android:layout_gravity="center_horizontal">
+                android:padding="5dp">
 
                 <TextView
                     android:id="@+id/textView17"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:padding="5dp"
                     android:text="@string/stddev"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
                 <TextView
                     android:id="@+id/textView_stdev"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:maxLines="1"
                     android:padding="5dp"
                     android:text="---"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="left"
                 android:orientation="horizontal"
-                android:padding="5dp"
-                android:layout_gravity="center_horizontal">
+                android:padding="5dp">
 
                 <TextView
                     android:id="@+id/textView18"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:padding="5dp"
                     android:text="@string/relative_sd_cv"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
                 <TextView
                     android:id="@+id/textView_coefficient_of_variation"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:maxLines="1"
                     android:padding="5dp"
                     android:text= "--%"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="left"
                 android:orientation="horizontal"
-                android:padding="5dp"
-                android:layout_gravity="center_horizontal">
+                android:padding="5dp">
 
                 <TextView
                     android:id="@+id/textView19"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:padding="5dp"
-                    android:text="GVI: "
+                    android:text="GVI:"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
                 <TextView
                     android:id="@+id/textView_gvi"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:maxLines="1"
                     android:padding="5dp"
                     android:text= "--"
                     android:textAppearance="?android:attr/textAppearanceLarge" />

--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -26,7 +26,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="@string/range_in_high_low"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
@@ -35,7 +36,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="--%/--%/--%"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
@@ -51,7 +53,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="@string/absolute_s"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
@@ -60,7 +63,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="--/--/--"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
@@ -77,7 +81,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="@string/median_bg"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
@@ -86,7 +91,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="---"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
@@ -103,7 +109,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="@string/mean_bg"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
@@ -112,7 +119,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="---"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
@@ -129,7 +137,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="@string/hba1c_est"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
@@ -138,7 +147,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="2"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="-- mmol/mol\n--%"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
@@ -155,7 +165,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="@string/stddev"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
@@ -164,7 +175,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="---"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
@@ -181,7 +193,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="@string/relative_sd_cv"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
@@ -190,7 +203,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="--%"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
@@ -207,7 +221,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="GVI:"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
@@ -216,7 +231,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="1"
-                    android:padding="5dp"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
                     android:text="--"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>

--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -139,7 +139,7 @@
                     android:layout_height="wrap_content"
                     android:maxLines="2"
                     android:padding="5dp"
-                    android:text= "-- mmol/mol\n --%"
+                    android:text="-- mmol/mol\n--%"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
 
@@ -168,6 +168,7 @@
                     android:text="---"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
+
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -183,15 +184,17 @@
                     android:padding="5dp"
                     android:text="@string/relative_sd_cv"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
+
                 <TextView
                     android:id="@+id/textView_coefficient_of_variation"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="1"
                     android:padding="5dp"
-                    android:text= "--%"
+                    android:text="--%"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
+
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -207,13 +210,14 @@
                     android:padding="5dp"
                     android:text="GVI:"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
+
                 <TextView
                     android:id="@+id/textView_gvi"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:maxLines="1"
                     android:padding="5dp"
-                    android:text= "--"
+                    android:text="--"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -15,24 +15,26 @@
             android:layout_gravity="center_horizontal">
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="left"
                 android:orientation="horizontal"
-                android:padding="5dp"
-                android:layout_gravity="center_horizontal">
+                android:padding="5dp">
 
                 <TextView
                     android:id="@+id/textView4"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:padding="5dp"
                     android:text="@string/range_in_high_low"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
 
                 <TextView
                     android:id="@+id/textView_ranges_percent"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:maxLines="1"
                     android:padding="5dp"
                     android:text="--%/--%/--%"
                     android:textAppearance="?android:attr/textAppearanceLarge" />

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
         android:key="xdrip_plus_category"
         android:title="@string/xdrip_plus_extra_settings" />
-    <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    <PreferenceScreen
         android:icon="@drawable/ic_chart_areaspline_grey600_48dp"
         android:key="xdrip_plus_display_settings"
         android:summary="@string/display_customisations"
@@ -13,9 +13,7 @@
         <PreferenceCategory
             android:key="xdrip_plus_display_category"
             android:title="@string/xdrip_plus_display_settings">
-            <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-
+            <PreferenceScreen
                 android:icon="@drawable/ic_palette_grey600_48dp"
                 android:key="xdrip_plus_color_settings"
                 android:summary="@string/customize_colours"
@@ -320,7 +318,7 @@
                 android:summary="@string/show_tips_hints"
                 android:title="@string/show_interface_hints" />
 
-            <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+            <PreferenceScreen
                 android:icon="@drawable/ic_chart_areaspline_grey600_48dp"
                 android:key="xdrip_plus_graph_display_settings"
                 android:summary="@string/summary_xdrip_plus_graph_display_settings"
@@ -472,7 +470,7 @@
                     android:action="android.settings.ACCESSIBILITY_SETTINGS"
                     />
             </Preference>
-            <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+            <PreferenceScreen
                 android:key="xdrip_plus_number_wall"
                 android:title="@string/title_xdrip_plus_number_wall">
                 <Preference
@@ -593,7 +591,7 @@
         </PreferenceCategory>
     </PreferenceScreen>
 
-    <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    <PreferenceScreen
         android:dependency="I_understand"
         android:icon="@drawable/ic_auto_fix_grey600_48dp"
         android:key="xdrip_plus_profile_settings"
@@ -687,7 +685,7 @@
             </Preference>
         </PreferenceCategory>
 
-        <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        <PreferenceScreen
             android:dependency="I_understand"
             android:key="xdrip_plus_adv_predict"
             android:summary="@string/deel_settings_for_algs"
@@ -729,7 +727,7 @@
 
     </PreferenceScreen>
 
-    <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    <PreferenceScreen
         android:dependency="I_understand"
         android:icon="@drawable/ic_google_circles_communities_grey600_48dp"
         android:key="xdrip_plus_sync_settings"
@@ -785,7 +783,7 @@
                 android:key="plus_follow_geolocation"
                 android:summary="@string/send_parakeet_map_location_to_followers"
                 android:title="@string/sync_parakeet_geolocation" />
-            <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+            <PreferenceScreen
                 android:key="xdrip_plus_remote_snooze_settings"
                 android:summary="@string/remote_snoozes"
                 android:title="@string/remote_snoozing">
@@ -830,7 +828,7 @@
                         android:title="Accept Local Broadcast" />
                 </PreferenceCategory>
             </PreferenceScreen>
-            <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+            <PreferenceScreen
                 android:icon="@drawable/desert_sync"
                 android:key="xdrip_plus_desert_sync_settings"
                 android:summary="@string/summary_xdrip_plus_desert_sync_settings"
@@ -873,7 +871,7 @@
         </PreferenceCategory>
     </PreferenceScreen>
 
-    <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    <PreferenceScreen
         android:icon="@drawable/ic_car_connected_grey600_48dp"
         android:key="xdrip_plus_motion_settings"
         android:summary="@string/movement_detection_and_vehicle_mode"
@@ -959,7 +957,7 @@
     </PreferenceScreen>
 
 
-    <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    <PreferenceScreen
         android:icon="@drawable/ic_briefcase_download_grey600_48dp"
         android:key="xdrip_plus_update_settings"
         android:summary="@string/automatic_updates_crash_reports_and_feedback"
@@ -1029,7 +1027,7 @@
         android:key="xdrip_plus_experimental"
         android:title="@string/title_xdrip_plus_experimental">
 
-        <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        <PreferenceScreen
             android:icon="@drawable/ic_mode_edit_grey_600_48dp"
             android:key="inpen_screen"
             android:summary="@string/summary_inpen_screen"
@@ -1088,7 +1086,7 @@
             </Preference>
         </PreferenceScreen>
 
-        <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        <PreferenceScreen
             android:icon="@drawable/ic_mode_edit_grey_600_48dp"
             android:key="pendiq_screen"
             android:summary="@string/summary_pendiq_screen"


### PR DESCRIPTION
This PR fixes #1641 by correcting layout parameters. It also adjusts the vertical padding to get a slightly more compact design.

Tested with all languages and small and large devices.

Here are two examples if German or Romanian (the longest strings) is set (old view to the left):
<img src="https://user-images.githubusercontent.com/35429041/107614497-b67da780-6c4a-11eb-9478-9cfa16795fac.png" width="300"/><img src="https://user-images.githubusercontent.com/1370732/117210361-da8af800-adf7-11eb-83a7-fb4cbe966fa2.png"/><img src="https://user-images.githubusercontent.com/1370732/117210568-2178ed80-adf8-11eb-999c-320d82924812.png"/>

As you can see, the description wraps if the string is too long and the values are shown right-aligned. I could not find a way to avoid this right-alignment. But it should be much more readable as before.