### PR TITLE
Add resource string for the newly added Stop Sensor Confirmation

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
@@ -49,7 +49,7 @@ public class StopSensor extends ActivityWithMenu {
     public void addListenerOnButton() {
         button = (Button)findViewById(R.id.stop_sensor);
         val activity = this;
-        button.setOnClickListener(v -> GenericConfirmDialog.show(activity, gs(R.string.are_you_sure), "Do you want to stop this sensor session?", () -> {
+        button.setOnClickListener(v -> GenericConfirmDialog.show(activity, gs(R.string.are_you_sure), gs(R.string.sensor_stop_confirm), () -> {
             stop();
             JoH.startActivity(Home.class);
             finish();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1496,6 +1496,7 @@
     <string name="__do_you_want_to_change_settings_or_start_sensor">\n\nDo you want to change settings or start sensor?</string>
     <string name="change_settings">Change settings</string>
     <string name="do_you_want_to_delete_and_reset_the_calibrations_for_this_sensor">Do you want to delete and reset the calibrations for this sensor?</string>
+    <string name="sensor_stop_confirm">Do you want to Stop sensor and end the current session?</string>
     <string name="you_have_an_old_experimental_glucose_prediction_setting_enabled__this_is_not_recommended_and_could_mess_things_up_badly__shall_i_disable_this_for_you">You have an old experimental glucose prediction setting enabled.\n\nThis is NOT RECOMMENDED and could mess things up badly.\n\nShall I disable this for you?</string>
     <string name="settings_issue">Settings Issue!</string>
     <string name="do_you_want_to_use_this_synced_fingerstick_blood_glucose_result_to_calibrate_with__you_can_change_when_this_dialog_is_displayed_in_settings">Do you want to use this synced finger-stick blood glucose result to calibrate with?\n\n(you can change when this dialog is displayed in Settings)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1496,7 +1496,7 @@
     <string name="__do_you_want_to_change_settings_or_start_sensor">\n\nDo you want to change settings or start sensor?</string>
     <string name="change_settings">Change settings</string>
     <string name="do_you_want_to_delete_and_reset_the_calibrations_for_this_sensor">Do you want to delete and reset the calibrations for this sensor?</string>
-    <string name="sensor_stop_confirm">Do you want to Stop sensor and end the current session?</string>
+    <string name="sensor_stop_confirm">Do you want to stop the sensor?</string>
     <string name="you_have_an_old_experimental_glucose_prediction_setting_enabled__this_is_not_recommended_and_could_mess_things_up_badly__shall_i_disable_this_for_you">You have an old experimental glucose prediction setting enabled.\n\nThis is NOT RECOMMENDED and could mess things up badly.\n\nShall I disable this for you?</string>
     <string name="settings_issue">Settings Issue!</string>
     <string name="do_you_want_to_use_this_synced_fingerstick_blood_glucose_result_to_calibrate_with__you_can_change_when_this_dialog_is_displayed_in_settings">Do you want to use this synced finger-stick blood glucose result to calibrate with?\n\n(you can change when this dialog is displayed in Settings)</string>


### PR DESCRIPTION
Adding a resource string for the stop sensor confirmation that was added with build [2021.05.16](https://github.com/NightscoutFoundation/xDrip/releases/tag/2021.05.16) (https://github.com/NightscoutFoundation/xDrip/commit/84e4376c601e52c561ab17a34f691136b62ef27d).