### PR TITLE
Change Nightscout "Download data" to "Download treatments"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1194,8 +1194,8 @@
     <string name="manual_overwrite_not_possible">Manual overwrite not possible!</string>
     <string name="upload_even_when_using_mobile_data">Upload even when using mobile data</string>
     <string name="use_mobile_data">Use mobile data</string>
-    <string name="summary_cloud_storage_api_download_enable">Also try to download data from Nightscout</string>
-    <string name="title_cloud_storage_api_download_enable">Download data</string>
+    <string name="summary_cloud_storage_api_download_enable">Also try to download treatments from Nightscout</string>
+    <string name="title_cloud_storage_api_download_enable">Download treatments</string>
     <string name="summary_bluetooth_meter_for_calibrations_auto">Calibrate using new blood glucose readings if the conditions appear right to do so without asking confirmation (experimental)</string>
     <string name="title_bluetooth_meter_for_calibrations_auto">Automatic Calibration</string>
     <string name="title_rest_api_extra_options">Extra Options</string>


### PR DESCRIPTION
Related: https://github.com/NightscoutFoundation/xDrip/issues/403

xDrip cannot download CGM readings from Nightscout.
There is an option, on the Nightscout upload page, that reads "Download data".

When I saw that the first time, I thought I could download all my CGM BG readings from Nightscout into xDrip on a new phone.  But, xDrip cannot do that.  The title of the option can be misleading as you can see from the linked issue.

I have changed the menu to look as shown below following Patrick's suggestion (please see [his post in the issue](https://github.com/NightscoutFoundation/xDrip/issues/403#issuecomment-782720963)).
![Screenshot_1621366736](https://user-images.githubusercontent.com/51497406/118713598-1fe3f800-b7f0-11eb-9ea5-38a8edd34b18.png)
