### PR TITLE
Improve Tasker snooze functionality

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
@@ -34,38 +34,50 @@ public class SnoozeActivity extends ActivityWithMenu {
     private static String status;
 
     // Snooze types supported by this class
-    public static final String ALERTS_DISABLED_UNTIL = "alerts_disabled_until";
-    public static final String LOW_ALERTS_DISABLED_UNTIL = "low_alerts_disabled_until";
-    public static final String HIGH_ALERTS_DISABLED_UNTIL = "high_alerts_disabled_until";
+    public enum SnoozeType {
+        ALL_ALERTS("alerts_disabled_until"),
+        LOW_ALERTS("low_alerts_disabled_until"),
+        HIGH_ALERTS("high_alerts_disabled_until")
+        ;
+
+        private final String prefKey;
+        SnoozeType(String prefKey) {
+            this.prefKey = prefKey;
+        }
+
+        public String getPrefKey() {
+            return prefKey;
+        }
+    }
 
     /**
      * Snoozes a given type for the specified number of minutes.
      */
-    public static void snoozeForType(long minutes, String disableType, SharedPreferences prefs) {
+    public static void snoozeForType(long minutes, SnoozeType disableType, SharedPreferences prefs) {
         if (minutes == -1) {
             minutes = infiniteSnoozeValueInMinutes;
         }
         long disableUntil = new Date().getTime() + minutes * 1000 * 60;
 
-        prefs.edit().putLong(disableType, disableUntil).apply();
+        prefs.edit().putLong(disableType.getPrefKey(), disableUntil).apply();
 
         //check if active bg alert exists and delete it depending on type of alert
         ActiveBgAlert aba = ActiveBgAlert.getOnly();
         if (aba != null) {
             AlertType activeBgAlert = ActiveBgAlert.alertTypegetOnly();
-            if (disableType.equalsIgnoreCase(ALERTS_DISABLED_UNTIL)
-                    || (activeBgAlert.above && disableType.equalsIgnoreCase(HIGH_ALERTS_DISABLED_UNTIL))
-                    || (!activeBgAlert.above && disableType.equalsIgnoreCase(LOW_ALERTS_DISABLED_UNTIL))
+            if (disableType == SnoozeType.ALL_ALERTS
+                    || (activeBgAlert.above && disableType == SnoozeType.HIGH_ALERTS)
+                    || (!activeBgAlert.above && disableType == SnoozeType.LOW_ALERTS)
             ) {
                 //active bg alert exists which is a type that is being disabled so let's remove it completely from the database
                 ActiveBgAlert.ClearData();
             }
         }
 
-        if (disableType.equalsIgnoreCase(ALERTS_DISABLED_UNTIL)) {
+        if (disableType == SnoozeType.ALL_ALERTS) {
             //disabling all , after the Snooze time set, all alarms will be re-enabled, inclusive low and high bg alarms
-            prefs.edit().putLong(HIGH_ALERTS_DISABLED_UNTIL, 0).apply();
-            prefs.edit().putLong(LOW_ALERTS_DISABLED_UNTIL, 0).apply();
+            prefs.edit().putLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0).apply();
+            prefs.edit().putLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0).apply();
         }
         recheckAlerts();
     }
@@ -205,25 +217,24 @@ public class SnoozeActivity extends ActivityWithMenu {
         });
         showDisableEnableButtons();
 
-        setOnClickListenerOnDisableButton(disableAlerts, ALERTS_DISABLED_UNTIL);
-        setOnClickListenerOnDisableButton(disableLowAlerts, LOW_ALERTS_DISABLED_UNTIL);
-        setOnClickListenerOnDisableButton(disableHighAlerts, HIGH_ALERTS_DISABLED_UNTIL);
+        setOnClickListenerOnDisableButton(disableAlerts, SnoozeType.ALL_ALERTS);
+        setOnClickListenerOnDisableButton(disableLowAlerts, SnoozeType.LOW_ALERTS);
+        setOnClickListenerOnDisableButton(disableHighAlerts, SnoozeType.HIGH_ALERTS);
 
-        setOnClickListenerOnClearDisabledButton(clearDisabled, ALERTS_DISABLED_UNTIL);
-        setOnClickListenerOnClearDisabledButton(clearLowDisabled, LOW_ALERTS_DISABLED_UNTIL);
-        setOnClickListenerOnClearDisabledButton(clearHighDisabled, HIGH_ALERTS_DISABLED_UNTIL);
+        setOnClickListenerOnClearDisabledButton(clearDisabled, SnoozeType.ALL_ALERTS);
+        setOnClickListenerOnClearDisabledButton(clearLowDisabled, SnoozeType.LOW_ALERTS);
+        setOnClickListenerOnClearDisabledButton(clearHighDisabled, SnoozeType.HIGH_ALERTS);
     }
 
     /**
      * Functionality used at least three times moved to a function. Adds an onClickListener that will re-enable the identified alert
      * @param button to which onclicklistener should be added
-     * @param alert identifies the alert, the text string used in the preferences for example alerts_disabled_until
+     * @param snoozeType identifies the alert, value of the SnoozeType enum
      */
