### PR TITLE
Speak Readings says dot dot dot 

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SpeechUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SpeechUtil.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 public class SpeechUtil {
 
     public static final String TAG = "SpeechUtil";
-    public static final String TWICE_DELIMITER = " ... ... ... "; // creates a pause hopefully works on all locales
+    public static final String TWICE_DELIMITER = "... "; // creates a pause hopefully works on all locales
     private static volatile TextToSpeech tts = null; // maintained instance
 
     // delay parameter allows you to force a millis delay before playing to avoid clash with notification sounds triggered at the same time


### PR DESCRIPTION
Fixes:  https://github.com/NightscoutFoundation/xDrip/issues/1707

There are two individuals on facebook who have raised this issue.  I was able to recreate the problem on my phone as well.
I suspect that the three instances (of ...) worked previously for an extended delay.  But, there may have been an update to Google text to speech, which now only treats the first instance as delay but speaks the following two.

I removed two instances and now there is only one, which allows the user to select speak everything twice and not hear dot dot dot spoken twice.