### PR TITLE
Different color for marked bad readings

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -146,6 +146,7 @@ public class BgGraphBuilder {
     private final List<PointValue> remoteValues = new ArrayList<>();
     private final List<PointValue> highValues = new ArrayList<>();
     private final List<PointValue> lowValues = new ArrayList<>();
+    private final List<PointValue> badValues = new ArrayList<>();
     private final List<PointValue> pluginValues = new ArrayList<PointValue>();
     private final List<PointValue> rawInterpretedValues = new ArrayList<PointValue>();
     private final List<PointValue> filteredValues = new ArrayList<PointValue>();
@@ -701,6 +702,7 @@ public class BgGraphBuilder {
 
             lines.add(remoteValuesLine()); // TODO conditional ?
             lines.add(backFillValuesLine()); // TODO conditional ?
+            lines.add(badValuesLine());
             lines.add(inRangeValuesLine());
             lines.add(lowValuesLine());
             lines.add(highValuesLine());
@@ -742,6 +744,15 @@ public class BgGraphBuilder {
         highValuesLine.setPointRadius(pointSize);
         highValuesLine.setHasPoints(true);
         return highValuesLine;
+    }
+
+    public Line badValuesLine() {
+        Line badValuesLine = new Line (badValues);
+        badValuesLine.setColor(getCol(X.color_bad_values));
+        badValuesLine.setHasLines(false);
+        badValuesLine.setPointRadius(pointSize);
+        badValuesLine.setHasPoints(true);
+        return badValuesLine;
     }
 
     public Line lowValuesLine() {
@@ -1044,6 +1055,7 @@ public class BgGraphBuilder {
             noisePolyBgValues.clear();
             annotationValues.clear();
             treatmentValues.clear();
+            badValues.clear();
             highValues.clear();
             lowValues.clear();
             inRangeValues.clear();
@@ -1231,7 +1243,9 @@ public class BgGraphBuilder {
                 if ((!glucose_from_plugin) && (plugin != null) && (cd != null)) {
                     pluginValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(plugin.getGlucoseFromBgReading(bgReading, cd))));
                 }
-                if (bgReading.calculated_value >= 400) {
+                if (bgReading.ignoreForStats) {
+                    badValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
+                } else if (bgReading.calculated_value >= 400) {
                     highValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(400)));
                 } else if (unitized(bgReading.calculated_value) >= highMark) {
                     highValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -182,8 +182,9 @@ public class BgGraphBuilder {
     public BgGraphBuilder(Context context, long start, long end) {
         this(context, start, end, NUM_VALUES, true);
     }
+
     public BgGraphBuilder(Context context, long start, long end, int numValues, boolean show_prediction) {
-        this(context,start,end,numValues,show_prediction,false);
+        this(context, start, end, numValues, show_prediction, false);
     }
 
     public BgGraphBuilder(Context context, long start, long end, int numValues, boolean show_prediction, final boolean useArchive) {
@@ -206,9 +207,9 @@ public class BgGraphBuilder {
         readings_lock.lock();
         try {
             // store the initialization values used for this instance
-            loaded_numValues=numValues;
-            loaded_start=start;
-            loaded_end=end;
+            loaded_numValues = numValues;
+            loaded_start = start;
+            loaded_end = end;
             bgReadings = BgReading.latestForGraph(numValues, start, end);
             if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver)
                 Libre2RawValues = Libre2RawValue.latestForGraph(numValues * 5, start, end);
@@ -253,7 +254,7 @@ public class BgGraphBuilder {
     static public boolean isXLargeTablet(Context context) {
         return (context.getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_XLARGE;
     }
-    
+
     static public boolean isLargeTablet(Context context) {
         return (context.getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE;
     }
@@ -266,7 +267,8 @@ public class BgGraphBuilder {
         if (thisnoise > NOISE_HIGH) return "Extreme";
         if (thisnoise > NOISE_TOO_HIGH_FOR_PREDICT) return "Very High";
         if (thisnoise > NOISE_TRIGGER) return "High";
-        if (thisnoise > NOISE_TRIGGER_ULTRASENSITIVE && Pref.getBooleanDefaultFalse("engineering_mode") && Pref.getBooleanDefaultFalse("bg_compensate_noise_ultrasensitive")) return "Some";
+        if (thisnoise > NOISE_TRIGGER_ULTRASENSITIVE && Pref.getBooleanDefaultFalse("engineering_mode") && Pref.getBooleanDefaultFalse("bg_compensate_noise_ultrasensitive"))
+            return "Some";
         return "Low";
     }
 
@@ -275,7 +277,7 @@ public class BgGraphBuilder {
             points.remove(1); // replace last
         }
         points.add(new PointValue(x, y));
-        Log.d(TAG,"Extend line size: "+points.size());
+        Log.d(TAG, "Extend line size: " + points.size());
     }
 
     private List<Line> predictiveLines() {
@@ -314,8 +316,6 @@ public class BgGraphBuilder {
 
         return lines;
     }
-
-
 
 
     private List<Line> basalLines() {
@@ -476,14 +476,15 @@ public class BgGraphBuilder {
             if (d) Log.d(TAG, "heartrate before size: " + heartRates.size());
             if (d) Log.d(TAG, "heartrate after c size: " + condensedHeartRateList.size());
             //final float yscale = doMgdl ? (float) Constants.MMOLL_TO_MGDL : 1f;
-            final float yscale = doMgdl ?  10f : 1f;
+            final float yscale = doMgdl ? 10f : 1f;
             float ypos; //
 
             final List<PointValue> new_points = new ArrayList<>();
             if (d) UserError.Log.d("HEARTRATE", "Size " + condensedHeartRateList.size());
 
             for (HeartRate pm : condensedHeartRateList) {
-                if (d) UserError.Log.d("HEARTRATE: ", JoH.dateTimeText(pm.timestamp) + " \tHR: " + pm.bpm);
+                if (d)
+                    UserError.Log.d("HEARTRATE: ", JoH.dateTimeText(pm.timestamp) + " \tHR: " + pm.bpm);
 
                 ypos = (pm.bpm * yscale) / 10;
                 final PointValue this_point = new PointValue((float) pm.timestamp / FUZZER, ypos);
@@ -508,13 +509,13 @@ public class BgGraphBuilder {
         final ArrayList<ActivityRecognizedService.motionData> motion_datas = ActivityRecognizedService.getForGraph((long) start_time * FUZZER, (long) end_time * FUZZER);
         List<PointValue> linePoints = new ArrayList<>();
 
-        final float ypos = (float)highMark;
+        final float ypos = (float) highMark;
         int last_type = -9999;
 
 
         final ArrayList<Line> line_array = new ArrayList<>();
 
-        Log.d(TAG,"Motion datas size: "+motion_datas.size());
+        Log.d(TAG, "Motion datas size: " + motion_datas.size());
         if (motion_datas.size() > 0) {
             motion_datas.add(new ActivityRecognizedService.motionData((long) end_time * FUZZER, DetectedActivity.UNKNOWN)); // terminator
 
@@ -557,14 +558,14 @@ public class BgGraphBuilder {
             }
 
         }
-        Log.d(TAG,"Motion array size: "+line_array.size());
-            return line_array;
+        Log.d(TAG, "Motion array size: " + line_array.size());
+        return line_array;
     }
 
 
     public LineChartData lineData() {
-       // if (d) Log.d(TAG, "START lineData from: " + JoH.backTrace());
-       JoH.benchmark(null);
+        // if (d) Log.d(TAG, "START lineData from: " + JoH.backTrace());
+        JoH.benchmark(null);
         LineChartData lineData = new LineChartData(defaultLines(false));
         JoH.benchmark("Default lines create - bggraph builder");
         lineData.setAxisYLeft(yAxis());
@@ -580,7 +581,7 @@ public class BgGraphBuilder {
         } else {
             JoH.benchmark(null);
             Cloner cloner = new Cloner();
-           // cloner.setDumpClonedClasses(true);
+            // cloner.setDumpClonedClasses(true);
             cloner.dontClone(
                     lecho.lib.hellocharts.model.PointValue.class,
                     lecho.lib.hellocharts.formatter.SimpleLineChartValueFormatter.class,
@@ -588,7 +589,7 @@ public class BgGraphBuilder {
                     android.graphics.DashPathEffect.class);
             previewLineData = cloner.deepClone(hint);
             JoH.benchmark("Clone preview data");
-            if (d) Log.d(TAG,"Cloned preview chart data");
+            if (d) Log.d(TAG, "Cloned preview chart data");
         }
 
         previewLineData.setAxisYLeft(yAxis());
@@ -602,7 +603,7 @@ public class BgGraphBuilder {
         }
         for (Line lline : previewLineData.getLines()) {
             if (((lline.getPointRadius() == pluginSize) && (lline.getPointColor() == getCol(X.color_secondary_glucose_value)))
-                    || ((lline.getColor() == getCol(X.color_step_counter1) || (lline.getColor() == getCol(X.color_step_counter2) || (lline.getColor()== getCol(X.color_heart_rate1)))))) {
+                    || ((lline.getColor() == getCol(X.color_step_counter1) || (lline.getColor() == getCol(X.color_step_counter2) || (lline.getColor() == getCol(X.color_heart_rate1)))))) {
                 removeItems.add(lline); // remove plugin or step counter plot from preview graph
             }
 
@@ -692,7 +693,7 @@ public class BgGraphBuilder {
 
             if (prefs.getBoolean("show_filtered_curve", true)) {
                 // use autosplit here too
-               final ArrayList<Line> filtered_lines = filteredLines();
+                final ArrayList<Line> filtered_lines = filteredLines();
 
                 for (Line thisline : filtered_lines) {
                     lines.add(thisline);
@@ -728,7 +729,6 @@ public class BgGraphBuilder {
             lines.add(treatments[4]); // annotations
 
 
-
         } catch (Exception e) {
             e.printStackTrace();
             Log.e(TAG, "Error in bgbuilder defaultlines: " + e.toString());
@@ -747,7 +747,7 @@ public class BgGraphBuilder {
     }
 
     public Line badValuesLine() {
-        Line badValuesLine = new Line (badValues);
+        Line badValuesLine = new Line(badValues);
         badValuesLine.setColor(getCol(X.color_bad_values));
         badValuesLine.setHasLines(false);
         badValuesLine.setPointRadius(pointSize);
@@ -792,7 +792,7 @@ public class BgGraphBuilder {
         line.setHasPoints(true);
         return line;
     }
-    
+
     public void debugPrintPoints(List<PointValue> mypoints) {
         for (PointValue thispoint : mypoints) {
             UserError.Log.i(TAG, "Debug Points: " + thispoint.toString());
@@ -801,7 +801,7 @@ public class BgGraphBuilder {
 
     // auto split a line - jump thresh in minutes
     public ArrayList<Line> autoSplitLine(Line macroline, final float jumpthresh) {
-       // if (d) Log.d(TAG, "Enter autoSplit Line");
+        // if (d) Log.d(TAG, "Enter autoSplit Line");
         ArrayList<Line> linearray = new ArrayList<Line>();
         float lastx = -999999;
 
@@ -830,9 +830,10 @@ public class BgGraphBuilder {
                 thesepoints.add(thispoint); // grow current line list
             }
         }
-     //   if (d) Log.d(TAG, "Exit autoSplit Line");
+        //   if (d) Log.d(TAG, "Exit autoSplit Line");
         return linearray;
     }
+
     // Produce an array of cubic lines, split as needed
     public ArrayList<Line> filteredLines() {
         ArrayList<Line> linearray = new ArrayList<Line>();
@@ -879,8 +880,7 @@ public class BgGraphBuilder {
         return line;
     }
 
-    public List<Line> extraLines()
-    {
+    public List<Line> extraLines() {
         final List<Line> lines = new ArrayList<>();
         Line line = new Line(pluginValues);
         line.setHasLines(false);
@@ -1060,7 +1060,7 @@ public class BgGraphBuilder {
             lowValues.clear();
             inRangeValues.clear();
             backfillValues.clear();
-           remoteValues.clear();
+            remoteValues.clear();
             calibrationValues.clear();
             bloodTestValues.clear();
             pluginValues.clear();
@@ -1317,7 +1317,7 @@ public class BgGraphBuilder {
             }
 
             try {
-                if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver && prefs.getBoolean("Libre2_showRawGraph",false)) {
+                if (DexCollectionType.getDexCollectionType() == DexCollectionType.LibreReceiver && prefs.getBoolean("Libre2_showRawGraph", false)) {
                     for (final Libre2RawValue bgLibre : Libre2RawValues) {
                         if (bgLibre.glucose > 0) {
                             rawInterpretedValues.add(new PointValue((float) (bgLibre.timestamp / FUZZER), (float) unitized(bgLibre.glucose)));
@@ -1826,7 +1826,7 @@ public class BgGraphBuilder {
                 // new only the last hour worth of data for this
                 (new BgGraphBuilder(xdrip.getAppContext(), System.currentTimeMillis() - 60 * 60 * 1000, System.currentTimeMillis() + 5 * 60 * 1000, 24, true)).addBgReadingValues(false);
             } else {
-                Log.d(TAG, "Cached current low timestamp ok: " +  JoH.dateTimeText((long) low_occurs_at_processed_till_timestamp) + " vs " + JoH.dateTimeText(last_bg_reading_timestamp));
+                Log.d(TAG, "Cached current low timestamp ok: " + JoH.dateTimeText((long) low_occurs_at_processed_till_timestamp) + " vs " + JoH.dateTimeText(last_bg_reading_timestamp));
             }
         } catch (Exception e) {
             Log.e(TAG, "Got exception in getCurrentLowOccursAt() " + e);
@@ -1858,6 +1858,7 @@ public class BgGraphBuilder {
         myLine.setAreaTransparency(50);
         return myLine;
     }
+
     public Line avg2Line() {
         List<PointValue> myLineValues = new ArrayList<PointValue>();
         myLineValues.add(new PointValue((float) start_time, (float) unitized(avg2value)));
@@ -1874,7 +1875,7 @@ public class BgGraphBuilder {
     public Line idealLine() {
         // if profile has more than 1 target bg value then we need to iterate those and plot them for completeness
         List<PointValue> myLineValues = new ArrayList<PointValue>();
-        myLineValues.add(new PointValue((float) start_time, (float)  Profile.getTargetRangeInUnits(start_time)));
+        myLineValues.add(new PointValue((float) start_time, (float) Profile.getTargetRangeInUnits(start_time)));
         myLineValues.add(new PointValue((float) predictive_end_time, (float) Profile.getTargetRangeInUnits(predictive_end_time)));
         Line myLine = new Line(myLineValues);
         myLine.setHasPoints(false);
@@ -1954,14 +1955,14 @@ public class BgGraphBuilder {
     }
 
     private Line libreTrendLine() {
-        final List<PointValue> libreTrendValues =  LibreTrendGraph.getTrendDataPoints(doMgdl, (long)(start_time * FUZZER), (long)(end_time * FUZZER));
+        final List<PointValue> libreTrendValues = LibreTrendGraph.getTrendDataPoints(doMgdl, (long) (start_time * FUZZER), (long) (end_time * FUZZER));
         final Line line = new Line(libreTrendValues);
         line.setHasPoints(true);
         line.setHasLines(false);
         line.setCubic(false);
         line.setStrokeWidth(2);
         line.setPointRadius(1);
-        line.setColor(Color.argb(240,25,206,244)); // temporary pending preference
+        line.setColor(Color.argb(240, 25, 206, 244)); // temporary pending preference
         return line;
     }
 
@@ -1991,7 +1992,7 @@ public class BgGraphBuilder {
         line.setHasPoints(true);
         line.setHasLines(false);
         line.setPointRadius(5);
-        line.setPointColor(ColorUtil.blendColor(Color.BLACK,Color.TRANSPARENT, 0.99f));
+        line.setPointColor(ColorUtil.blendColor(Color.BLACK, Color.TRANSPARENT, 0.99f));
         line.setBitmapScale(1f);
         line.setBitmapLabels(true);
         line.setBitmapLabelShadowColor(Color.WHITE);
@@ -2016,11 +2017,11 @@ public class BgGraphBuilder {
             }
         }
         yAxis.setValues(axisValues);
-       // yAxis.setHasLines(true);
+        // yAxis.setHasLines(true);
         yAxis.setMaxLabelChars(5);
         yAxis.setInside(true);
         yAxis.setTextSize(axisTextSize);
-        yAxis.setHasLines(prefs.getBoolean("show_graph_grid_glucose",true));
+        yAxis.setHasLines(prefs.getBoolean("show_graph_grid_glucose", true));
         return yAxis;
     }
 
@@ -2033,27 +2034,27 @@ public class BgGraphBuilder {
         //GregorianCalendar today = new GregorianCalendar(now.get(Calendar.YEAR), now.get(Calendar.MONTH), now.get(Calendar.DAY_OF_MONTH));
         final java.text.DateFormat timeFormat = hourFormat();
         timeFormat.setTimeZone(TimeZone.getDefault());
-       // double start_hour_block = today.getTime().getTime();
+        // double start_hour_block = today.getTime().getTime();
         //double timeNow = new Date().getTime();
         //for (int l = 0; l <= 24; l++) {
         //    if ((start_hour_block + (60000 * 60 * (l))) < timeNow) {
         //        if ((start_hour_block + (60000 * 60 * (l + 1))) >= timeNow) {
         //            endHour = start_hour_block + (60000 * 60 * (l));
         //            l = 25;
-       //         }
+        //         }
         //    }
-       // }
+        // }
 
 
         GregorianCalendar calendar = new GregorianCalendar();
-        calendar.setTimeInMillis((long)(start_time * FUZZER));
+        calendar.setTimeInMillis((long) (start_time * FUZZER));
         calendar.set(Calendar.MINUTE, 0);
         calendar.set(Calendar.SECOND, 0);
         calendar.set(Calendar.MILLISECOND, 0);
-        if (calendar.getTimeInMillis()<(start_time * FUZZER)){
+        if (calendar.getTimeInMillis() < (start_time * FUZZER)) {
             calendar.add(Calendar.HOUR, 1);
         }
-        while (calendar.getTimeInMillis()< ( (end_time * FUZZER) + (predictivehours * 60 * 60 * 1000))) {
+        while (calendar.getTimeInMillis() < ((end_time * FUZZER) + (predictivehours * 60 * 60 * 1000))) {
             xAxisValues.add(new AxisValue((calendar.getTimeInMillis() / FUZZER), (timeFormat.format(calendar.getTimeInMillis())).toCharArray()));
             calendar.add(Calendar.HOUR, 1);
         }
@@ -2061,7 +2062,7 @@ public class BgGraphBuilder {
         //for (int l = 0; l <= (24 + predictivehours); l++) {
         //    double timestamp = (endHour + ((predictivehours) * 60 * 1000 * 60) - (60000 * 60 * l));
         //    xAxisValues.add(new AxisValue((long) (timestamp / FUZZER), (timeFormat.format(timestamp)).toCharArray()));
-       // }
+        // }
         xAxis.setValues(xAxisValues);
         return xAxis;
     }
@@ -2073,7 +2074,7 @@ public class BgGraphBuilder {
         return xAxis;
     }
 
-    public Axis previewXAxis(){
+    public Axis previewXAxis() {
         Axis previewXaxis = xAxis();
         previewXaxis.setTextSize(previewAxisTextSize);
         previewXaxis.setHasLines(true);
@@ -2084,21 +2085,21 @@ public class BgGraphBuilder {
         return new SimpleDateFormat(DateFormat.is24HourFormat(context) ? "HH" : "h a");
     }
 
-  /*  public Axis previewXAxis() {
-        List<AxisValue> previewXaxisValues = new ArrayList<AxisValue>();
-        final java.text.DateFormat timeFormat = hourFormat();
-        timeFormat.setTimeZone(TimeZone.getDefault());
-        for (int l = 0; l <= (24 + predictivehours); l += hoursPreviewStep) {
-            double timestamp = (endHour + (predictivehours * 60 * 1000 * 60) - (60000 * 60 * l));
-            previewXaxisValues.add(new AxisValue((long) (timestamp / FUZZER), (timeFormat.format(timestamp)).toCharArray()));
-        }
-        Axis previewXaxis = new Axis();
-        previewXaxis.setValues(previewXaxisValues);
-        previewXaxis.setHasLines(true);
-        previewXaxis.setTextSize(previewAxisTextSize);
-        return previewXaxis;
-    }
-*/
+    /*  public Axis previewXAxis() {
+          List<AxisValue> previewXaxisValues = new ArrayList<AxisValue>();
+          final java.text.DateFormat timeFormat = hourFormat();
+          timeFormat.setTimeZone(TimeZone.getDefault());
+          for (int l = 0; l <= (24 + predictivehours); l += hoursPreviewStep) {
+              double timestamp = (endHour + (predictivehours * 60 * 1000 * 60) - (60000 * 60 * l));
+              previewXaxisValues.add(new AxisValue((long) (timestamp / FUZZER), (timeFormat.format(timestamp)).toCharArray()));
+          }
+          Axis previewXaxis = new Axis();
+          previewXaxis.setValues(previewXaxisValues);
+          previewXaxis.setHasLines(true);
+          previewXaxis.setTextSize(previewAxisTextSize);
+          return previewXaxis;
+      }
+  */
     /////////VIEWPORT RELATED//////////////
     public Viewport advanceViewport(Chart chart, Chart previewChart, float hours) {
         viewport = new Viewport(previewChart.getMaximumViewport());
@@ -2135,12 +2136,12 @@ public class BgGraphBuilder {
 
     public static String unitized_string_with_units_static(double value) {
         final boolean domgdl = Pref.getString("units", "mgdl").equals("mgdl");
-        return unitized_string(value, domgdl)+" "+(domgdl ? "mg/dl" : "mmol/l");
+        return unitized_string(value, domgdl) + " " + (domgdl ? "mg/dl" : "mmol/l");
     }
 
     public static String unitized_string_with_units_static_short(double value) {
         final boolean domgdl = Pref.getString("units", "mgdl").equals("mgdl");
-        return unitized_string(value, domgdl)+" "+(domgdl ? "mgdl" : "mmol");
+        return unitized_string(value, domgdl) + " " + (domgdl ? "mgdl" : "mmol");
     }
 
     public static String unitized_string_static_no_interpretation_short(double value) {
@@ -2195,7 +2196,7 @@ public class BgGraphBuilder {
     }
 
     public String unitizedDeltaString(boolean showUnit, boolean highGranularity) {
-    return unitizedDeltaString( showUnit, highGranularity,Home.get_follower());
+        return unitizedDeltaString(showUnit, highGranularity, Home.get_follower());
     }
 
     public String unitizedDeltaString(boolean showUnit, boolean highGranularity, boolean is_follower) {
@@ -2204,7 +2205,7 @@ public class BgGraphBuilder {
 
     public static String unitizedDeltaString(boolean showUnit, boolean highGranularity, boolean is_follower, boolean doMgdl) {
 
-        List<BgReading> last2 = BgReading.latest(2,is_follower);
+        List<BgReading> last2 = BgReading.latest(2, is_follower);
         if (last2.size() < 2 || last2.get(0).timestamp - last2.get(1).timestamp > 20 * 60 * 1000) {
             // don't show delta if there are not enough values or the values are more than 20 mintes apart
             return "???";
@@ -2212,14 +2213,14 @@ public class BgGraphBuilder {
 
         double value = BgReading.currentSlope(is_follower) * 5 * 60 * 1000;
 
-       return unitizedDeltaStringRaw(showUnit, highGranularity, value, doMgdl);
+        return unitizedDeltaStringRaw(showUnit, highGranularity, value, doMgdl);
     }
 
     public String unitizedDeltaStringRaw(boolean showUnit, boolean highGranularity, double value) {
         return unitizedDeltaStringRaw(showUnit, highGranularity, value, doMgdl);
     }
 
-    public static String unitizedDeltaStringRaw(boolean showUnit, boolean highGranularity,double value, boolean doMgdl) {
+    public static String unitizedDeltaStringRaw(boolean showUnit, boolean highGranularity, double value, boolean doMgdl) {
 
 
         if (Math.abs(value) > 100) {
@@ -2241,7 +2242,7 @@ public class BgGraphBuilder {
                 df.setMaximumFractionDigits(0);
             }
 
-            return delta_sign + df.format(unitized(value,doMgdl)) + (showUnit ? " mg/dl" : "");
+            return delta_sign + df.format(unitized(value, doMgdl)) + (showUnit ? " mg/dl" : "");
         } else {
             // only show 2 decimal places on mmol/l delta when less than 0.1 mmol/l
             if (highGranularity && (Math.abs(value) < (Constants.MMOLL_TO_MGDL * 0.1))) {
@@ -2252,7 +2253,7 @@ public class BgGraphBuilder {
 
             df.setMinimumFractionDigits(1);
             df.setMinimumIntegerDigits(1);
-            return delta_sign + df.format(unitized(value,doMgdl)) + (showUnit ? " mmol/l" : "");
+            return delta_sign + df.format(unitized(value, doMgdl)) + (showUnit ? " mmol/l" : "");
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ColorCache.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ColorCache.java
@@ -42,6 +42,7 @@ public class ColorCache {
     public enum X {
 
         color_high_values("color_high_values"),
+        color_bad_values("color_bad_values"),
         color_inrange_values("color_inrange_values"),
         color_low_values("color_low_values"),
         color_filtered("color_filtered"),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,6 +487,7 @@
     <string name="start_sensor">Start Sensor</string>
     <string name="debug_and_other_misc_options">Debug and other misc. options</string>
     <string name="low_glucose_values">Low Glucose Values</string>
+    <string name="bad_glucose_values">Bad Glucose Values</string>
     <string name="revert_to_default">Revert to Default</string>
     <string name="filtered_values">Filtered Values</string>
     <string name="treatment_color">Treatment Color</string>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -52,6 +52,13 @@
                         app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
                         app:colorpicker_selectNoneButtonText="@string/revert_to_default"
                         app:colorpicker_showHex="false" />
+                    <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
+                        android:defaultValue="#006293"
+                        android:key="color_bad_values"
+                        android:title="@string/bad_glucose_values"
+                        app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
+                        app:colorpicker_selectNoneButtonText="@string/revert_to_default"
+                        app:colorpicker_showHex="false" />
 
                     <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
                         android:defaultValue="#a0a0a0"

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -53,7 +53,7 @@
                         app:colorpicker_selectNoneButtonText="@string/revert_to_default"
                         app:colorpicker_showHex="false" />
                     <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
-                        android:defaultValue="#006293"
+                        android:defaultValue="#ffffff"
                         android:key="color_bad_values"
                         android:title="@string/bad_glucose_values"
                         app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"


### PR DESCRIPTION
Fixes https://github.com/NightscoutFoundation/xDrip/issues/874

If you use the data table to mark a reading as bad, the reading is not used for statistical analysis.  However, there is no visual distinction for such readings on the main screen.
This update changes the color of such readings to a different unique color.  The user can also tweak the color the same as low, in range and high.  



The following image shows an example where low, in range, high and bad colors can be seen side by side.
![1](https://user-images.githubusercontent.com/51497406/118752244-b932fe80-b830-11eb-9add-c93821f6f20b.png)  

I changed the color to white to make it distinctly different from the existing 4 colors. 
![Screenshot_20210529-154434](https://user-images.githubusercontent.com/51497406/120083304-ca340900-c095-11eb-8f7f-6ceedc7b3554.png)
