### PR TITLE
Ensure wakelocks are released on more exception paths.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/AddCalibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/AddCalibration.java
@@ -20,6 +20,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.UndoRedo;
 import com.eveningoutpost.dexdrip.calibrations.NativeCalibrationPipe;
+import com.eveningoutpost.dexdrip.utils.framework.WakeLockThread;
 
 import java.util.UUID;
 
@@ -87,12 +88,9 @@ public class AddCalibration extends AppCompatActivity implements NavigationDrawe
                     if (!TextUtils.isEmpty(string_value)) {
                         if (!TextUtils.isEmpty(bg_age)) {
                             final double calValue = Double.parseDouble(string_value);
-                            new Thread() {
+                            new WakeLockThread("xdrip-autocalibt", 60000) {
                                 @Override
-                                public void run() {
-
-                                    final PowerManager.WakeLock wlt = JoH.getWakeLock("xdrip-autocalibt", 60000);
-
+                                public void runWithWakeLock() {
                                     long bgAgeNumber = Long.parseLong(bg_age);
 
                                     if ((bgAgeNumber >= 0) && (bgAgeNumber < 86400)) {
@@ -156,8 +154,6 @@ public class AddCalibration extends AppCompatActivity implements NavigationDrawe
                                     } else {
                                         Log.wtf("CALERROR", "bg age either in future or older than 1 day: " + bgAgeNumber);
                                     }
-
-                                    JoH.releaseWakeLock(wlt);
                                 }
                             }.start();
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
@@ -34,6 +34,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.utils.CipherUtils;
 import com.eveningoutpost.dexdrip.utils.DisplayQRCode;
 import com.eveningoutpost.dexdrip.utils.SdcardImportExport;
+import com.eveningoutpost.dexdrip.utils.framework.WakeLockThread;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.gcm.GoogleCloudMessaging;
@@ -544,10 +545,9 @@ public class GcmActivity extends FauxActivity {
 
     static synchronized void syncBGTable2() {
         if (!Sensor.isActive()) return;
-        new Thread() {
+        new WakeLockThread("syncBGTable", 300000) {
             @Override
-            public void run() {
-                final PowerManager.WakeLock wl = JoH.getWakeLock("syncBGTable", 300000);
+            public void runWithWakeLock() {
                 //if ((JoH.ts() - last_sync_fill) > (60 * 1000 * (5 + bg_sync_backoff))) {
                 if (JoH.pratelimit("last-sync-fill", 60 * (5 + bg_sync_backoff))) {
                     last_sync_fill = JoH.tsl();
@@ -576,7 +576,6 @@ public class GcmActivity extends FauxActivity {
                 } else {
                     Log.d(TAG, "Ignoring recent sync request, backoff: " + bg_sync_backoff);
                 }
-                JoH.releaseWakeLock(wl);
             }
         }.start();
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
@@ -24,6 +24,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Intents;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.utils.CheckBridgeBattery;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
+import com.eveningoutpost.dexdrip.utils.framework.WakeLockThread;
 import com.google.gson.Gson;
 
 import org.apache.commons.math3.analysis.interpolation.SplineInterpolator;
@@ -104,10 +105,9 @@ public class LibreAlarmReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(final Context context, final Intent intent) {
-        new Thread() {
+        new WakeLockThread("librealarm-receiver", 60000) {
             @Override
-            public void run() {
-                final PowerManager.WakeLock wl = JoH.getWakeLock("librealarm-receiver", 60000);
+            public void runWithWakeLock() {
                 synchronized (lock) {
                     try {
 
@@ -172,7 +172,6 @@ public class LibreAlarmReceiver extends BroadcastReceiver {
                         }
                     } finally {
                         JoH.benchmark("LibreReceiver process");
-                        JoH.releaseWakeLock(wl);
                     }
                 } // lock
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/LibreReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/LibreReceiver.java
@@ -18,6 +18,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Intents;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.StatusItem;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
+import com.eveningoutpost.dexdrip.utils.framework.WakeLockThread;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -45,10 +46,9 @@ public class LibreReceiver extends BroadcastReceiver {
     public void onReceive(final Context context, final Intent intent) {
         if(DexCollectionType.getDexCollectionType() != DexCollectionType.LibreReceiver)
             return;
-        new Thread() {
+        new WakeLockThread("libre-receiver", 60000) {
             @Override
-            public void run() {
-                PowerManager.WakeLock wl = JoH.getWakeLock("libre-receiver", 60000);
+            public void runWithWakeLock() {
                 synchronized (lock) {
                     try {
 
@@ -96,7 +96,6 @@ public class LibreReceiver extends BroadcastReceiver {
                         }
                     } finally {
                         JoH.benchmark("NSEmulator process");
-                        JoH.releaseWakeLock(wl);
                     }
                 } // lock
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -62,6 +62,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.XdripNotificationCompat;
 import com.eveningoutpost.dexdrip.utils.BestGZIPOutputStream;
 import com.eveningoutpost.dexdrip.utils.CipherUtils;
+import com.eveningoutpost.dexdrip.utils.framework.WakeLockThread;
 import com.eveningoutpost.dexdrip.xdrip;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.UnsignedInts;
@@ -1581,29 +1582,24 @@ public class JoH {
     }
 
     public synchronized static void restartBluetooth(final Context context, final int startInMs) {
-        new Thread() {
+        new WakeLockThread("restart-bluetooth", 60000) {
             @Override
-            public void run() {
-                final PowerManager.WakeLock wl = getWakeLock("restart-bluetooth", 60000);
+            public void runWithWakeLock() {
                 Log.d(TAG, "Restarting bluetooth");
-                try {
-                    if (startInMs > 0) {
-                        try {
-                            Thread.sleep(startInMs);
-                        } catch (InterruptedException e) {
-                            Log.d(TAG, "Got interrupted waiting to start resetBluetooth");
-                        }
-                    }
-                    setBluetoothEnabled(context, false);
+                if (startInMs > 0) {
                     try {
-                        Thread.sleep(6000);
+                        Thread.sleep(startInMs);
                     } catch (InterruptedException e) {
-                        Log.d(TAG, "Got interrupted in resetBluetooth");
+                        Log.d(TAG, "Got interrupted waiting to start resetBluetooth");
                     }
-                    setBluetoothEnabled(context, true);
-                } finally {
-                    releaseWakeLock(wl);
                 }
+                setBluetoothEnabled(context, false);
+                try {
+                    Thread.sleep(6000);
+                } catch (InterruptedException e) {
+                    Log.d(TAG, "Got interrupted in resetBluetooth");
+                }
+                setBluetoothEnabled(context, true);
             }
         }.start();
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
@@ -20,6 +20,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Intents;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.PumpStatus;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
+import com.eveningoutpost.dexdrip.utils.framework.WakeLockThread;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -43,13 +44,11 @@ public class NSEmulatorReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(final Context context, final Intent intent) {
-        new Thread() {
+        new WakeLockThread("nsemulator-receiver", 60000) {
             @Override
-            public void run() {
-                PowerManager.WakeLock wl = JoH.getWakeLock("nsemulator-receiver", 60000);
+            public void runWithWakeLock() {
                 synchronized (lock) {
                     try {
-
                         Log.d(TAG, "NSEmulator onReceiver: " + intent.getAction());
                         JoH.benchmark(null);
                         // check source
@@ -216,7 +215,6 @@ public class NSEmulatorReceiver extends BroadcastReceiver {
                         }
                     } finally {
                         JoH.benchmark("NSEmulator process");
-                        JoH.releaseWakeLock(wl);
                     }
                 } // lock
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5BaseService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/G5BaseService.java
@@ -19,7 +19,7 @@ import com.google.android.gms.wearable.DataMap;
 
 public abstract class G5BaseService extends Service {
 
-
+    // TODO: Should probably only acquire this during onCreate()?
     private final PowerManager.WakeLock wl = JoH.getWakeLock("g5-base-bt", 100);
 
     public static final int G6_SCALING = 34;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/LibreWifiReader.java
@@ -405,8 +405,8 @@ public class LibreWifiReader extends AsyncTask<String, Void, Void> {
     }
 
     public Void doInBackground(String... urls) {
-        final PowerManager.WakeLock wl = JoH.getWakeLock("LibreWifiReader", 120000);
         Log.e(TAG, "doInBackground called");
+        final PowerManager.WakeLock wl = JoH.getWakeLock("LibreWifiReader", 120000);
         try {
             synchronized (LibreWifiReader.class) {
                 readData();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/WifiCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/WifiCollectionService.java
@@ -112,7 +112,13 @@ public class WifiCollectionService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         final PowerManager.WakeLock wl = JoH.getWakeLock("xdrip-wificolsvc-onStart", 60000);
-
+        try {
+            return onStartCommandWithWakeLockHeld(intent, flags, startId);
+        } finally {
+            if (wl.isHeld()) wl.release();
+        }
+    }
+    private int onStartCommandWithWakeLockHeld(Intent intent, int flags, int startId) {
         if (requested_wake_time > 0) {
             JoH.persistentBuggySamsungCheck();
             final long wakeup_jitter = JoH.msSince(requested_wake_time);
@@ -135,11 +141,9 @@ public class WifiCollectionService extends Service {
         } else {
             lastState = "Stopping " + JoH.hourMinuteString();
             stopSelf();
-            if (wl.isHeld()) wl.release();
             return START_NOT_STICKY;
         }
         lastState = "Started " + JoH.hourMinuteString();
-        if (wl.isHeld()) wl.release();
         return START_STICKY;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
@@ -133,16 +133,18 @@ public class SystemStatusFragment extends Fragment {
     }
 
     private void requestWearCollectorStatus() {
-        final PowerManager.WakeLock wl = JoH.getWakeLock("ACTION_STATUS_COLLECTOR",120000);
         if (Home.get_enable_wear()) {
-            if (DexCollectionType.getDexCollectionType().equals(DexcomG5)) {
-                startWatchUpdaterService(safeGetContext(), WatchUpdaterService.ACTION_STATUS_COLLECTOR, TAG, "getBatteryStatusNow", G5CollectionService.getBatteryStatusNow);
-            }
-            else {
-                startWatchUpdaterService(safeGetContext(), WatchUpdaterService.ACTION_STATUS_COLLECTOR, TAG);
+            final PowerManager.WakeLock wl = JoH.getWakeLock("ACTION_STATUS_COLLECTOR",120000);
+            try {
+                if (DexCollectionType.getDexCollectionType().equals(DexcomG5)) {
+                    startWatchUpdaterService(safeGetContext(), WatchUpdaterService.ACTION_STATUS_COLLECTOR, TAG, "getBatteryStatusNow", G5CollectionService.getBatteryStatusNow);
+                } else {
+                    startWatchUpdaterService(safeGetContext(), WatchUpdaterService.ACTION_STATUS_COLLECTOR, TAG);
+                }
+            } finally {
+                JoH.releaseWakeLock(wl);
             }
         }
-        JoH.releaseWakeLock(wl);
     }
 
     @Override

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LowPriorityThread.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/LowPriorityThread.java
@@ -7,7 +7,6 @@ import com.eveningoutpost.dexdrip.Models.JoH;
 // jamorham
 
 // run a thread at the lowest priority with wake-locking
-
 public class LowPriorityThread extends Thread {
 
     private final String name;
@@ -19,6 +18,11 @@ public class LowPriorityThread extends Thread {
         this.setPriority(Thread.MIN_PRIORITY);
     }
 
+    // TODO: Make final and just call runnable.run() instead of super.run().
+    // This is because any subclass that wants to override this method would lose
+    // the wakelock functionality, or else have to call super.run() at which point
+    // it would be pointless to have the subclass. Alternatively, this whole class
+    // should be final.
     @Override
     public void run() {
         final PowerManager.WakeLock wl = JoH.getWakeLock(name, 60000);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -29,6 +29,7 @@ import com.eveningoutpost.dexdrip.Services.ActivityRecognizedService;
 import com.eveningoutpost.dexdrip.utils.CipherUtils;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.utils.Mdns;
+import com.eveningoutpost.dexdrip.utils.framework.WakeLockThread;
 import com.eveningoutpost.dexdrip.xdrip;
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
@@ -236,24 +237,19 @@ public class NightscoutUploader {
     }
 
     public boolean downloadRest(final long sleep) {
-        new Thread(new Runnable() {
+        new WakeLockThread("ns-download-rest", 180000) {
             @Override
-            public void run() {
-                final PowerManager.WakeLock wl = JoH.getWakeLock("ns-download-rest", 180000);
+            public void runWithWakeLock() {
                 try {
-                    try {
-                        if (sleep > 0) Thread.sleep(sleep);
-                    } catch (InterruptedException e) {
-                        //
-                    }
-                    if (doRESTtreatmentDownload(prefs)) {
-                        Home.staticRefreshBGCharts();
-                    }
-                } finally {
-                    JoH.releaseWakeLock(wl);
+                    if (sleep > 0) Thread.sleep(sleep);
+                } catch (InterruptedException e) {
+                    //
+                }
+                if (doRESTtreatmentDownload(prefs)) {
+                    Home.staticRefreshBGCharts();
                 }
             }
-        }).start();
+        }.start();
         return true;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -124,10 +124,8 @@ public class Notifications extends IntentService {
 
     @Override
     protected void onHandleIntent(Intent intent) {
-
-        final PowerManager.WakeLock wl = JoH.getWakeLock("NotificationsService", 60000);
-
         boolean unclearReading;
+        final PowerManager.WakeLock wl = JoH.getWakeLock("NotificationsService", 60000);
         try {
             Log.d("Notifications", "Running Notifications Intent Service");
             final Context context = getApplicationContext();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SpeechUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SpeechUtil.java
@@ -9,6 +9,7 @@ import android.speech.tts.TextToSpeech;
 
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.UserError;
+import com.eveningoutpost.dexdrip.utils.framework.WakeLockThread;
 import com.eveningoutpost.dexdrip.xdrip;
 
 import java.util.Locale;
@@ -46,9 +47,9 @@ public class SpeechUtil {
     @SuppressWarnings("WeakerAccess")
     public static void say(final String text, long delay, int retry) {
 
-        new Thread(() -> {
-            final PowerManager.WakeLock wl = JoH.getWakeLock("SpeechUtil", (int) Constants.SECOND_IN_MS * 60);
-            try {
+        new WakeLockThread("SpeechUtil", (int) Constants.SECOND_IN_MS * 60) {
+            @Override
+            protected void runWithWakeLock() {
                 if (tts == null) {
                     initialize();
                 }
@@ -110,11 +111,8 @@ public class SpeechUtil {
                 } else {
                     UserError.Log.d(TAG, "Successfully spoke: " + text);
                 }
-
-            } finally {
-                JoH.releaseWakeLock(wl);
             }
-        }).start();
+        }.start();
 
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/WidgetUpdateService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/WidgetUpdateService.java
@@ -36,16 +36,19 @@ public class WidgetUpdateService extends Service {
         @Override
         public void onReceive(Context ctx, Intent intent) {
             final PowerManager.WakeLock wl = JoH.getWakeLock("xdrip-widget-bcast", 20000);
-            //Log.d(TAG, "onReceive("+intent.getAction()+")");
-            if (intent.getAction().compareTo(Intent.ACTION_TIME_TICK) == 0) {
-                updateCurrentBgInfo();
-            } else if (intent.getAction().compareTo(Intent.ACTION_SCREEN_ON) == 0) {
-                enableClockTicks();
-                updateCurrentBgInfo();
-            } else if (intent.getAction().compareTo(Intent.ACTION_SCREEN_OFF) == 0) {
-                disableClockTicks();
+            try {
+                //Log.d(TAG, "onReceive("+intent.getAction()+")");
+                if (intent.getAction().compareTo(Intent.ACTION_TIME_TICK) == 0) {
+                    updateCurrentBgInfo();
+                } else if (intent.getAction().compareTo(Intent.ACTION_SCREEN_ON) == 0) {
+                    enableClockTicks();
+                    updateCurrentBgInfo();
+                } else if (intent.getAction().compareTo(Intent.ACTION_SCREEN_OFF) == 0) {
+                    disableClockTicks();
+                }
+            } finally {
+                JoH.releaseWakeLock(wl);
             }
-            JoH.releaseWakeLock(wl);
         }
     };
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DisplayQRCode.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DisplayQRCode.java
@@ -142,6 +142,8 @@ public class DisplayQRCode extends BaseAppCompatActivity {
 
 
     public static synchronized void uploadBytes(byte[] result, final int callback_option) {
+        // FIXME: This wakelock should probably only be acquired in the case where we
+        // actually get to the try block below?
         final PowerManager.WakeLock wl = JoH.getWakeLock("uploadBytes", 1200000);
         if ((result != null) && (result.length > 0)) {
             final byte[] mykey = CipherUtils.getRandomKey();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Mdns.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Mdns.java
@@ -167,11 +167,14 @@ public class Mdns {
             int spinner = 0;
             while (locked_until > JoH.tsl()) {
                 PowerManager.WakeLock wlx = JoH.getWakeLock("mdns-resolve", 200);
-                spinner++;
-                if ((spinner % 10) == 0)
-                    UserError.Log.d(TAG, "Waiting on Lock: " + JoH.niceTimeTill(locked_until));
-                Thread.sleep(100);
-                JoH.releaseWakeLock(wlx);
+                try {
+                    spinner++;
+                    if ((spinner % 10) == 0)
+                        UserError.Log.d(TAG, "Waiting on Lock: " + JoH.niceTimeTill(locked_until));
+                    Thread.sleep(100);
+                } finally {
+                    JoH.releaseWakeLock(wlx);
+                }
             }
             // TODO wly timeout excessive and not cancelled
             PowerManager.WakeLock wly = JoH.getWakeLock("mdns-resolve-x", 2000);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/WakeLockThread.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/WakeLockThread.java
@@ -1,0 +1,57 @@
+package com.eveningoutpost.dexdrip.utils.framework;
+
+import android.os.PowerManager;
+
+import com.eveningoutpost.dexdrip.Models.JoH;
+import com.google.common.base.Preconditions;
+
+/**
+ * A thread that acquires the wakelock of the given name for the duration it runs,
+ * or until the given timeout has elapsed, whichever happens sooner.
+ */
+public abstract class WakeLockThread extends Thread {
+
+    private final String wakeLockName;
+    private final int millis;
+
+    public WakeLockThread(String wakeLockName, int millis) {
+        super("WakeLockThread (wakeLock='" + wakeLockName + "', timeout=" + millis + "msec");
+        this.wakeLockName = wakeLockName;
+        this.millis = millis;
+        Preconditions.checkArgument(millis >= 0,
+                "Expected millis > 0, got " + millis);
+        Preconditions.checkArgument(!wakeLockName.isEmpty(), "Empty wakeLockName");
+    }
+
+    /**
+     * Calls {@link #runWithWakeLock()} exactly once, with the wakelock held.
+     *
+     * WakeLock acquisition is attempted via {@link JoH#getWakeLock(String, int)},
+     * without attempting to catch any unchecked exceptions that method might throw
+     * now or in future (it shouldn't).
+     */
+    @Override
+    public final void run() {
+        /*
+         * Note that because this class isn't exposing the WakeLock, it's impossible
+         * for unit tests to assert that it is actually held during runWithWakeLockHeld(),
+         * because there doesn't seem to be a way to get hold of the WakeLock by
+         * name without acquiring it.
+         * We could store the WakeLock acquired here in an AtomicReference<WakeLock> and
+         * expose it via an protected final getter, but that might encourage subclasses
+         * to inappropriately interact with the wakelock, so we're not doing it for now.
+         */
+        PowerManager.WakeLock wakeLock = JoH.getWakeLock(wakeLockName, millis);
+        try {
+            runWithWakeLock();
+        } finally {
+            JoH.releaseWakeLock(wakeLock);
+        }
+    }
+
+    /**
+     * Called from {@link #run()} once with the wakelock held, assuming the WakeLock
+     * was acquired.
+     */
+    protected abstract void runWithWakeLock();
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -921,6 +921,14 @@ public class WatchUpdaterService extends WearableListenerService implements
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         final PowerManager.WakeLock wl = JoH.getWakeLock("watchupdate-onstart", 60000);
+        try {
+            return onStartCommandWithWakeLockHeld(intent, flags, startId);
+        } finally {
+            JoH.releaseWakeLock(wl);
+        }
+    }
+
+    private int onStartCommandWithWakeLockHeld(Intent intent, int flags, int startId) {
         wear_integration = mPrefs.getBoolean("wear_sync", false);
 
         String action = null;
@@ -1035,11 +1043,9 @@ public class WatchUpdaterService extends WearableListenerService implements
             Log.i(TAG, "Stopping service");
             startBtService();
             stopSelf();
-            JoH.releaseWakeLock(wl);
             return START_NOT_STICKY;
         }
 
-        JoH.releaseWakeLock(wl);
         return START_STICKY;
     }
 
@@ -1447,7 +1453,7 @@ public class WatchUpdaterService extends WearableListenerService implements
                                     JoH.static_toast_long("Sending latest version to watch");
                                 }
                                 final int finalStartAt = startAt;
-                                new Thread(new Runnable() {
+                                new Thread() {
                                     @Override
                                     public void run() {
                                         if (mWearNodeId == null) {
@@ -1525,7 +1531,7 @@ public class WatchUpdaterService extends WearableListenerService implements
                                             Log.d(TAG, "VUP: Could not send wearable apk as nodeid is currently null");
                                         }
                                     }
-                                }).start();
+                                }.start();
                             }
                         } else {
                             Log.d(TAG, "Unknown wearable path: " + event.getPath());

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
@@ -39,14 +39,15 @@ public class xDripWidget extends AppWidgetProvider {
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
         final PowerManager.WakeLock wl = JoH.getWakeLock("xdrip-widget-onupdate", 20000);
-        final int N = appWidgetIds.length;
-        for (int i = 0; i < N; i++) {
-
-            //update the widget
-            updateAppWidget(context, appWidgetManager, appWidgetIds[i]);
-
+        try {
+            final int N = appWidgetIds.length;
+            for (int i = 0; i < N; i++) {
+                //update the widget
+                updateAppWidget(context, appWidgetManager, appWidgetIds[i]);
+            }
+        } finally {
+            JoH.releaseWakeLock(wl);
         }
-        JoH.releaseWakeLock(wl);
     }
 
     @Override

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utils/framework/WakeLockThreadTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utils/framework/WakeLockThreadTest.java
@@ -1,0 +1,66 @@
+package com.eveningoutpost.dexdrip.utils.framework;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests {@link WakeLockThread}.
+ */
+public class WakeLockThreadTest extends RobolectricTestWithConfig {
+
+    @Test(expected = NullPointerException.class)
+    public void constructor_nullWakeLockName() {
+        new DoNothingThread(null, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_emptyWakeLockName() {
+        new DoNothingThread("", 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_negativeTimeout() {
+        new DoNothingThread("name", -1);
+    }
+
+    @Test
+    public void constructor_zeroTimeout_doesNotThrow() {
+        new DoNothingThread("name", 0);
+    }
+
+    @Test
+    public void constructor_doesNotThrow() {
+        new DoNothingThread("name", 0);
+    }
+
+    @Test
+    public void runRunsOnceAfterThreadStarted() throws InterruptedException {
+        final AtomicInteger runCount = new AtomicInteger(0);
+        Thread thread = new WakeLockThread("testWakeLock", 10000) {
+            @Override
+            protected void runWithWakeLock() {
+                runCount.incrementAndGet();
+            }
+        };
+        Assert.assertEquals(0, runCount.get());
+        thread.start();
+        thread.join();
+        Assert.assertEquals(1, runCount.get());
+    }
+
+    /**
+     * Convenience class for test purposes to avoid WakeLockThread having to be non-abstract or
+     * test methods needing to implement runWithWakeLock().
+     */
+    static class DoNothingThread extends WakeLockThread {
+        public DoNothingThread(String wakeLockName, int millis) {
+            super(wakeLockName, millis);
+        }
+        @Override protected void runWithWakeLock() { }
+    }
+
+}


### PR DESCRIPTION
There are a lot of places around xDrip+ where wakelocks are acquired but not released until the (generally inconsistently picked) timeout runs out. Many of those are deliberate (although probably not a good idea), but others occur by accident, on exception paths. This commit fixes a subset of the latter.

 * There were a few cases where no try/finally block was used but there were multiple return statements that were each accompanied by a release of the wakelock. This is needlessly complex and error prone. I've replaced these with a try/finally block; note that even in case of a return statement being encountered in the try block, the finally block will still run.

 * Many of these occur on background threads; when uncaught exceptions on background threads kill the app, this is okay - but these many threads should not hard code assumptions about the UncaughtExceptionHandler, which is a global setting. This commits introduces a helper class WakeLockThread that takes care of the acquisition/release of the wakelock, and ensures that the thread has a name (which can help during debugging); in some cases, this also allows dropping a try/finally block to avoid indentation in the source code. The presence of the new class should hopefully encourage more mindful handling of wakelocks in future code.

 * There were also a handful of cases where there was a try/finally block, but the wakelock acquisition occurred a few statements before the try block; I've moved the wakelock acquisition to just before try block in order to make sure that it is always released.

Unrelatedly, I've also fixed a handful of needless constructions of Runnable objects for invocations of the form new Thread(new Runnable() { public void run() { ... } } which can instead just override Thread.run() instead (same behavior, but one less object).

I ran all Robolectric unit tests and confirmed that they still pass.

Potential work for follow-up commits:
 - Potentially address the two TODOs and one FIXME that I've left in the code.
 - Add convenience API to specify (TimeUnit timeUnit, long duration) instead
   of (long millis) for more readable / less error-prone code.
 - Add an AbstractWakeLockService class that takes care of acquiring/releasing
   a wakelock during onStartCommand(), since xDrip+ has multiple independent
   implementations of this behavior, some of which were buggy. That said,
   the app will probably be killed during onStartCommand() only in extreme
   cases, so acquiring the wakelock might be unnecessary in the first place.