### PR TITLE
Change rewrite history default to false

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -551,7 +551,7 @@ public class Calibration extends Model {
     public static Calibration create(double bg, long timeoffset, Context context, boolean note_only, long estimatedInterstitialLagSeconds) {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         final String unit = prefs.getString("units", "mgdl");
-        final boolean adjustPast = prefs.getBoolean("rewrite_history", true);
+        final boolean adjustPast = prefs.getBoolean("rewrite_history", false);
 
         final Double result = getConvertedBg(bg);
         if (result == null) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -999,7 +999,7 @@ public class WatchUpdaterService extends WearableListenerService implements
                         Log.d(TAG, "onStartCommand Action=" + ACTION_SYNC_CALIBRATION + " Path=" + WEARABLE_CALIBRATION_DATA_PATH);
 
                         sendWearCalibrationData(sendCalibrationCount);
-                        final boolean adjustPast = mPrefs.getBoolean("rewrite_history", true);
+                        final boolean adjustPast = mPrefs.getBoolean("rewrite_history", false);
                         Log.d(TAG, "onStartCommand adjustRecentBgReadings for rewrite_history=" + adjustPast);
                         sendWearBgData(adjustPast ? 30 : 2);//wear may not have all BGs if force_wearG5=false, so send BGs from phone
                         sendData();//ensure BgReading.Last is displayed on watch
@@ -1770,7 +1770,7 @@ public class WatchUpdaterService extends WearableListenerService implements
             force_wearG5 = mPrefs.getBoolean("force_wearG5", false);
             node_wearG5 = mPrefs.getString("node_wearG5", "");
             dataMap.putString("dex_collection_method", dexCollector);
-            dataMap.putBoolean("rewrite_history", mPrefs.getBoolean("rewrite_history", true));
+            dataMap.putBoolean("rewrite_history", mPrefs.getBoolean("rewrite_history", false));
             dataMap.putBoolean("enable_wearG5", enable_wearG5);
             dataMap.putBoolean("force_wearG5", force_wearG5);
             dataMap.putString("node_wearG5", node_wearG5);

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -326,7 +326,7 @@
 
 
                 <CheckBoxPreference
-                    android:defaultValue="true"
+                    android:defaultValue="false"
                     android:key="rewrite_history"
                     android:summary="@string/after_calibration_rewrite_history"
                     android:title="@string/rewrite_history" />


### PR DESCRIPTION
**Why do we need this?**
Rewrite history modifies past readings after a calibration.
We should not be doing this by default.

**Is there a work-around?**
No, after a fresh install, the setting is currently enabled.

**Are there any side effects to this change?**
No, this setting remains unchanged after an install over going back and forth from this to previous releases.
Only after a reinstall, does the setting become disabled, which can be enabled again if needed.

**Tests**
I have performed no tests other than verifying the user interface and confirming that after a fresh install, the setting is disabled.  The only working transmitter I have available is a Firefly, which is limited to native, which cannot use rewrite history.