### PR TITLE
Exclude Nightscout ID and password from logs

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -299,7 +299,7 @@ public class NightscoutUploader {
         try {
             uri = new URI(baseURI);
         } catch (URISyntaxException e) {
-            Log.e(TAG, "Error URISyntaxException for " + baseURI, e);
+            Log.e(TAG, "Error URISyntaxException for the base URL", e);
             return baseURI;
         }
         String host = uri.getHost();
@@ -419,7 +419,7 @@ public class NightscoutUploader {
                             PersistentStore.setString(LAST_MODIFIED_KEY, last_modified_string);
                             checkGzipSupport(r);
                         } else {
-                            Log.d(TAG, "Failed to get treatments from: " + baseURI);
+                            Log.d(TAG, "Failed to get treatments from the base URL");
                         }
 
                     } else {
@@ -429,7 +429,7 @@ public class NightscoutUploader {
 
 
             } catch (Exception e) {
-                String msg = "Unable to do REST API Download " + e + " " + e.getMessage() + " url: " + baseURI;
+                String msg = "Unable to do REST API Download " + e + " " + e.getMessage() + " url: ";
                 handleRestFailure(msg);
             }
         }
@@ -489,7 +489,7 @@ public class NightscoutUploader {
                     last_success_time = JoH.tsl();
                     last_exception_count = 0;
                 } catch (Exception e) {
-                    String msg = "Unable to do REST API Upload: " + e.getMessage() + " url: " + baseURI + " marking record: " + (any_successes ? "succeeded" : "failed");
+                    String msg = "Unable to do REST API Upload: " + e.getMessage() + " url: " + " marking record: " + (any_successes ? "succeeded" : "failed");
                     handleRestFailure(msg);
                 }
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -429,7 +429,7 @@ public class NightscoutUploader {
 
 
             } catch (Exception e) {
-                String msg = "Unable to do REST API Download " + e + e.getMessage() + " url: ";
+                String msg = "Unable to do REST API Download " + e + e.getMessage();
                 handleRestFailure(msg);
             }
         }
@@ -489,7 +489,7 @@ public class NightscoutUploader {
                     last_success_time = JoH.tsl();
                     last_exception_count = 0;
                 } catch (Exception e) {
-                    String msg = "Unable to do REST API Upload: " + e.getMessage() + " url: " + " marking record: " + (any_successes ? "succeeded" : "failed");
+                    String msg = "Unable to do REST API Upload: " + e.getMessage() + " marking record: " + (any_successes ? "succeeded" : "failed");
                     handleRestFailure(msg);
                 }
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -429,7 +429,7 @@ public class NightscoutUploader {
 
 
             } catch (Exception e) {
-                String msg = "Unable to do REST API Download " + e + " " + e.getMessage() + " url: ";
+                String msg = "Unable to do REST API Download " + e + e.getMessage() + " url: ";
                 handleRestFailure(msg);
             }
         }


### PR DESCRIPTION
Users who ask for support are often asked to show event logs.  
They may not be aware that the logs may include their Nightscout ID and password.
This PR removes base URL, which includes the ID and password, from the logs.

Fixes https://github.com/NightscoutFoundation/xDrip/issues/1741