### PR TITLE
Stop sensor on master disable switch

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
@@ -56,6 +56,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import static com.eveningoutpost.dexdrip.xdrip.gs;
+
 import static android.support.v4.content.WakefulBroadcastReceiver.completeWakefulIntent;
 import static com.eveningoutpost.dexdrip.Models.JoH.isAnyNetworkConnected;
 import static com.eveningoutpost.dexdrip.Models.JoH.showNotification;
@@ -542,8 +544,12 @@ public class GcmListenerSvc extends JamListenerSvc {
                 } else if (action.equals("ssom")) {
                     if (Home.get_master()) {
                         if (payload.equals("challenge string")) {
-                            UserError.Log.e(TAG, "Stopping sensor by remote");
-                            StopSensor.stop();
+                            if (Pref.getBoolean("plus_accept_follower_actions", true)) {
+                                UserError.Log.e(TAG, "Stopping sensor by remote");
+                                StopSensor.stop();
+                            } else {
+                                UserError.Log.wtf(TAG, gs(R.string.not_follower_switch));
+                            }
                         } else {
                             UserError.Log.wtf(TAG, "Challenge string failed in ssom");
                         }
@@ -581,14 +587,14 @@ public class GcmListenerSvc extends JamListenerSvc {
             return;
         }
         LibreBlock.Save(lb);
-        
+
         PersistentStore.setString("LibreSN", lb.reference);
-        
+
         if(Home.get_master()) {
             if (SensorSanity.checkLibreSensorChangeIfEnabled(lb.reference)) {
                 Log.e(TAG, "Problem with Libre Serial Number - not processing");
             }
-            
+
             NFCReaderX.HandleGoodReading(lb.reference, lb.blockbytes, lb.timestamp, false, lb.patchUid,  lb.patchInfo);
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1387,8 +1387,9 @@
     <string name="summary_show_home_on_boot">Bring up xDrip screen automatically after device boots</string>
     <string name="title_show_home_on_boot">Show xDrip on Boot</string>
     <string name="eula">EULA</string>
-    <string name="summary_plus_accept_follower_actions">Treatments and Calibrations from followers will be accepted</string>
+    <string name="summary_plus_accept_follower_actions">Treatments, Calibrations and remote sensor stop from followers will be accepted</string>
     <string name="title_plus_accept_follower_actions">Accept follower actions</string>
+    <string name="not_follower_switch">Follower actions switch is disabled</string>
     <string name="summary_plus_whole_house">Participate in a Whole House Network</string>
     <string name="title_plus_whole_house">Whole House</string>
     <string name="summary_libre_whole_house_collector">This phone will be a collector in a whole house network</string>


### PR DESCRIPTION
The follower can stop sensor on master only if the existing switch on master is enabled.