### PR TITLE
add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ patches/
 *.dll
 *.exe
 *.iml
+installed-android-sdk-stamp
+unzipped-android-sdk-stamp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 ANDROID_HOME=$(PWD)/../android
 export ANDROID_HOME
+
+GIT_DISCOVERY_ACROSS_FILESYSTEM=y
+export GIT_DISCOVERY_ACROSS_FILESYSTEM
+
 SDKS = "platforms;android-26" "build-tools;27.0.3" "extras;google;m2repository"
 ANDROID_SDK_ZIP=sdk-tools-linux-4333796.zip
 
@@ -7,7 +11,15 @@ DEBUG_APK = app/build/outputs/apk/debug/app-debug.apk
 RELEASE_APK = app/build/outputs/apk/release/app-release-unsigned.apk
 
 .DEFAULT_GOAL = app-release-unsigned.apk
-.PHONY: assembleRelease clean clean-global-caches install
+.PHONY: assembleRelease clean clean-global-caches install tasks
+
+gradle := $(shell [ "$(which gradle >/dev/null)" ] && echo gradle || echo bash gradlew)
+
+exec:
+	@if [ "$(sh)" ]; then sh -c "$(sh)"; else exec bash; fi
+
+tasks:
+	$(gradle) tasks
 
 install: app-release-unsigned.apk
 	adb install $^
@@ -18,7 +30,7 @@ app-release-unsigned.apk: $(RELEASE_APK)
 $(RELEASE_APK): assembleRelease
 
 assembleRelease: | installed-android-sdk-stamp
-	bash gradlew assembleRelease
+	$(gradle) assembleRelease
 
 BUILD_DIRS = app/build/ build/ localeapi/build/ wear/build/
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 ANDROID_HOME=$(PWD)/../android
 export ANDROID_HOME
 
+BUILD_TOOLS_VERSION := $(shell sed -n 's/^ *- build-tools-//p' .travis.yml)
+ANDROID_PLATFORM_VERSION := $(shell sed -n 's/^ *- yes | sdkmanager "platforms;android-\([0-9]*\)"/\1/p' .travis.yml || echo 26)
+
+
 GIT_DISCOVERY_ACROSS_FILESYSTEM=y
 export GIT_DISCOVERY_ACROSS_FILESYSTEM
 
-SDKS = "platforms;android-26" "build-tools;27.0.3" "extras;google;m2repository"
+SDKS = "platforms;android-$(ANDROID_PLATFORM_VERSION)" "build-tools;$(BUILD_TOOLS_VERSION)" "extras;google;m2repository"
 ANDROID_SDK_ZIP=sdk-tools-linux-4333796.zip
 
 DEBUG_APK = app/build/outputs/apk/debug/app-debug.apk

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,14 @@
 ANDROID_HOME=$(PWD)/../android
 export ANDROID_HOME
 
-BUILD_TOOLS_VERSION := $(shell sed -n 's/^ *- build-tools-//p' .travis.yml)
-ANDROID_PLATFORM_VERSION := $(shell sed -n 's/^ *- yes | sdkmanager "platforms;android-\([0-9]*\)"/\1/p' .travis.yml || echo 26)
-
+BUILD_TOOLS_VERSION != sed -n 's/^ *- build-tools-//p' .travis.yml
+ANDROID_PLATFORM_VERSION != (sed -n 's/^ *- yes | sdkmanager "platforms;android-\([0-9]*\)"/\1/p' .travis.yml; echo 26) | head -n1
 
 GIT_DISCOVERY_ACROSS_FILESYSTEM=y
 export GIT_DISCOVERY_ACROSS_FILESYSTEM
 
 SDKS = "platforms;android-$(ANDROID_PLATFORM_VERSION)" "build-tools;$(BUILD_TOOLS_VERSION)" "extras;google;m2repository"
-ANDROID_SDK_ZIP=sdk-tools-linux-4333796.zip
+ANDROID_CLI_TOOLS_ZIP=commandlinetools-linux-7302050_latest.zip
 
 DEBUG_APK = app/build/outputs/apk/debug/app-debug.apk
 RELEASE_APK = app/build/outputs/apk/release/app-release-unsigned.apk
@@ -33,9 +32,6 @@ app-release-unsigned.apk: $(RELEASE_APK)
 
 $(RELEASE_APK): assembleRelease
 
-assembleRelease: | installed-android-sdk-stamp
-	$(gradle) assembleRelease
-
 BUILD_DIRS = app/build/ build/ localeapi/build/ wear/build/
 clean:
 	rm -r .gradle/ $(BUILD_DIRS)
