### PR TITLE
XdripWebService: send HTTP 500 when exception occurs during processing

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/webservices/BaseWebService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/webservices/BaseWebService.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip.webservices;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
 import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.URLDecoder;
@@ -20,7 +22,11 @@ public abstract class BaseWebService {
     public abstract WebResponse request(String query);
 
     public WebResponse request(final String query, final InetAddress source) {
-        return request(query);
+        try {
+            return request(query);
+        } catch (Exception ex) {
+            return webError("Exception in "+getClass()+": " +ExceptionUtils.getStackTrace(ex), 500);
+        }
     }
 
     // web error helpers

--- a/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebResponse.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebResponse.java
@@ -31,4 +31,19 @@ public class WebResponse {
         this.mimeType = mimeType;
         this.resultCode = resultCode;
     }
+
+    public String getResultDesc() {
+        switch (resultCode) {
+            case 200:
+                return "OK";
+            case 400:
+                return "Bad Request";
+            case 404:
+                return "Not Found";
+            case 500:
+                return "Server Error";
+            default:
+                return "Unknown";
+        }
+    }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebServiceSgv.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebServiceSgv.java
@@ -111,6 +111,10 @@ public class WebServiceSgv extends BaseWebService {
             sensor_status_string = SensorStatus.status();
         }
 
+        if (cgi.containsKey("test_trigger_exception")) {
+            throw new RuntimeException("This is a test exception");
+        }
+
         if (cgi.containsKey("brief_mode")) {
             brief = true;
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/webservices/XdripWebService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/webservices/XdripWebService.java
@@ -16,6 +16,8 @@ import com.eveningoutpost.dexdrip.xdrip;
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -326,7 +328,7 @@ public class XdripWebService implements Runnable {
                 return;
             }
             // Send out the content.
-            output.println("HTTP/1.0 " + response.resultCode + " OK");
+            output.println("HTTP/1.0 " + response.resultCode + " " + response.getResultDesc());
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 output.println("Date: " + rfc7231formatter.format(ZonedDateTime.now(ZoneOffset.UTC)));
             }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/webservices/RouteFinderTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/webservices/RouteFinderTest.java
@@ -25,7 +25,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 /**
  * Created by jamorham on 17/01/2018.
  */
-public class RouterFinderTest extends RobolectricTestWithConfig {
+public class RouteFinderTest extends RobolectricTestWithConfig {
 
     private static void log(String msg) {
         System.out.println(msg);
@@ -118,6 +118,14 @@ public class RouterFinderTest extends RobolectricTestWithConfig {
         response = routeFinder.handleRoute(subroute);
         validResponse(subroute, response);
         // TODO look for output markers
+
+        // sgv with server exception
+        subroute = "sgv.json?test_trigger_exception=1";
+        response = routeFinder.handleRoute(subroute);
+        responseWithStatusCode(subroute, response, 500);
+        assertWithMessage(subroute + " instance error text")
+                .that(new String(response.bytes))
+                .startsWith("Exception in "+WebServiceSgv.class.toString());
     }
 
     @Test
@@ -374,6 +382,9 @@ public class RouterFinderTest extends RobolectricTestWithConfig {
     }
 
     private void validResponse(String subroute, WebResponse response) {
+        responseWithStatusCode(subroute, response, 200);
+    }
+    private void responseWithStatusCode(String subroute, WebResponse response, int status) {
         assertWithMessage(subroute + " instance null data response")
                 .that(response)
                 .isNotNull();
@@ -383,7 +394,7 @@ public class RouterFinderTest extends RobolectricTestWithConfig {
 
         assertWithMessage(subroute + " result code")
                 .that(response.resultCode)
-                .isEqualTo(200);
+                .isEqualTo(status);
         assertWithMessage(subroute + " instance data length")
                 .that(response.bytes.length)
                 .isAtLeast(1);


### PR DESCRIPTION
Previously, if an error occurred while processing a web service
endpoint then the connection would be terminated with an EOF.

This adds a test which verifies that instead a HTTP 500 is sent
with MIME type text/plain, containing the traceback of the error
to ease debugging.