### PR TITLE
Vertical (y) axis range

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -247,8 +247,8 @@ public class BgGraphBuilder {
         defaultMinY = unitized(40);
         defaultMaxY = unitized(250);
         if (custimze_y_range) { // If Customize y axis range is enabled
-            defaultMinY = unitized(Integer.parseInt(Pref.getString("default_ymin", "40"))); // Use the user-defined ymin
-            defaultMaxY = unitized(Integer.parseInt(Pref.getString("default_ymax", "250"))); // Use the user-defined ymax
+            defaultMinY = unitized(Pref.getStringToInt("default_ymin", 40)); // Use the user-defined ymin
+            defaultMaxY = unitized(Pref.getStringToInt("default_ymax", 250)); // Use the user-defined ymax
         }
         pointSize = isXLargeTablet(context) ? 5 : 3;
         axisTextSize = isXLargeTablet(context) ? 20 : Axis.DEFAULT_TEXT_SIZE_SP;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -100,6 +100,9 @@ public class BgGraphBuilder {
     private static long noise_processed_till_timestamp = -1;
     private final static String TAG = "jamorham graph";
     //private final static int pluginColor = Color.parseColor("#AA00FFFF"); // temporary
+    public boolean custimze_y_range = Pref.getBoolean("Customize_yRange", false);
+    public static int default_ymin = getDefaultyMin();
+    public static int default_ymax = getDefaultyMax();
 
     private final static int pluginSize = 2;
     final int pointSize;
@@ -245,6 +248,10 @@ public class BgGraphBuilder {
         this.doMgdl = (prefs.getString("units", "mgdl").equals("mgdl"));
         defaultMinY = unitized(40);
         defaultMaxY = unitized(250);
+        if (custimze_y_range) { // If Customize_yRange  is enabled
+            defaultMaxY = unitized(default_ymax); // Let the user define MaxY
+            defaultMinY = unitized(default_ymin); // Let the user define MinY
+        }
         pointSize = isXLargeTablet(context) ? 5 : 3;
         axisTextSize = isXLargeTablet(context) ? 20 : Axis.DEFAULT_TEXT_SIZE_SP;
         previewAxisTextSize = isXLargeTablet(context) ? 12 : 5;
@@ -270,6 +277,26 @@ public class BgGraphBuilder {
 
     public static double mmolConvert(double mgdl) {
         return mgdl * Constants.MGDL_TO_MMOLL;
+    }
+
+    public static int getDefaultyMin() {
+        int value = 40;
+        try {
+            value = Integer.parseInt(Pref.getString("default_ymin", "40"));
+        } catch (NumberFormatException e) {
+            UserError.Log.e(TAG, "Cannot process default ymin value: " + e);
+        }
+        return value;
+    }
+
+    public static int getDefaultyMax() {
+        int value = 250;
+        try {
+            value = Integer.parseInt(Pref.getString("default_ymax", "250"));
+        } catch (NumberFormatException e) {
+            UserError.Log.e(TAG, "Cannot process default ymax value: " + e);
+        }
+        return value;
     }
 
     public static String noiseString(double thisnoise) {
@@ -1165,7 +1192,7 @@ public class BgGraphBuilder {
                 for (BloodTest bloodtest : bloodtests) {
                     final long adjusted_timestamp = (bloodtest.timestamp + (AddCalibration.estimatedInterstitialLagSeconds * 1000));
                     final PointValueExtended this_point = new PointValueExtended((double) (adjusted_timestamp / FUZZER), unitized(bloodtest.mgdl))
-                           .setType(PointValueExtended.BloodTest)
+                            .setType(PointValueExtended.BloodTest)
                             .setUUID(bloodtest.uuid);
                     this_point.real_timestamp = bloodtest.timestamp;
                     // exclude any which have been used for calibration

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -100,9 +100,7 @@ public class BgGraphBuilder {
     private static long noise_processed_till_timestamp = -1;
     private final static String TAG = "jamorham graph";
     //private final static int pluginColor = Color.parseColor("#AA00FFFF"); // temporary
-    public boolean custimze_y_range = Pref.getBoolean("Customize_yRange", false);
-    public static int default_ymin = getDefaultyMin();
-    public static int default_ymax = getDefaultyMax();
+    public boolean custimze_y_range = Pref.getBoolean("Customize_yRange", false); // True when Customize y axis range is enabled
 
     private final static int pluginSize = 2;
     final int pointSize;
@@ -248,9 +246,9 @@ public class BgGraphBuilder {
         this.doMgdl = (prefs.getString("units", "mgdl").equals("mgdl"));
         defaultMinY = unitized(40);
         defaultMaxY = unitized(250);
-        if (custimze_y_range) { // If Customize_yRange  is enabled
-            defaultMaxY = unitized(default_ymax); // Let the user define MaxY
-            defaultMinY = unitized(default_ymin); // Let the user define MinY
+        if (custimze_y_range) { // If Customize y axis range is enabled
+            defaultMinY = unitized(Integer.parseInt(Pref.getString("default_ymin", "40"))); // Use the user-defined ymin
+            defaultMaxY = unitized(Integer.parseInt(Pref.getString("default_ymax", "250"))); // Use the user-defined ymax
         }
         pointSize = isXLargeTablet(context) ? 5 : 3;
         axisTextSize = isXLargeTablet(context) ? 20 : Axis.DEFAULT_TEXT_SIZE_SP;
@@ -277,26 +275,6 @@ public class BgGraphBuilder {
 
     public static double mmolConvert(double mgdl) {
         return mgdl * Constants.MGDL_TO_MMOLL;
-    }
-
-    public static int getDefaultyMin() {
-        int value = 40;
-        try {
-            value = Integer.parseInt(Pref.getString("default_ymin", "40"));
-        } catch (NumberFormatException e) {
-            UserError.Log.e(TAG, "Cannot process default ymin value: " + e);
-        }
-        return value;
-    }
-
-    public static int getDefaultyMax() {
-        int value = 250;
-        try {
-            value = Integer.parseInt(Pref.getString("default_ymax", "250"));
-        } catch (NumberFormatException e) {
-            UserError.Log.e(TAG, "Cannot process default ymax value: " + e);
-        }
-        return value;
     }
 
     public static String noiseString(double thisnoise) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -470,4 +470,31 @@
         <item>vn</item>
     </string-array>
 
+    <string-array name="ymin_entries">
+        <item>40 mg/dL (2.2 mmol/L) ></item>
+        <item>50 mg/dL (2.8 mmol/L)</item>
+        <item>60 mg/dL (3.3 mmol/L)</item>
+        <item>70 mg/dL (3.9 mmol/L)</item>
+    </string-array>
+    <string-array name="ymin_values">
+        <item>40</item>
+        <item>50</item>
+        <item>60</item>
+        <item>70</item>
+    </string-array>
+    <string-array name="ymax_entries">
+        <item>210 mg/dL (11.7 mmol/L)</item>
+        <item>230 mg/dL (12.8 mmol/L)</item>
+        <item>250 mg/dL (13.9 mmol/L) ></item>
+        <item>300 mg/dL (16.7 mmol/L)</item>
+        <item>400 mg/dL (22.2 mmol/L)</item>
+    </string-array>
+    <string-array name="ymax_values">
+        <item>210</item>
+        <item>230</item>
+        <item>250</item>
+        <item>300</item>
+        <item>400</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -471,10 +471,10 @@
     </string-array>
 
     <string-array name="ymin_entries">
-        <item>40 mg/dL (2.2 mmol/L) ></item>
-        <item>50 mg/dL (2.8 mmol/L)</item>
-        <item>60 mg/dL (3.3 mmol/L)</item>
-        <item>70 mg/dL (3.9 mmol/L)</item>
+        <item>40 mg/dl (2.2 mmol/l) ></item>
+        <item>50 mg/dl (2.8 mmol/l)</item>
+        <item>60 mg/dl (3.3 mmol/l)</item>
+        <item>70 mg/dl (3.9 mmol/l)</item>
     </string-array>
     <string-array name="ymin_values">
         <item>40</item>
@@ -483,11 +483,11 @@
         <item>70</item>
     </string-array>
     <string-array name="ymax_entries">
-        <item>210 mg/dL (11.7 mmol/L)</item>
-        <item>230 mg/dL (12.8 mmol/L)</item>
-        <item>250 mg/dL (13.9 mmol/L) ></item>
-        <item>300 mg/dL (16.7 mmol/L)</item>
-        <item>400 mg/dL (22.2 mmol/L)</item>
+        <item>210 mg/dl (11.7 mmol/l)</item>
+        <item>230 mg/dl (12.8 mmol/l)</item>
+        <item>250 mg/dl (13.9 mmol/l) ></item>
+        <item>300 mg/dl (16.7 mmol/l)</item>
+        <item>400 mg/dl (22.2 mmol/l)</item>
     </string-array>
     <string-array name="ymax_values">
         <item>210</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1803,7 +1803,7 @@
     <string name="android_8_background_scanning">Use Android 8+ background scanning feature</string>
     <string name="title_yRange">Customize y axis range</string>
     <string name="titleInside_yRange">Enable</string>
-    <string name="summaryInside_yRange">You can adjust the vertical (y) axis range here.\nHowever, when you have readings beyond that range, the range will automatically extend, for the next 24 hors, to allow all your readings to show .</string>
+    <string name="summaryInside_yRange">You can adjust the vertical (y) axis range here.\nHowever, when you have readings beyond that range, the range will automatically extend, for the next 24 hours, to allow all your readings to show .</string>
     <string name="title_ymin">Adjust y axis minimum</string>
     <string name="title_ymax">Adjust y axis maximum</string>
     <string name="summary_ymin">Change yMin if you have no readings smaller.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1801,5 +1801,12 @@
     <string name="format_string_ago">%s ago</string>
     <string name="use_background_scans">Use Background Scans</string>
     <string name="android_8_background_scanning">Use Android 8+ background scanning feature</string>
+    <string name="title_yRange">Customize y axis range</string>
+    <string name="titleInside_yRange">Enable</string>
+    <string name="summaryInside_yRange">You can adjust the vertical (y) axis range here.\nHowever, when you have readings beyond that range, the range will automatically extend, for the next 24 hors, to allow all your readings to show .</string>
+    <string name="title_ymin">Adjust y axis minimum</string>
+    <string name="title_ymax">Adjust y axis maximum</string>
+    <string name="summary_ymin">Change yMin if you have no readings smaller.</string>
+    <string name="summary_ymax">Change yMax if you have no readings greater.</string>
     <string name="close">Close</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1803,10 +1803,10 @@
     <string name="android_8_background_scanning">Use Android 8+ background scanning feature</string>
     <string name="title_yRange">Customize y axis range</string>
     <string name="titleInside_yRange">Enable</string>
-    <string name="summaryInside_yRange">You can adjust the vertical (y) axis range here.\nHowever, when you have readings beyond that range, the range will automatically extend, for the next 24 hours, to allow all your readings to show .</string>
+    <string name="summaryInside_yRange">You can adjust the vertical (y) axis range here.\nHowever, if you have readings outside that range, it will automatically extend, for several hours, to allow those readings to show.</string>
     <string name="title_ymin">Adjust y axis minimum</string>
     <string name="title_ymax">Adjust y axis maximum</string>
-    <string name="summary_ymin">Change yMin if you have no readings smaller.</string>
-    <string name="summary_ymax">Change yMax if you have no readings greater.</string>
+    <string name="summary_ymin">Choose yMin for when there are no smaller readings.</string>
+    <string name="summary_ymax">Choose yMax for when there are no greater readings.</string>
     <string name="close">Close</string>
 </resources>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -459,6 +459,31 @@
                     android:key="illustrate_remote_data"
                     android:summary="@string/summary_illustrate_remote_data"
                     android:title="@string/title_illustrate_remote_data" />
+                <PreferenceScreen
+                    android:key="Y_axis_range"
+                    android:title="@string/title_yRange">
+                    <CheckBoxPreference
+                        android:defaultValue="false"
+                        android:key="Customize_yRange"
+                        android:title="@string/titleInside_yRange"
+                        android:summary="@string/summaryInside_yRange" />
+                    <ListPreference
+                        android:key="default_ymin"
+                        android:summary="@string/summary_ymin"
+                        android:title="@string/title_ymin"
+                        android:entries="@array/ymin_entries"
+                        android:entryValues="@array/ymin_values"
+                        android:defaultValue="40"
+                        android:dependency="Customize_yRange"/>
+                    <ListPreference
+                        android:key="default_ymax"
+                        android:summary="@string/summary_ymax"
+                        android:title="@string/title_ymax"
+                        android:entries="@array/ymax_entries"
+                        android:entryValues="@array/ymax_values"
+                        android:defaultValue="250"
+                        android:dependency="Customize_yRange"/>
+                </PreferenceScreen>
             </PreferenceScreen>
 
             <CheckBoxPreference

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -468,20 +468,20 @@
                         android:title="@string/titleInside_yRange"
                         android:summary="@string/summaryInside_yRange" />
                     <ListPreference
-                        android:key="default_ymin"
-                        android:summary="@string/summary_ymin"
-                        android:title="@string/title_ymin"
-                        android:entries="@array/ymin_entries"
-                        android:entryValues="@array/ymin_values"
-                        android:defaultValue="40"
-                        android:dependency="Customize_yRange"/>
-                    <ListPreference
                         android:key="default_ymax"
                         android:summary="@string/summary_ymax"
                         android:title="@string/title_ymax"
                         android:entries="@array/ymax_entries"
                         android:entryValues="@array/ymax_values"
                         android:defaultValue="250"
+                        android:dependency="Customize_yRange"/>
+                    <ListPreference
+                        android:key="default_ymin"
+                        android:summary="@string/summary_ymin"
+                        android:title="@string/title_ymin"
+                        android:entries="@array/ymin_entries"
+                        android:entryValues="@array/ymin_values"
+                        android:defaultValue="40"
                         android:dependency="Customize_yRange"/>
                 </PreferenceScreen>
             </PreferenceScreen>


### PR DESCRIPTION
**Why do we need this?**
The main screen vertical axis has a default minimum of 40 (2.22) and default maximum of 250 (13.9).
If your readings are far from those extremes, the screen still shows those as min and max and most of your screen is blank.

After the change, you can change those defaults. The minimum and maximum will continue to change according to your readings as they did before. But, if you have a very good day, with minimal fluctuations, the axis range will take the values you have chosen.

There are also users who find xDrip curve variations too extreme and prefer to extend the maximum to 300 or 400.  This PR allows that also.

fixes #1216



**Are there any side-effects to this change?**
No.   Nothing changes, from the user perspective, after this PR is merged unless the user changes the default settings to choose a different default min or max.

**Tests**
This has been tested with Android 9 and 11.  

**Previous closed PR**
https://github.com/NightscoutFoundation/xDrip/pull/1742