### PR TITLE
Override silent mode - other alerts Android 10 & 11

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -319,7 +319,7 @@ public class AlertPlayer {
         return false;
     }
 
-    private synchronized void playFile(final Context ctx, final String fileName, final float volumeFrac, final boolean forceSpeaker, final boolean overrideSilentMode) {
+    public synchronized void playFile(final Context ctx, final String fileName, final float volumeFrac, final boolean forceSpeaker, final boolean overrideSilentMode) {
         Log.i(TAG, "playFile: called fileName = " + fileName);
         if (volumeFrac <= 0) {
             UserError.Log.e(TAG, "Not playing file " + fileName + " as requested volume is " + volumeFrac);
@@ -609,7 +609,7 @@ public class AlertPlayer {
     }
 
     // True means play the file false means only vibrate.
-    private boolean isLoudPhone(Context ctx) {
+    public boolean isLoudPhone(Context ctx) {
         final AudioManager am = (AudioManager)ctx.getSystemService(Context.AUDIO_SERVICE);
         try {
             switch (am.getRingerMode()) {


### PR DESCRIPTION
**Why do we need this?**
Override silent mode does not work for "Other Alerts" on Android 10 or 11.

This PR fixes that for missed signal alert only.
If it is merged and no issues are experienced, we can gradually move other members of the alert group to use the alert player (with future PRs).  But, I am doing it like this (one step at a time) to minimize impact on users.

Fixes: https://github.com/NightscoutFoundation/xDrip/issues/193  
This PR is one small step towards goals described here:  https://github.com/NightscoutFoundation/xDrip/issues/1762

**Is there a workaround?**
The only workaround, if you could call it that, is to disable the silent mode on the phone.  

**Are there any side-effects to this change?**
* Unfortunately, I have changed two functions in AlertPlayer from private to public.  AlertPlayer is what all the main original alerts use.  So, I need you all developers to be as brutal as you can be in reviewing this PR.    Please point out anything you don't like.  Please let me know if there is a more graceful way to do any of it.  
* The alert volume is equivalent to the medium volume profile.  But, the user cannot change that.  The capability to change the volume profile, for this alert, is on my roadmap.  Please see issue 1762 linked above.  I have left it out of this pull request to simplify the review process by keeping the change small.


**Tests**  
I have tested the impact on Android 10 and 11, the objective of this PR, on with Android Studio virtual devices.  
I have tested this with an Android 9 handset.  