### PR TITLE
Change "Import database" to "Restore database".

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/ImportDatabaseActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ImportDatabaseActivity.java
@@ -84,7 +84,7 @@ public class ImportDatabaseActivity extends ListActivityWithMenu {
         LayoutInflater inflater= LayoutInflater.from(this);
         View view=inflater.inflate(R.layout.import_db_warning, null);
         AlertDialog.Builder alertDialog = new AlertDialog.Builder(this);
-        alertDialog.setTitle("Import Instructions");
+        alertDialog.setTitle("Restore Instructions");
         alertDialog.setView(view);
         alertDialog.setCancelable(false);
         alertDialog.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {

--- a/app/src/main/res/values/internal.xml
+++ b/app/src/main/res/values/internal.xml
@@ -4,20 +4,20 @@
     <string name="pref_I_understand_title"> I UNDERSTAND AND AGREE</string>
     <string name="pref_I_understand_summery" translatable="false">xDrip+ MUST NOT BE USED TO MAKE MEDICAL DECISIONS. IT IS A RESEARCH TOOL ONLY AND IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</string>
     <string name="import_db_warning">
-        WARNING: Importing a database might cause SEVERE DATA LOSS. If you don\'t know why you want to use the import, don\'t use it.
+        WARNING: Restoring a database might cause SEVERE DATA LOSS. If you don\'t know why you want to use the restore, don\'t use it.
         In regular operation of xDrip it is not needed. Just use it in case of previous data loss.
-        If you are not sure what to do, in case you still want to use the import, please ask an expert user.\n\n
+        If you are not sure what to do, in case you still want to use the restore, please ask an expert user.\n\n
         Instructions:\n
         Place the database you want to install in the directory \'xdrip\' on your primary external storage
         (sometimes called \'internal storage\' by the file browser).
         It is the same directory xDrip exports to.\n
         In case you have a zipped export in this directory, unzip it (usually longpress->extract on the file in the file browser).
-        If it gets extracted to a subdirectory it will still be found by the import.\n\n
-        After having placed the file, start this import routine.
+        If it gets extracted to a subdirectory it will still be found by the restore.\n\n
+        After having placed the file, start this restore routine.
         Scroll to the correct database name, click on it and follow the instructions on the screen.  \n\n
-        ATTENTION: A Database can only be imported if it has the same database version number currently needed for this xDrip version.
+        ATTENTION: A Database can only be restored if it has the same database version number currently needed for this xDrip version.
         The database verions number may change with xDrip updates.
-        It is best to import the database with the same version of the xDrip app it was exported and then update xDrip.
+        It is best to restore the database with the same version of the xDrip app it was exported and then update xDrip.
     </string>
 
     <string name="importanttext">Do NOT use or rely on this software or any associated materials for any medical purpose or decision.\n\nDo NOT rely on this system for any real-time alarms or time critical data.\n\nDo NOT use or rely on this system for treatment decisions or use as a substitute for professional healthcare judgement.\n\nAll software and materials have been provided for informational purposes only as a proof of concept to assist possibilities for further research.\n\nNo claims at all are made about fitness for any purpose and everything is provided \"AS IS\". Any part of the system can fail at any time.\n\nAlways seek the advice of a qualified healthcare professional for any medical questions.\n\nAlways follow your glucose-sensor or other device manufacturers\' instructions when using any equipment; do not discontinue use of accompanying reader or receiver, other than as advised by your doctor.\n\nThis software is not associated with or endorsed by any equipment manufacturer and all trademarks are those of their respective owners.\n\nYour use of this software is entirely at your own risk.\n\nNo charge has been made by the developers for the use of this software.\n\nThis is an open-source project which has been created by volunteers. The source code is published free and open-source for you to inspect and evaluate.\n\nBy using this software and/or website you agree that you are over 18 years of age and have read, understood and agree to all of the above.\n</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="menu_refresh">Refresh</string>
     <string name="menu_export_database">Export database</string>
     <string name="menu_export_csv_sidiary">Export CSV (SiDiary format)</string>
-    <string name="menu_import_db">Import database</string>
+    <string name="menu_import_db">Restore database</string>
     <string name="error_bluetooth_not_supported">Error: Bluetooth not supported by this device</string>
     <string name="unknown_device">Unrecognized Device</string>
     <string name="connecting_to_device">Connecting to device</string>
@@ -387,7 +387,7 @@
     <string name="install_pebble_trend_watchface">Install Pebble Trend Watchface</string>
     <string name="install_pebble_watchface">Install Pebble Watchface</string>
     <string name="glucose_history">Glucose History</string>
-    <string name="import_database">Import Database</string>
+    <string name="import_database">Restore Database</string>
     <string name="sensor_table">Sensor Table</string>
     <string name="bg_readings_table">Bg Readings Table</string>
     <string name="long_press_to_split_or_delete">Long Press to Split or Delete</string>


### PR DESCRIPTION
Users use the import database thinking it will only overwrite conflicts.  
https://github.com/NightscoutFoundation/xDrip/issues/1045

In reality, this command erases everything first.
Renaming the command to restore should better convey this behavior to users.

This image shows the proposed form.
![Screenshot_1619027093](https://user-images.githubusercontent.com/51497406/115598026-f3e45e00-a2a7-11eb-9f06-7f7b513d9ee7.png)
