### PR TITLE
G6 Temperature back

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/FirmwareCapability.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/FirmwareCapability.java
@@ -44,7 +44,11 @@ public class FirmwareCapability {
     }
 
     public static boolean isFirmwareTemperatureCapable(final String version) {
-        return !isG6Rev2(version) && !isG6Plus(version);
+        return !isG6Plus(version);
+    }
+
+    public static boolean isFirmwareResistanceCapable(final String Version) {
+        return !isG6Rev2(Version) && !isG6Plus(Version);
     }
 
     private static boolean isFirmwarePredictiveCapable(final String version) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
@@ -2092,8 +2092,10 @@ public class Ob1G5CollectionService extends G5BaseService {
             l.add(new StatusItem("Transmitter Days", ((bt.runtime > -1) ? bt.runtime : "") + ((timekeeperDays > -1) ? ((FirmwareCapability.isTransmitterG6Rev2(tx_id) ? " " : " / ") + timekeeperDays) : "") + ((last_transmitter_timestamp > 0) ? " / " + JoH.qs((double) last_transmitter_timestamp / 86400, 1) : "")));
             l.add(new StatusItem("Voltage A", bt.voltagea, bt.voltagea < LOW_BATTERY_WARNING_LEVEL ? BAD : NORMAL));
             l.add(new StatusItem("Voltage B", bt.voltageb, bt.voltageb < (LOW_BATTERY_WARNING_LEVEL - 10) ? BAD : NORMAL));
-            if (vr != null && FirmwareCapability.isFirmwareTemperatureCapable(vr.firmware_version_string)) {
+            if (vr != null && FirmwareCapability.isFirmwareResistanceCapable(vr.firmware_version_string)) {
                 l.add(new StatusItem("Resistance", bt.resist, bt.resist > 1400 ? BAD : (bt.resist > 1000 ? NOTICE : (bt.resist > 750 ? NORMAL : Highlight.GOOD))));
+            }
+            if (vr != null && FirmwareCapability.isFirmwareTemperatureCapable(vr.firmware_version_string)) {
                 l.add(new StatusItem("Temperature", bt.temperature + " \u2103"));
             }
         }


### PR DESCRIPTION
| Subject | Detail |
| ---------|-------|
|Why do we need this? | A G6 Firefly does not show the sensor temperature on the system status page now. <br /> After this fix, it will. |
| Is there a work-around? | The temperature is shown in the logs. |
| Are there any side-effects to this fix? | No |
| Tests | Has been tested with 2.27.2.98 and 2.27.2.103 firmwares. |
