### PR TITLE
Capitalize "Disable alert" on the alert edit screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -536,11 +536,11 @@
     <string name="tap_to_change">(tap to change)</string>
     <string name="override_phone_silent_mode_colon">Override phone Silent Mode:</string>
     <string name="vibrate_on_alert">Vibrate on alert</string>
-    <string name="test_alert">test alert</string>
+    <string name="test_alert">Test alert</string>
     <string name="disable_alert">Disable alert</string>
-    <string name="save_alert">save alert</string>
-    <string name="remove_alert">remove alert</string>
-    <string name="snooze_alert_before_it_fires">snooze alert before it fires</string>
+    <string name="save_alert">Save alert</string>
+    <string name="remove_alert">Remove alert</string>
+    <string name="snooze_alert_before_it_fires">Snooze alert before it fires</string>
     <string name="create_low_alert">Create low alert</string>
     <string name="create_high_alert">Create high alert</string>
     <string name="long_press_an_existing_alert_to_edit">(Long Press an existing alert to edit)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -537,7 +537,7 @@
     <string name="override_phone_silent_mode_colon">Override phone Silent Mode:</string>
     <string name="vibrate_on_alert">Vibrate on alert</string>
     <string name="test_alert">test alert</string>
-    <string name="disable_alert">disable alert</string>
+    <string name="disable_alert">Disable alert</string>
     <string name="save_alert">save alert</string>
     <string name="remove_alert">remove alert</string>
     <string name="snooze_alert_before_it_fires">snooze alert before it fires</string>


### PR DESCRIPTION
Be consistent about capitalizing the first word on the alert edit screen.