### PR TITLE
update rxandroidble2 to 1.12.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -344,7 +344,7 @@ dependencies {
     implementation 'io.reactivex:rxjava:1.3.3'
     implementation 'com.activeandroid:thread-safe-active-android:3.1.1'
     //implementation 'com.github.lecho:hellocharts-android:v1.5.8'
-    implementation "com.polidea.rxandroidble2:rxandroidble:1.11.1"
+    implementation "com.polidea.rxandroidble2:rxandroidble:1.12.1"
     implementation 'com.google.guava:guava:24.1-android'
     implementation 'com.embarkmobile:zxing-android-minimal:2.0.0@aar'
     implementation 'com.embarkmobile:zxing-android-integration:2.0.0@aar'

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/bt/ScanRecordImplCompatLocal.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/bt/ScanRecordImplCompatLocal.java
@@ -19,6 +19,9 @@ public class ScanRecordImplCompatLocal implements ScanRecord {
     @Nullable
     private final List<ParcelUuid> serviceUuids;
 
+    @Nullable
+    private final List<ParcelUuid> serviceSolicitationUuids;
+
     private final SparseArray<byte[]> manufacturerSpecificData;
 
     private final Map<ParcelUuid, byte[]> serviceData;
@@ -34,6 +37,7 @@ public class ScanRecordImplCompatLocal implements ScanRecord {
 
     public ScanRecordImplCompatLocal(
             @Nullable List<ParcelUuid> serviceUuids,
+            @Nullable List<ParcelUuid> serviceSolicitationUuids,
             SparseArray<byte[]> manufacturerData,
             Map<ParcelUuid, byte[]> serviceData,
             int advertiseFlags,
@@ -42,6 +46,7 @@ public class ScanRecordImplCompatLocal implements ScanRecord {
             byte[] bytes
     ) {
         this.serviceUuids = serviceUuids;
+        this.serviceSolicitationUuids = serviceSolicitationUuids;
         this.manufacturerSpecificData = manufacturerData;
         this.serviceData = serviceData;
         this.deviceName = localName;
@@ -65,6 +70,15 @@ public class ScanRecordImplCompatLocal implements ScanRecord {
     @Nullable
     public List<ParcelUuid> getServiceUuids() {
         return serviceUuids;
+    }
+
+    /**
+     * Returns a list of service solicitation UUIDs within the advertisement that are used to identify the
+     * bluetooth GATT services the peripheral requires on the Central.
+     */
+    @Nullable
+    public List<ParcelUuid> getServiceSolicitationUuids() {
+        return serviceSolicitationUuids;
     }
 
     /**

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -216,7 +216,7 @@ dependencies {
     implementation 'com.activeandroid:thread-safe-active-android:3.1.1'
     implementation 'com.google.guava:guava:24.1-jre'
     implementation 'io.reactivex:rxjava:1.3.3'
-    implementation 'com.polidea.rxandroidble2:rxandroidble:1.11.1'
+    implementation 'com.polidea.rxandroidble2:rxandroidble:1.12.1'
     implementation 'org.apache.commons:commons-math3:3.6'
     testImplementation "org.robolectric:robolectric:4.2.1"
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
This PR bumps RxAndroidBle to version 1.12.1 to fix a memory leak in [scanBleDevices](https://github.com/Polidea/RxAndroidBle/issues/607) which can cause the RxAndroidBle stack to hang.

It also add support to parse service solicitation UUIDs, which is required by the updated library but currently not used in xDrip.