-    private void setOnClickListenerOnClearDisabledButton(Button button, String alert) {
-        final String theAlert = alert;
+    private void setOnClickListenerOnClearDisabledButton(Button button, SnoozeType snoozeType) {
         button.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                prefs.edit().putLong(theAlert, 0).apply();
+                prefs.edit().putLong(snoozeType.getPrefKey(), 0).apply();
                 //this is needed to make sure that the missedreading alert will be rechecked, it might have to be raised
                 //and if not (ie no missed readings for long enough) then the alarm should be reset because it might have to recheck the missedreading status sooner
                 recheckAlerts();
@@ -237,14 +248,13 @@ public class SnoozeActivity extends ActivityWithMenu {
     /**
      * Functionality used at least three times moved to a function. Adds an onClickListener that will disable the identified alert<br>
      * Depending on type of disable, also active alarms will be set to inactive<br>
-     * - if alert = "alerts_disabled_until" then the active bg alert will be deleted if any<br>
-     * - if alert = "low_alerts_disabled_until" and if active low bg alert exists then it will be deleted<br>
-     * - if alert = "high_alerts_disabled_until" and if active high bg alert exists then it will be deleted<br>
+     * - if snoozeType = ALL_ALERTS then the active bg alert will be deleted if any<br>
+     * - if snoozeType = LOW_ALERTS and if active low bg alert exists then it will be deleted<br>
+     * - if snoozeType = HIGH_ALERTS and if active high bg alert exists then it will be deleted<br>
      * @param button to which onclicklistener should be added
-     * @param alert identifies the alert, the text string used in the preferences ie alerts_disabled_until, low_alerts_disabled_until or high_alerts_disabled_until
+     * @param snoozeType identifies the alert, an enum value of SnoozeType
      */
-    private void setOnClickListenerOnDisableButton(Button button, String alert) {
-        final String disableType = alert;
+    private void setOnClickListenerOnDisableButton(Button button, SnoozeType snoozeType) {
         button.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 final Dialog d = new Dialog(SnoozeActivity.this);
@@ -275,7 +285,7 @@ public class SnoozeActivity extends ActivityWithMenu {
                             minutes = SnoozeActivity.getTimeFromSnoozeValue(snoozeValue.getValue());
                         }
 
-                        snoozeForType(minutes, disableType, prefs);
+                        snoozeForType(minutes, snoozeType, prefs);
 
                         d.dismiss();
                         //also make sure the text in the Activity is changed
@@ -302,7 +312,7 @@ public class SnoozeActivity extends ActivityWithMenu {
     }
 
     public void showDisableEnableButtons() {
-        if(prefs.getLong(ALERTS_DISABLED_UNTIL, 0) > new Date().getTime()){
+        if(prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0) > new Date().getTime()){
             disableAlerts.setVisibility(View.GONE);
             clearDisabled.setVisibility(View.VISIBLE);
             //all alerts are disabled so no need to show the buttons related to disabling/enabling the low and high alerts
@@ -313,14 +323,14 @@ public class SnoozeActivity extends ActivityWithMenu {
         } else {
             clearDisabled.setVisibility(View.GONE);
             disableAlerts.setVisibility(View.VISIBLE);
-            if (prefs.getLong(LOW_ALERTS_DISABLED_UNTIL, 0) > new Date().getTime()) {
+            if (prefs.getLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0) > new Date().getTime()) {
                 disableLowAlerts.setVisibility(View.GONE);
                 clearLowDisabled.setVisibility(View.VISIBLE);
             } else {
                 disableLowAlerts.setVisibility(View.VISIBLE);
                 clearLowDisabled.setVisibility(View.GONE);
             }
-            if (prefs.getLong(HIGH_ALERTS_DISABLED_UNTIL, 0) > new Date().getTime()) {
+            if (prefs.getLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0) > new Date().getTime()) {
                 disableHighAlerts.setVisibility(View.GONE);
                 clearHighDisabled.setVisibility(View.VISIBLE);
             } else {
@@ -347,10 +357,10 @@ public class SnoozeActivity extends ActivityWithMenu {
         long now = new Date().getTime();
         if(activeBgAlert == null ) {
             sendRemoteSnooze.setVisibility(Pref.getBooleanDefaultFalse("send_snooze_to_remote") ? View.VISIBLE : View.GONE);
-            if (prefs.getLong(ALERTS_DISABLED_UNTIL, 0) > now
+            if (prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0) > now
                     ||
-                    (prefs.getLong(LOW_ALERTS_DISABLED_UNTIL, 0) > now
-                            && prefs.getLong(HIGH_ALERTS_DISABLED_UNTIL, 0) > now)
+                    (prefs.getLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0) > now
+                            && prefs.getLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0) > now)
                     ) {
                 //not useful to show now that there's no active alert because either all alerts are disabled or high and low alerts are disabled
                 //there can not be any active alert
@@ -373,19 +383,19 @@ public class SnoozeActivity extends ActivityWithMenu {
         }
 
         //check if there are disabled alerts and if yes add warning
-        if (prefs.getLong(ALERTS_DISABLED_UNTIL, 0) > now) {
+        if (prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0) > now) {
             String textToAdd = MessageFormat.format("{0,choice,0#{1,time}|1#you re-enable}",
-                    (prefs.getLong(ALERTS_DISABLED_UNTIL, 0) > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000) ? 1 : 0 , new Date(prefs.getLong("alerts_disabled_until", 0)));
+                    (prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0) > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000) ? 1 : 0 , new Date(prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0)));
             status = getString(R.string.all_alerts_disabled_until) + textToAdd;
         } else {
-            if (prefs.getLong(LOW_ALERTS_DISABLED_UNTIL, 0) > now) {
+            if (prefs.getLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0) > now) {
                 String textToAdd = MessageFormat.format("{0,choice,0#{1,time}|1#you re-enable}",
-                        (prefs.getLong(LOW_ALERTS_DISABLED_UNTIL, 0) > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000) ? 1 : 0 , new Date(prefs.getLong("low_alerts_disabled_until", 0)));
+                        (prefs.getLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0) > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000) ? 1 : 0 , new Date(prefs.getLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0)));
                 status += "\n\n"+getString(R.string.low_alerts_disabled_until) + textToAdd;
             }
-            if (prefs.getLong(HIGH_ALERTS_DISABLED_UNTIL, 0) > now) {
+            if (prefs.getLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0) > now) {
                 String textToAdd = MessageFormat.format("{0,choice,0#{1,time}|1#you re-enable}",
-                        (prefs.getLong(HIGH_ALERTS_DISABLED_UNTIL, 0) > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000) ? 1 : 0 , new Date(prefs.getLong("high_alerts_disabled_until", 0)));
+                        (prefs.getLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0) > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000) ? 1 : 0 , new Date(prefs.getLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0)));
                 status += "\n\n"+getString(R.string.high_alerts_disabled_until) + textToAdd;
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -225,18 +225,25 @@ public class AlertPlayer {
             return;
         }
         if (repeatTime == -1) {
-            // try to work out default
-            AlertType alert = ActiveBgAlert.alertTypegetOnly();
-            if (alert != null) {
-                repeatTime = alert.default_snooze;
-                Log.d(TAG, "Selecting default snooze time: " + repeatTime);
-            } else {
-                repeatTime = 30; // pick a number if we cannot even find the default
-                Log.e(TAG, "Cannot even find default snooze time so going with: " + repeatTime);
-            }
+            repeatTime = GuessDefaultSnoozeTime();
         }
         activeBgAlert.snooze(repeatTime);
         if (from_interactive) GcmActivity.sendSnoozeToRemote();
+    }
+
+    public synchronized int GuessDefaultSnoozeTime() {
+        int repeatTime;
+        // try to work out default
+        AlertType alert = ActiveBgAlert.alertTypegetOnly();
+        if (alert != null) {
+            repeatTime = alert.default_snooze;
+            Log.d(TAG, "Selecting default snooze time: " + repeatTime);
+        } else {
+            repeatTime = 30; // pick a number if we cannot even find the default
+            Log.e(TAG, "Cannot even find default snooze time so going with: " + repeatTime);
+        }
+
+        return repeatTime;
     }
 
     public synchronized void PreSnooze(Context ctx, String uuid, int repeatTime) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/receiver/FireReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/receiver/FireReceiver.java
@@ -162,8 +162,15 @@ public final class FireReceiver extends BroadcastReceiver {
                             break;
 
                         case "SNOOZE":
-                            AlertPlayer.defaultSnooze();
-                            JoH.static_toast_long("SNOOZE from Tasker");
+                            // default: snoozes the length of the current alert, or the default alert length
+                            int minutes = -1;
+                            if (message_array.length > 1) {
+                                minutes = Integer.valueOf(message_array[1]);
+                                JoH.static_toast_long("SNOOZE from Tasker for "+minutes+" min");
+                            } else {
+                                JoH.static_toast_long("SNOOZE from Tasker");
+                            }
+                            AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), minutes);
                             break;
 
                             //opportunistic snooze that only does anything if an alert is active

--- a/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/receiver/FireReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/receiver/FireReceiver.java
@@ -197,7 +197,7 @@ public final class FireReceiver extends BroadcastReceiver {
                                 JoH.static_toast_long("SNOOZE_LOW from Tasker for " + minutes + " min");
                             }
 
-                            SnoozeActivity.snoozeForType(minutes, SnoozeActivity.LOW_ALERTS_DISABLED_UNTIL, prefs);
+                            SnoozeActivity.snoozeForType(minutes, SnoozeActivity.SnoozeType.LOW_ALERTS, prefs);
                             break;
 
                         case "SNOOZE_HIGH":
@@ -219,7 +219,7 @@ public final class FireReceiver extends BroadcastReceiver {
                                 JoH.static_toast_long("SNOOZE_HIGH from Tasker for " + minutes + " min");
                             }
 
-                            SnoozeActivity.snoozeForType(minutes, SnoozeActivity.HIGH_ALERTS_DISABLED_UNTIL, prefs);
+                            SnoozeActivity.snoozeForType(minutes, SnoozeActivity.SnoozeType.HIGH_ALERTS, prefs);
                             break;
 
                             //opportunistic snooze that only does anything if an alert is active

--- a/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/receiver/FireReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/receiver/FireReceiver.java
@@ -19,13 +19,16 @@ package com.eveningoutpost.dexdrip.localeTasker.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.PowerManager;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.widget.Toast;
 
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.R;
+import com.eveningoutpost.dexdrip.SnoozeActivity;
 import com.eveningoutpost.dexdrip.UtilityModels.AlertPlayer;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
@@ -91,6 +94,8 @@ public final class FireReceiver extends BroadcastReceiver {
                 if ((message != null) && !message.isEmpty()) {
                     final String[] message_array = message.split("\\s+"); // split by space
                     Log.d(TAG,"Received tasker message: "+message);
+
+                    final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
 
                     // Commands recognised:
                     //
@@ -171,6 +176,50 @@ public final class FireReceiver extends BroadcastReceiver {
                                 JoH.static_toast_long("SNOOZE from Tasker");
                             }
                             AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), minutes);
+                            break;
+
+                        case "SNOOZE_LOW":
+                            // default: snoozes the length of the current alert, or the default alert length
+                            minutes = AlertPlayer.getPlayer().GuessDefaultSnoozeTime();
+
+                            // If a specific number of minutes is given, use it.
+                            // If -1, enables this alert indefinitely.
+                            // If 0, disables an already configured alert.
+                            if (message_array.length > 1) {
+                                minutes = Integer.valueOf(message_array[1]);
+                            }
+
+                            if (minutes == -1) {
+                                JoH.static_toast_long("SNOOZE_LOW from Tasker enabled indefinitely (until disabled)");
+                            } else if (minutes == 0) {
+                                JoH.static_toast_long("SNOOZE_LOW from Tasker disabled");
+                            } else {
+                                JoH.static_toast_long("SNOOZE_LOW from Tasker for " + minutes + " min");
+                            }
+
+                            SnoozeActivity.snoozeForType(minutes, SnoozeActivity.LOW_ALERTS_DISABLED_UNTIL, prefs);
+                            break;
+
+                        case "SNOOZE_HIGH":
+                            // default: snoozes the length of the current alert, or the default alert length
+                            minutes = AlertPlayer.getPlayer().GuessDefaultSnoozeTime();
+
+                            // If a specific number of minutes is given, use it.
+                            // If -1, enables this alert indefinitely.
+                            // If 0, disables an already configured alert.
+                            if (message_array.length > 1) {
+                                minutes = Integer.valueOf(message_array[1]);
+                            }
+
+                            if (minutes == -1) {
+                                JoH.static_toast_long("SNOOZE_HIGH from Tasker enabled indefinitely (until disabled)");
+                            } else if (minutes == 0) {
+                                JoH.static_toast_long("SNOOZE_HIGH from Tasker disabled");
+                            } else {
+                                JoH.static_toast_long("SNOOZE_HIGH from Tasker for " + minutes + " min");
+                            }
+
+                            SnoozeActivity.snoozeForType(minutes, SnoozeActivity.HIGH_ALERTS_DISABLED_UNTIL, prefs);
                             break;
 
                             //opportunistic snooze that only does anything if an alert is active


### PR DESCRIPTION
This PR allows for snoozing a specified number of minutes via Tasker, as well as a specified number of minutes for snoozing low/high alerts. It includes some cleanup in SnoozeActivity to allow for this to be queried via tasker.

Added tasker commands:
* **SNOOZE [mins]** - snoozes for the given number of minutes (Existing no-argument SNOOZE behavior is preserved -- snoozes the current event length or default snooze length)
* **SNOOZE_HIGH** - snoozes high alerts for the current alert length or default snooze length
* **SNOOZE_HIGH [mins]** - snoozes high alerts for the given number of minutes
* **SNOOZE_LOW** - snoozes low alerts for the current alert length or default snooze length
* **SNOOZE_LOW [mins]** - snoozes low alerts for the given number of minutes

These commands can be executed via the WebServiceTasker interface (e.g. http://localhost:17580/tasker/SNOOZE_LOW+30 to SNOOZE_LOW for 30 minutes). To test this functionality you can run `adb forward tcp:17580 tcp:17580` to access the web interface.