### PR TITLE
BgReading: store "G6 Native" label instead of "G5 Native" when using g6.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -1089,7 +1089,11 @@ public class BgReading extends Model implements ShareUploadableBg {
             bgr.uuid = UUID.randomUUID().toString();
             bgr.calculated_value = calculated_value;
             bgr.raw_data = SPECIAL_G5_PLACEHOLDER; // placeholder
-            bgr.appendSourceInfo("G5 Native");
+            if (Ob1G5CollectionService.usingG6()) {
+                bgr.appendSourceInfo("G6 Native");
+            } else {
+                bgr.appendSourceInfo("G5 Native");
+            }
             if (sourceInfoAppend != null && sourceInfoAppend.length() > 0) {
                 bgr.appendSourceInfo(sourceInfoAppend);
             }


### PR DESCRIPTION
This will cause the correct G6 label to also be stored in Nightscout.

As far as I can tell, this codepath only affects the internal sourceinfo stored in the xDrip database which is passed to Nightscout, and does not affect AndroidAPS or local broadcasts.

If this somehow does affect those, per the commits linked by @AdrianLxM in the original PR, AndroidAPS code has been aware of the "G6 Native" label since 2018. There also appears to be code that checks for backwards-compatibility at https://github.com/NightscoutFoundation/xDrip/blob/38fee03be56da6ce9cbe90e08dbe8e4b651c6edc/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BroadcastGlucose.java#L38

See original discussion in https://github.com/NightscoutFoundation/xDrip/pull/559

