### PR TITLE
Fix MMOLL_TO_MGDL conversion constant.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Constants.java
@@ -4,7 +4,9 @@ package com.eveningoutpost.dexdrip.UtilityModels;
  * Various constants
  */
 public class Constants {
-    public static final double MMOLL_TO_MGDL = 18.0182;
+    // Based on the molar mass of glucose (see e.g. https://pubchem.ncbi.nlm.nih.gov/compound/glucose).
+    // Note: some apps (and older versions of xDrip+) use the value 18.0182.
+    public static final double MMOLL_TO_MGDL = 18.0156;
     public static final double MGDL_TO_MMOLL = 1 / MMOLL_TO_MGDL;
 
 

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Constants.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Constants.java
@@ -4,7 +4,9 @@ package com.eveningoutpost.dexdrip.UtilityModels;
  * Various constants
  */
 public class Constants {
-    public static final double MMOLL_TO_MGDL = 18.0182;
+    // Based on the molar mass of glucose (see e.g. https://pubchem.ncbi.nlm.nih.gov/compound/glucose).
+    // Note: some apps (and older versions of xDrip+) use the value 18.0182.
+    public static final double MMOLL_TO_MGDL = 18.0156;
     public static final double MGDL_TO_MMOLL = 1 / MMOLL_TO_MGDL;
 
 


### PR DESCRIPTION
The molecular weight of glucose is 180.156 g/mol, so (glucose mmol/l) / (glucose mg/dl) = 180.156g * dl/l = 18.0156, rather than 18.0182.

Note: xDrip+ is not the only Diabetes-related software that has the (as far as I can tell) wrong constant. Several other software packages also have the value 18.0182 that I believe to be incorrect, while others have 18.0156 (correct); I suspect that someone got it wrong at some point and the others just copied from them. Dexcom's G6 app uses the value 18.0 in at least one place, which is even further off.

While this seems like an unnecessary place to introduce error, the value was less than 0.15% off the correct value. Rounding to whole mg/dl or to 1/10th of a mmol/l introduces a slightly larger error than this, so if one rounds both before and after the conversion then in practice, the result is unaffected by the exact value of the constant.