### PR TITLE
G5/G6: Automatically create Sensor Start and Stop treatments when they occur

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
@@ -174,7 +174,9 @@ public class StartNewSensor extends ActivityWithMenu {
         }
     }
 
-
+    /**
+     * Sends command to G5/G6 sensor for sensor start and adds a Sensor Start entry in the xDrip db
+     */
     public static void startSensorForTime(long startTime) {
         Sensor.create(startTime);
         UserError.Log.ueh("NEW SENSOR", "Sensor started at " + JoH.dateTimeText(startTime));
@@ -188,7 +190,9 @@ public class StartNewSensor extends ActivityWithMenu {
        // JoH.scheduleNotification(xdrip.getAppContext(), "Sensor should be ready", xdrip.getAppContext().getString(R.string.please_enter_two_calibrations_to_get_started), 60 * 130, Home.SENSOR_READY_ID);
 
         // reverse libre hacky workaround
-        Treatments.SensorStart((DexCollectionType.hasLibre() ? startTime + (3600000) : startTime));
+        long modifiedStartTime = DexCollectionType.hasLibre() ? (startTime + 3600000) : startTime;
+
+        Treatments.SensorStart(modifiedStartTime, "Started by xDrip");
 
         CollectionServiceStarter.restartCollectionServiceBackground();
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
@@ -11,6 +11,7 @@ import com.eveningoutpost.dexdrip.G5Model.Ob1G5StateMachine;
 import com.eveningoutpost.dexdrip.Models.Calibration;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.Sensor;
+import com.eveningoutpost.dexdrip.Models.Treatments;
 import com.eveningoutpost.dexdrip.UtilityModels.AlertPlayer;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.Inevitable;
@@ -65,6 +66,8 @@ public class StopSensor extends ActivityWithMenu {
         JoH.clearCache();
         LibreAlarmReceiver.clearSensorStats();
         PluggableCalibration.invalidateAllCaches();
+
+        Treatments.SensorStop(null, "Stopped by xDrip");
 
         Ob1G5StateMachine.stopSensor();
 


### PR DESCRIPTION
Currently, xDrip is aware of when a G5/G6 sensor reports that the sensor stopped or has been started, but this does not tie in to xDrip's own reporting of manual treatment events.

After this change, xDrip will create a "Sensor Stopped" treatment (which can also sync to Nightscout using existing mechanisms) whenever a G5/G6 sensor reports itself as being stopped.

xDrip will also create a "Sensor Started" treatment whenever a G5/G6 sensor reports itself as being in the warm-up period. Starting a sensor from within xDrip already creates a sensor start treatment, so that behavior is not modified. However, if a sensor start treatment was within the xdrip database within the past 15 minutes then an additional treatment is not created, to avoid double-creating a treatment if you manually hit "start" within xDrip which then triggers xDrip to detect that the transmitter reports itself as started soon after.


With these changes applied, when my G6 sensor automatically stopped at the end of the 10-day window, a sensor stop treatment was created with "Stopped by transmitter" in the notes field. When I started a G6 sensor from a non-xDrip device, a new start treatment was created with "Started by transmitter" in the notes field. 

![image](https://user-images.githubusercontent.com/192620/121608499-1f6e0400-ca20-11eb-82e1-0a3d328f44a5.png) ![image](https://user-images.githubusercontent.com/192620/121608505-2432b800-ca20-11eb-938b-92bba9e64198.png)

<img src="https://user-images.githubusercontent.com/192620/121608436-fb122780-ca1f-11eb-9bda-c3ff6b2a5e4b.png" width=350>

Additionally, some minor code cleanup is done in StartNewSensor.java in a separate commit.