### PR TITLE
Hidden original translator credits

### DIFF
--- a/app/src/main/res/layout/activity_license_agreement.xml
+++ b/app/src/main/res/layout/activity_license_agreement.xml
@@ -66,7 +66,7 @@
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/translation_credits"
+                    android:text=""
                     android:id="@+id/translator_credits"
                     android:layout_alignParentBottom="true"
                     android:layout_alignParentEnd="true"


### PR DESCRIPTION
Fixes https://github.com/NightscoutFoundation/xDrip/issues/1586

Am I supposed to move the original credits to some specific file?  