### PR TITLE
Preemptive restart settings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1586,7 +1586,8 @@
     <string name="summary_ob1_g5_preemptive_restart_extended_time_travel">Restart the session to start at day 3 to avoid causing jumps</string>
     <string name="title_ob1_g5_preemptive_restart_extended_time_travel_all_firmwares">Always allow extended time-travel</string>
     <string name="summary_ob1_g5_preemptive_restart_extended_time_travel_all_firmwares">Allow extended time-travel with all firmware versions (engineering mode only)</string>
-    <string name="collection_summary_ob1_g5_preemptive_restart">Automatically restart a sensor before it stops</string>
+    <string name="collection_summary_ob1_g5_preemptive_restart">Configure or disable preemptive restarts</string>
+    <string name="title_preemptive_restart_settings">Preemptive restart settings</string>
     <string name="title_ob1_g5_preemptive_restart_alert">Alert on preemptive restart</string>
     <string name="summary_ob1_g5_preemptive_restart_alert">Raise an alert when preemptively restarting the session</string>
     <string name="blood_glucose_graph">Blood Glucose Graph</string>

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -173,7 +173,7 @@
                     android:key="collection_preemptive_restart"
                     android:dependency="ob1_g5_use_transmitter_alg"
                     android:summary="@string/collection_summary_ob1_g5_preemptive_restart"
-                    android:title="@string/title_ob1_g5_preemptive_restart">
+                    android:title="@string/title_preemptive_restart_settings">
                 <CheckBoxPreference
                         android:defaultValue="false"
                         android:dependency="ob1_g5_use_transmitter_alg"


### PR DESCRIPTION
Every now and then, someone on facebook asks why their G6 sensor has stopped on day 9 instead of day 10.
After checking, sure enough, they have preemptive restarts enabled for a firefly G6.

Looking at the G5/G6 Debug Settings, you can see that every single item on that page, except preemptive restarts, is a checkbox.
It's very easy for someone to look at that page and conclude that they don't have preemptive restarts enabled just because they don't see a checkmark on it.  
But, they cannot make that conclusion because that is not a checkbox.  Since every other entry on that page is a checkbox, it is a common confusion.

I have changed that label from "Preemptive restarts" to "Preemptive restart Settings".  And, I have changed the summary also accordingly.
![Screenshot_1619325715](https://user-images.githubusercontent.com/51497406/115981099-6468d480-a55f-11eb-8dea-1d2bfc674166.png)

This should reduce the confusion and hopefully the number of errors resulting in sensors stopping on day 9.
There was a person who posted and said that her sensors stopped on day 9, instead of day 10, and she believed it was because of the low quality of the sensors.  So, it's not even clear exactly how many people are affected really.  Some people are not even aware that they have a problem that can easily be resolved.