### PR TITLE
Optionally store g5/g6 transmitter battery information in nightscout

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1DexTransmitterBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1DexTransmitterBattery.java
@@ -1,0 +1,135 @@
+package com.eveningoutpost.dexdrip.G5Model;
+
+
+import com.eveningoutpost.dexdrip.Models.JoH;
+import com.eveningoutpost.dexdrip.Services.G5BaseService;
+import com.eveningoutpost.dexdrip.Services.Ob1G5CollectionService;
+import com.eveningoutpost.dexdrip.UtilityModels.Pref;
+import com.eveningoutpost.dexdrip.UtilityModels.StatusItem;
+
+
+/**
+ * External public-facing accessor for getting transmitter battery and related status information
+ * for Ob1G5/G6, which abstracts away the G5/G6 internals.
+ *
+ * Used in the Ob1G5/G6 status page as well as for Nightscout transmitter battery upload.
+ *
+ * @author James Woglom (j@wogloms.net)
+ */
+public class Ob1DexTransmitterBattery {
+
+    private final String tx_id;
+    private final BatteryInfoRxMessage battery;
+    private final VersionRequestRxMessage firmware;
+
+    public Ob1DexTransmitterBattery(String tx_id, BatteryInfoRxMessage battery, VersionRequestRxMessage firmware) {
+        this.tx_id = tx_id;
+        this.battery = battery;
+        this.firmware = firmware;
+    }
+
+    private Ob1DexTransmitterBattery(String tx_id) {
+        this.tx_id = tx_id;
+        this.battery = Ob1G5StateMachine.getBatteryDetails(tx_id);
+        this.firmware = (VersionRequestRxMessage) Ob1G5StateMachine.getFirmwareXDetails(tx_id, 0);
+    }
+
+    public Ob1DexTransmitterBattery() {
+        this(Pref.getStringDefaultBlank("dex_txid"));
+    }
+
+    public boolean isPresent() {
+        return battery != null && firmware != null;
+    }
+
+    public TransmitterStatus status() {
+        return TransmitterStatus.getBatteryLevel(firmware.status);
+    }
+
+    public int days() {
+        if (battery.runtime > -1) {
+            return battery.runtime;
+        }
+
+        return DexTimeKeeper.getTransmitterAgeInDays(tx_id);
+    }
+
+    public String daysEstimate() {
+        final int timekeeperDays = DexTimeKeeper.getTransmitterAgeInDays(tx_id);
+        long last_transmitter_timestamp = Ob1G5CollectionService.getLast_transmitter_timestamp();
+
+        StringBuilder b = new StringBuilder();
+
+        if (battery.runtime > -1) {
+            b.append(battery.runtime);
+        }
+
+        if (timekeeperDays > -1) {
+            if (b.length() > 0) {
+                b.append(FirmwareCapability.isTransmitterG6Rev2(tx_id) ? " " : " / ");
+            }
+            b.append(timekeeperDays);
+        }
+
+        if (last_transmitter_timestamp > 0) {
+            b.append(" / ");
+            b.append(JoH.qs((double) last_transmitter_timestamp / 86400, 1));
+        }
+
+        return b.toString();
+    }
+
+    public int voltageA() {
+        return battery.voltagea;
+    };
+
+    public int voltageB() {
+        return battery.voltageb;
+    }
+
+    public boolean voltageAWarning() {
+        return voltageA() < G5BaseService.LOW_BATTERY_WARNING_LEVEL;
+    }
+
+    public boolean voltageBWarning() {
+        return voltageB() < (G5BaseService.LOW_BATTERY_WARNING_LEVEL - 10);
+    };
+
+    public int resistance() {
+        return battery.resist;
+    }
+
+    public enum ResistanceStatus {
+        UNKNOWN(null),
+        GOOD(StatusItem.Highlight.GOOD),
+        NORMAL(StatusItem.Highlight.NORMAL),
+        WARNING(StatusItem.Highlight.NOTICE),
+        BAD(StatusItem.Highlight.BAD)
+        ;
+
+        // Passes-through the highlight used on the status page
+        public final StatusItem.Highlight highlight;
+        ResistanceStatus(StatusItem.Highlight highlight) {
+            this.highlight = highlight;
+        }
+    }
+    public ResistanceStatus resistanceStatus() {
+        if (!FirmwareCapability.isFirmwareTemperatureCapable(firmware.firmware_version_string)) {
+            return ResistanceStatus.UNKNOWN;
+        }
+
+        if (resistance() > 1400) {
+            return ResistanceStatus.BAD;
+        } else if (resistance() > 1000) {
+            return ResistanceStatus.WARNING;
+        } else if (resistance() > 750) {
+            return ResistanceStatus.NORMAL;
+        } else {
+            return ResistanceStatus.GOOD;
+        }
+    };
+
+    public int temperature() {
+        return battery.temperature;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1DexTransmitterBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1DexTransmitterBattery.java
@@ -4,6 +4,7 @@ package com.eveningoutpost.dexdrip.G5Model;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Services.G5BaseService;
 import com.eveningoutpost.dexdrip.Services.Ob1G5CollectionService;
+import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.StatusItem;
 
@@ -128,6 +129,10 @@ public class Ob1DexTransmitterBattery {
             return ResistanceStatus.GOOD;
         }
     };
+
+    public long lastQueried() {
+        return PersistentStore.getLong(G5BaseService.G5_BATTERY_FROM_MARKER + tx_id);
+    }
 
     public int temperature() {
         return battery.temperature;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5BaseService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5BaseService.java
@@ -35,7 +35,8 @@ public abstract class G5BaseService extends Service {
 
     protected static final int G5_LOW_BATTERY_WARNING_DEFAULT = 300;
     protected static final int G6_LOW_BATTERY_WARNING_DEFAULT = 290;
-    protected static int LOW_BATTERY_WARNING_LEVEL = G5_LOW_BATTERY_WARNING_DEFAULT; // updated by updateBatteryWarningLevel()
+    // updated by updateBatteryWarningLevel(), accessed by Ob1DexTransmitterBattery
+    public static int LOW_BATTERY_WARNING_LEVEL = G5_LOW_BATTERY_WARNING_DEFAULT;
 
     public static volatile boolean getBatteryStatusNow = false;
     protected static volatile boolean hardResetTransmitterNow = false;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
@@ -27,9 +27,9 @@ import com.eveningoutpost.dexdrip.G5Model.BatteryInfoRxMessage;
 import com.eveningoutpost.dexdrip.G5Model.BluetoothServices;
 import com.eveningoutpost.dexdrip.G5Model.CalibrationState;
 import com.eveningoutpost.dexdrip.G5Model.DexSyncKeeper;
-import com.eveningoutpost.dexdrip.G5Model.DexTimeKeeper;
 import com.eveningoutpost.dexdrip.G5Model.FirmwareCapability;
 import com.eveningoutpost.dexdrip.G5Model.Ob1G5StateMachine;
+import com.eveningoutpost.dexdrip.G5Model.Ob1DexTransmitterBattery;
 import com.eveningoutpost.dexdrip.G5Model.TransmitterStatus;
 import com.eveningoutpost.dexdrip.G5Model.VersionRequest1RxMessage;
 import com.eveningoutpost.dexdrip.G5Model.VersionRequest2RxMessage;
@@ -84,6 +84,7 @@ import java.util.concurrent.TimeUnit;
 import io.reactivex.Observable;
 import io.reactivex.Scheduler;
 import io.reactivex.schedulers.Schedulers;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.val;
 
@@ -180,6 +181,7 @@ public class Ob1G5CollectionService extends G5BaseService {
     private static volatile String static_connection_state = null;
     private static volatile long static_last_connected = 0;
     @Setter
+    @Getter
     private static long last_transmitter_timestamp = 0;
     private static long lastStateUpdated = 0;
     private static long wakeup_time = 0;
@@ -2073,8 +2075,9 @@ public class Ob1G5CollectionService extends G5BaseService {
             l.add(new StatusItem("Shelf Life", "" + vr1.inactive_days + " / " + vr1.max_inactive_days));
         }
 
-        final int timekeeperDays = DexTimeKeeper.getTransmitterAgeInDays(tx_id);
         if ((bt != null) && (last_battery_query > 0)) {
+            Ob1DexTransmitterBattery parsedBattery = new Ob1DexTransmitterBattery(tx_id, bt, vr);
+
             l.add(new StatusItem("Battery Last queried", JoH.niceTimeSince(last_battery_query) + " " + "ago", NORMAL, "long-press",
                     new Runnable() {
                         @Override
@@ -2088,16 +2091,23 @@ public class Ob1G5CollectionService extends G5BaseService {
                     l.add(new StatusItem("Transmitter Status", battery_status, BAD));
             }
 
-            // TODO use string builder instead of ternary for days
-            l.add(new StatusItem("Transmitter Days", ((bt.runtime > -1) ? bt.runtime : "") + ((timekeeperDays > -1) ? ((FirmwareCapability.isTransmitterG6Rev2(tx_id) ? " " : " / ") + timekeeperDays) : "") + ((last_transmitter_timestamp > 0) ? " / " + JoH.qs((double) last_transmitter_timestamp / 86400, 1) : "")));
-            l.add(new StatusItem("Voltage A", bt.voltagea, bt.voltagea < LOW_BATTERY_WARNING_LEVEL ? BAD : NORMAL));
-            l.add(new StatusItem("Voltage B", bt.voltageb, bt.voltageb < (LOW_BATTERY_WARNING_LEVEL - 10) ? BAD : NORMAL));
+            l.add(new StatusItem("Transmitter Days", parsedBattery.daysEstimate()));
+            l.add(new StatusItem("Voltage A", parsedBattery.voltageA(), parsedBattery.voltageAWarning() ? BAD : NORMAL));
+            l.add(new StatusItem("Voltage B", parsedBattery.voltageB(), parsedBattery.voltageBWarning() ? BAD : NORMAL));
             if (vr != null && FirmwareCapability.isFirmwareResistanceCapable(vr.firmware_version_string)) {
-                l.add(new StatusItem("Resistance", bt.resist, bt.resist > 1400 ? BAD : (bt.resist > 1000 ? NOTICE : (bt.resist > 750 ? NORMAL : Highlight.GOOD))));
+                l.add(new StatusItem("Resistance", parsedBattery.resistance(), parsedBattery.resistanceStatus().highlight));
             }
             if (vr != null && FirmwareCapability.isFirmwareTemperatureCapable(vr.firmware_version_string)) {
-                l.add(new StatusItem("Temperature", bt.temperature + " \u2103"));
+                l.add(new StatusItem("Temperature", parsedBattery.temperature() + " \u2103"));
             }
+        } else {
+            l.add(new StatusItem("Battery Info Unavailable", "Click to trigger update", NORMAL, "long-press",
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            getBatteryStatusNow = true;
+                        }
+                    }));
         }
 
         return l;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutBatteryDevice.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutBatteryDevice.java
@@ -1,0 +1,103 @@
+package com.eveningoutpost.dexdrip.UtilityModels;
+
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.BatteryManager;
+import android.os.Build;
+
+import com.eveningoutpost.dexdrip.G5Model.Ob1G5StateMachine;
+import com.eveningoutpost.dexdrip.G5Model.Ob1DexTransmitterBattery;
+import com.eveningoutpost.dexdrip.Services.DexCollectionService;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Represents a device type tracked by xDrip which can be uploaded to Nightscout devicestatus.
+ *
+ * Contains methods for identifying the current battery level and details for how the device's
+ * status will be sent to Nightscout.
+ *
+ * @author James Woglom (j@wogloms.net)
+ */
+public enum NightscoutBatteryDevice {
+    PHONE {
+        @Override
+        int getBatteryLevel(Context mContext) {
+            Intent batteryIntent = mContext.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+            if (batteryIntent != null) {
+                int level = batteryIntent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
+                int scale = batteryIntent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+                if (level == -1 || scale == -1) {
+                    return 50;
+                }
+                return (int) (((float) level / (float) scale) * 100.0f);
+            } else return 50;
+        }
+
+        @Override
+        String getDeviceName() {
+            return Build.MANUFACTURER + " " + Build.MODEL;
+        }
+    },
+    BRIDGE {
+        @Override
+        int getBatteryLevel(Context mContext) {
+            return Pref.getInt("bridge_battery", -1);
+        }
+
+        @Override
+        String getDeviceName() {
+            return DexCollectionService.getBestLimitterHardwareName();
+        }
+    },
+    PARAKEET {
+        @Override
+        int getBatteryLevel(Context mContext) {
+            return Pref.getInt("parakeet_battery", -1);
+        }
+
+        @Override
+        String getDeviceName() {
+            return "Parakeet";
+        }
+    };
+
+
+    /**
+     * Returns the battery level of the device.
+     *
+     * @param mContext is supplied so that the phone battery can be retrieved.
+     */
+    abstract int getBatteryLevel(Context mContext);
+
+    /**
+     * Returns the JSON object containing the battery details.
+     * Defaults to returning a JSONObject with integer key battery.
+     *
+     * @param mContext is supplied so that the phone battery can be retrieved.
+     */
+    public JSONObject getUploaderJson(Context mContext) throws JSONException {
+        JSONObject uploader = new JSONObject();
+        uploader.put("battery", getBatteryLevel(mContext));
+        return uploader;
+    }
+
+    /**
+     * Returns the device name sent to Nightscout for the device.
+     */
+    abstract String getDeviceName();
+
+    /**
+     * If true, the battery status is always uploaded to Nightscout.
+     * If false, the battery status is only uploaded when it changes.
+     *
+     * Nightscout doesn't currently display a device's status if it thinks
+     * that it is stale, so this has always been set to TRUE.
+     */
+    boolean alwaysSendBattery() {
+        return true;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutBatteryDevice.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutBatteryDevice.java
@@ -42,6 +42,7 @@ public enum NightscoutBatteryDevice {
             return Build.MANUFACTURER + " " + Build.MODEL;
         }
     },
+
     BRIDGE {
         @Override
         int getBatteryLevel(Context mContext) {
@@ -53,6 +54,7 @@ public enum NightscoutBatteryDevice {
             return DexCollectionService.getBestLimitterHardwareName();
         }
     },
+
     PARAKEET {
         @Override
         int getBatteryLevel(Context mContext) {
@@ -64,9 +66,11 @@ public enum NightscoutBatteryDevice {
             return "Parakeet";
         }
     },
+
     DEXCOM_TRANSMITTER {
         /**
-         * This is used for checking if the battery value is stale.
+         * This is only used as a check before uploading that we were able to
+         * obtain data for the transmitter in NightscoutUploader.
          */
         @Override
         int getBatteryLevel(Context mContext) {
@@ -112,14 +116,17 @@ public enum NightscoutBatteryDevice {
             if (b.voltageBWarning()) {
                 uploader.put("voltageb_warning", true);
             }
-            uploader.put("resistance", b.resistance());
             if (b.resistanceStatus() != Ob1DexTransmitterBattery.ResistanceStatus.UNKNOWN) {
+                uploader.put("resistance", b.resistance());
                 uploader.put("resistance_status", b.resistanceStatus().name());
             }
             uploader.put("temperature", b.temperature());
 
             // What nightscout will normally show in the UI
             uploader.put("battery", b.days() + " days (voltage: " + b.voltageA() + "/" + b.voltageB() + ")");
+
+            // Epoch timestamp representing when the battery was last queried.
+            uploader.put("lastQueried", b.lastQueried());
 
             uploader.put("type", name());
             return uploader;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -1,11 +1,7 @@
 package com.eveningoutpost.dexdrip.UtilityModels;
 
 import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.os.BatteryManager;
-import android.os.Build;
 import android.os.PowerManager;
 import android.preference.PreferenceManager;
 import android.util.Base64;
@@ -24,7 +20,6 @@ import com.eveningoutpost.dexdrip.Models.Treatments;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.Models.LibreBlock;
-import com.eveningoutpost.dexdrip.Services.DexCollectionService;
 import com.eveningoutpost.dexdrip.Services.ActivityRecognizedService;
 import com.eveningoutpost.dexdrip.utils.CipherUtils;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
@@ -1051,56 +1046,48 @@ public class NightscoutUploader {
         }
     }
 
-
     private static final String LAST_NIGHTSCOUT_BATTERY_LEVEL = "last-nightscout-battery-level";
 
-    private void postDeviceStatus(NightscoutService nightscoutService, String apiSecret) throws Exception {
+    private long getLastBatteryLevel(NightscoutBatteryDevice type) {
+        return PersistentStore.getLong(LAST_NIGHTSCOUT_BATTERY_LEVEL + "-" + type.name());
+    }
 
+    private void setLastBatteryLevel(NightscoutBatteryDevice type, long value) {
+        PersistentStore.setLong(LAST_NIGHTSCOUT_BATTERY_LEVEL + "-" + type.name(), value);
+    }
+
+    /**
+     * Uploads the device status (containing battery details) to Nightscout for
+     */
+    private void postDeviceStatus(NightscoutService nightscoutService, String apiSecret) throws Exception {
         // TODO optimize based on changes avoiding stale marker issues
-        final boolean always_send_battery = true; // nightscout doesn't currently display device device status if it thinks its stale
-        final List<String> batteries = new ArrayList<>();
-        batteries.add("Phone");
+
+        final List<NightscoutBatteryDevice> batteries = new ArrayList<>();
+
+        batteries.add(NightscoutBatteryDevice.PHONE);
+
         if ((DexCollectionType.hasBattery() && (Pref.getBoolean("send_bridge_battery_to_nightscout", true)))
                 || (Home.get_forced_wear() && DexCollectionType.getDexCollectionType().equals(DexCollectionType.DexcomG5))) {
-            batteries.add("Bridge");
+            batteries.add(NightscoutBatteryDevice.BRIDGE);
         }
-        if (DexCollectionType.hasWifi()) batteries.add("Parakeet");
+        if (DexCollectionType.hasWifi()) {
+            batteries.add(NightscoutBatteryDevice.PARAKEET);
+        }
 
-        for (String battery : batteries) {
+        for (NightscoutBatteryDevice batteryType : batteries) {
+            final long last_battery_level = getLastBatteryLevel(batteryType);
+            final int new_battery_level = batteryType.getBatteryLevel(mContext);
 
-            int battery_level;
-            String battery_name = "";
-            switch (battery) {
-                case "Phone":
-                    battery_level = getBatteryLevel();
-                    battery_name = Build.MANUFACTURER + " " + Build.MODEL;
-                    break;
-                case "Bridge":
-                    battery_level = Pref.getInt("bridge_battery", -1);
-                    battery_name = DexCollectionService.getBestLimitterHardwareName();
-                    break;
-                case "Parakeet":
-                    battery_level = Pref.getInt("parakeet_battery", -1);
-                    battery_name = "Parakeet";
-                    break;
-                default:
-                    battery_level = -1;
-                    break;
-            }
-            final long last_battery_level = PersistentStore.getLong(LAST_NIGHTSCOUT_BATTERY_LEVEL);
-
-            final JSONArray array = new JSONArray();
-            final JSONObject json = new JSONObject();
-            final JSONObject uploader = new JSONObject();
-
-            if ((battery_level > 0) && (battery_level != last_battery_level || always_send_battery)) {
-                PersistentStore.setLong(LAST_NIGHTSCOUT_BATTERY_LEVEL, battery_level);
+            if ((new_battery_level > 0) && (new_battery_level != last_battery_level || batteryType.alwaysSendBattery())) {
+                setLastBatteryLevel(batteryType, new_battery_level);
                 // UserError.Log.d(TAG, "Uploading battery detail: " + battery_level);
                 // json.put("uploaderBattery", battery_level); // old style
 
-                uploader.put("battery", battery_level);
-                json.put("device", battery_name);
-                json.put("uploader", uploader);
+                final JSONArray array = new JSONArray();
+                final JSONObject json = new JSONObject();
+
+                json.put("device", batteryType.getDeviceName());
+                json.put("uploader", batteryType.getUploaderJson(mContext));
 
                 array.put(json);
 
@@ -1113,7 +1100,6 @@ public class NightscoutUploader {
                 //            "temperature": "+51.0°C"
                 //}
                 //}
-
 
                 final RequestBody body = RequestBody.create(MediaType.parse("application/json"), json.toString());
                 Response<ResponseBody> r;
@@ -1329,16 +1315,9 @@ public class NightscoutUploader {
             }
             return false;
         }
+
     public int getBatteryLevel() {
-        Intent batteryIntent = mContext.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
-        if (batteryIntent != null) {
-            int level = batteryIntent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
-            int scale = batteryIntent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
-            if (level == -1 || scale == -1) {
-                return 50;
-            }
-            return (int) (((float) level / (float) scale) * 100.0f);
-        } else return 50;
+        return NightscoutBatteryDevice.PHONE.getBatteryLevel(mContext);
     }
 
     private static boolean isLANhost(String host) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -1070,8 +1070,14 @@ public class NightscoutUploader {
                 || (Home.get_forced_wear() && DexCollectionType.getDexCollectionType().equals(DexCollectionType.DexcomG5))) {
             batteries.add(NightscoutBatteryDevice.BRIDGE);
         }
+
         if (DexCollectionType.hasWifi()) {
             batteries.add(NightscoutBatteryDevice.PARAKEET);
+        }
+
+        boolean sendDexcomTxBattery = Pref.getBooleanDefaultFalse("send_ob1dex_tx_battery_to_nightscout");
+        if (sendDexcomTxBattery) {
+            batteries.add(NightscoutBatteryDevice.DEXCOM_TRANSMITTER);
         }
 
         for (NightscoutBatteryDevice batteryType : batteries) {
@@ -1085,9 +1091,14 @@ public class NightscoutUploader {
 
                 final JSONArray array = new JSONArray();
                 final JSONObject json = new JSONObject();
+                final JSONObject uploader = batteryType.getUploaderJson(mContext);
+
+                if (uploader == null) {
+                    continue;
+                }
 
                 json.put("device", batteryType.getDeviceName());
-                json.put("uploader", batteryType.getUploaderJson(mContext));
+                json.put("uploader", uploader);
 
                 array.put(json);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1201,6 +1201,8 @@
     <string name="title_rest_api_extra_options">Extra Options</string>
     <string name="summary_send_bridge_battery_to_nightscout">Send your bridge battery level to Nightscout. Uncheck if your battery sensor is broken.</string>
     <string name="title_send_bridge_battery_to_nightscout">Upload bridge battery</string>
+    <string name="summary_send_dexcom_transmitter_battery_to_nightscout">Send Dexcom transmitter battery statistics to Nightscout. Includes all of the data shown on the Collector Status screen.</string>
+    <string name="title_send_dexcom_transmitter_battery_to_nightscout">Upload OB1G5/G6 transmitter battery</string>
     <string name="summary_send_treatments_to_nightscout">Send treatment data to Nightscout. Uncheck if your careportal is broken.</string>
     <string name="title_send_treatments_to_nightscout">Upload treatments</string>
     <string name="summary_warn_nightscout_failures">Display and sound a notification if Nightscout upload is failing.</string>

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -74,6 +74,11 @@
                         android:summary="@string/summary_send_bridge_battery_to_nightscout"
                         android:title="@string/title_send_bridge_battery_to_nightscout" />
                     <CheckBoxPreference
+                        android:defaultValue="false"
+                        android:key="send_ob1dex_tx_battery_to_nightscout"
+                        android:summary="@string/summary_send_dexcom_transmitter_battery_to_nightscout"
+                        android:title="@string/title_send_dexcom_transmitter_battery_to_nightscout" />
+                    <CheckBoxPreference
                         android:defaultValue="true"
                         android:key="send_treatments_to_nightscout"
                         android:summary="@string/summary_send_treatments_to_nightscout"


### PR DESCRIPTION
This is an updated version of https://github.com/NightscoutFoundation/xDrip/pull/584 (which was originally submitted as a PR in 2018).

When enabled, the changes in this CR allow for uploading battery and status data for Dexcom G5/G6 transmitters to Nightscout. 

The following appears at /api/v1/devicestatus in Nightscout:

```
[
  {
    "_id": "608d030f695b8526acd3fabc",
    "device": "G6 Transmitter",
    "uploader": {
      "days": 85,
      "daysEstimate": "85",
      "status": "OK",
      "voltagea": 309,
      "voltageb": 290,
      "resistance": 0,
      "temperature": 32,
      "battery": "85 days (voltage: 309/290)",
      "type": "DEXCOM_TRANSMITTER"
    },
    "created_at": "2021-05-01T07:28:15.656Z"
  },
  ...
]
```

Other devicestatus uploads now contain a type field, e.g.:

```
{
  "_id": "608d0561695b8526acd3fabe",
  "device": "Google Pixel 2 XL",
  "uploader": {
    "battery": 100,
    "type": "PHONE"
  }
}
```

The transmitter details are now visible in the Nightscout UI:

<img src="https://user-images.githubusercontent.com/192620/116775194-b8782b00-aa2f-11eb-908a-09677b34f33b.png" width=450 />