@@ -44,25 +40,32 @@ GLOBAL_CACHE_DIRS = ~/.android/build-cache ~/.android/cache/
 clean-global-caches:
 	rm -r $(GLOBAL_CACHE_DIRS)
 
-../$(ANDROID_SDK_ZIP):
-	wget -c https://dl.google.com/android/repository/$(ANDROID_SDK_ZIP) -O $@.partial
+../$(ANDROID_CLI_TOOLS_ZIP):
+	wget -c https://dl.google.com/android/repository/$(ANDROID_CLI_TOOLS_ZIP) -O $@.partial
 	mv $@.partial $@
 
 $(ANDROID_HOME):
 	mkdir $@
 
-unzipped-android-sdk-stamp: ../$(ANDROID_SDK_ZIP)
+unzipped-tools-stamp: ../$(ANDROID_CLI_TOOLS_ZIP)
 	unzip -d $(ANDROID_HOME) $^
 	touch $@
 
 sdkmanager = $(ANDROID_HOME)/tools/bin/sdkmanager
 
-installed-android-sdk-stamp: | unzipped-android-sdk-stamp $(ANDROID_HOME)
-	yes | $(sdkmanager) --licenses
-	yes | $(sdkmanager) $(SDKS)
+$(sdkmanager): | installed-sdkmanager-stamp
+
+installed-sdkmanager-stamp: ../$(ANDROID_CLI_TOOLS_ZIP) | $(ANDROID_HOME)
+	unzip -d $(ANDROID_HOME) $^
+	mv -T $(ANDROID_HOME)/cmdline-tools/ $(ANDROID_HOME)/tools/
 	touch $@
 
-sdk-update:
+assembleRelease: | sdk-update-stamp
+	$(gradle) assembleRelease
+
+sdk-update: sdk-update-stamp
+
+sdk-update-stamp: | $(sdkmanager)
 	yes | $(sdkmanager) $(SDKS)  $(foreach x, $(EXTRA_SDKS),"$x")
 	yes | $(sdkmanager) --update
 	yes | $(sdkmanager) --licenses

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+ANDROID_HOME=$(PWD)/../android
+export ANDROID_HOME
+SDKS = "platforms;android-26" "build-tools;27.0.3" "extras;google;m2repository"
+ANDROID_SDK_ZIP=sdk-tools-linux-4333796.zip
+
+DEBUG_APK = app/build/outputs/apk/debug/app-debug.apk
+RELEASE_APK = app/build/outputs/apk/release/app-release-unsigned.apk
+
+.DEFAULT_GOAL = app-release-unsigned.apk
+.PHONY: assembleRelease clean clean-global-caches install
+
+install: app-release-unsigned.apk
+	adb install $^
+
+app-release-unsigned.apk: $(RELEASE_APK)
+	ln -sf $^ .
+
+$(RELEASE_APK): assembleRelease
+
+assembleRelease: | installed-android-sdk-stamp
+	bash gradlew assembleRelease
+
+BUILD_DIRS = app/build/ build/ localeapi/build/ wear/build/
+clean:
+	rm -r .gradle/ $(BUILD_DIRS)
+
+GLOBAL_CACHE_DIRS = ~/.android/build-cache ~/.android/cache/
+clean-global-caches:
+	rm -r $(GLOBAL_CACHE_DIRS)
+
+../$(ANDROID_SDK_ZIP):
+	wget -c https://dl.google.com/android/repository/$(ANDROID_SDK_ZIP) -O $@.partial
+	mv $@.partial $@
+
+$(ANDROID_HOME):
+	mkdir $@
+
+unzipped-android-sdk-stamp: ../$(ANDROID_SDK_ZIP)
+	unzip -d $(ANDROID_HOME) $^
+	touch $@
+
+sdkmanager = $(ANDROID_HOME)/tools/bin/sdkmanager
+
+installed-android-sdk-stamp: | unzipped-android-sdk-stamp $(ANDROID_HOME)
+	yes | $(sdkmanager) --licenses
+	yes | $(sdkmanager) $(SDKS)
+	touch $@
+
+sdk-update:
+	yes | $(sdkmanager) $(SDKS)  $(foreach x, $(EXTRA_SDKS),"$x")
+	yes | $(sdkmanager) --update
+	yes | $(sdkmanager) --licenses


### PR DESCRIPTION
This allows the project to be built in a single command (`make`).  The `Makefile` handles downloading and installing the SDKs in an essentially identical way to the `.travis.yml`, then builds with `gradle`.

This is an updated version of PR #903 which incorporates the requested change by @tolot27 (obtain version strings from `.travis.yml`) and uses a new .zip for `sdkmanager`.

Also related #768.