### PR TITLE
hide password of Dexcom Share Follower

### DIFF
--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -12,7 +12,7 @@
             android:key="dex_collection_method"
             android:summary="@string/how_receive_data"
             android:title="@string/hardware_data_source" />
-        <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        <PreferenceScreen
             android:icon="@drawable/ic_nfc_grey600_48dp"
             android:key="xdrip_plus_nfc_settings"
             android:summary="@string/nfc_options"
@@ -140,10 +140,7 @@
             android:summary="Login password for Dex Share Following"
             android:title="Share Password" />
 
-
-
-
-        <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        <PreferenceScreen
             android:key="xdrip_plus_g5_extra_settings"
             android:summary="@string/advanced_g5_settings"
             android:title="@string/g5_debug_settings">

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -288,7 +288,7 @@
                 android:key="g5-battery-warning-level"
                 android:title="@string/title_g5_battery_warning_level"
                 android:defaultValue="300"
-                android:numeric="integer"
+                android:inputType="number"
                 />
             </PreferenceCategory>
 

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -133,7 +133,7 @@
             android:title="Share Username" />
         <EditTextPreference
             android:defaultValue=""
-            android:inputType="textNoSuggestions|textVisiblePassword"
+            android:inputType="textNoSuggestions|textPassword"
             android:key="shfollow_pass"
             android:maxLines="1"
             android:singleLine="true"


### PR DESCRIPTION
This PR hides the password in the Dexcom Share Follower settings. This is consistent with the other password fields, i. e. Dexcom Account Password of the Dexcom Share Server Upload.

The two additional commits cleaning up the xml file similar to 6d3f629.

fixes #1187