### PR TITLE
support TLSv1.2 for NightscoutUploader on pre-Lollipop devices 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -327,9 +327,8 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:10.2.1'
     implementation "com.google.android.gms:play-services-gcm:10.2.1"
     implementation 'com.squareup.wire:wire-runtime:2.2.0'
-    implementation 'com.squareup.okhttp:okhttp:2.7.5'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.13'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.13'
     implementation "com.newrelic.agent.android:android-agent:5.27.1"
     //implementation 'com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -327,6 +327,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:10.2.1'
     implementation "com.google.android.gms:play-services-gcm:10.2.1"
     implementation 'com.squareup.wire:wire-runtime:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp:2.7.5'
     implementation 'com.squareup.okhttp3:okhttp:3.12.13'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.13'
     implementation "com.newrelic.agent.android:android-agent:5.27.1"

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserError.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserError.java
@@ -404,7 +404,7 @@ public class UserError extends Model {
             Log.e(TAG, "Unknown level for tag " + tag + " please use d v or i");
         }
         
-        static boolean shouldLogTag(final String tag, final int level) {
+        public static boolean shouldLogTag(final String tag, final int level) {
             final Integer levelForTag = extraTags.get(tag != null ? tag.toLowerCase() : "");
             return levelForTag != null && level >= levelForTag;
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -79,6 +79,8 @@ import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
+import static com.eveningoutpost.dexdrip.UtilityModels.OkHttpWrapper.enableTls12OnPreLollipop;
+
 /**
  * THIS CLASS WAS BUILT BY THE NIGHTSCOUT GROUP FOR THEIR NIGHTSCOUT ANDROID UPLOADER
  * https://github.com/nightscout/android-uploader/
@@ -165,7 +167,7 @@ public class NightscoutUploader {
         public NightscoutUploader(Context context) {
             mContext = context;
             prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
-            final OkHttpClient.Builder okHttp3Builder = new OkHttpClient.Builder();
+            final OkHttpClient.Builder okHttp3Builder = enableTls12OnPreLollipop(new OkHttpClient.Builder());
 
             if (USE_GZIP) okHttp3Builder.addInterceptor(new GzipRequestInterceptor());
             okHttp3Builder.connectTimeout(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Earlier, it was [announced](https://help.heroku.com/SXWA00YI/tls-v1-0-v1-1-end-of-life-schedule) that Heroku will drop TLS v1.0 and v1.1 by July 31, 2021 (as major browser vendors already did). Since August, xDrip on older Android versions below 4.4 but maybe also on some 4.4 devices cannot connect to Nightscout instances running on Heroku because of this TLS drop. This is a breaking bug of xDrip which is addressed by this PR.
It implements the same workaround for NS uploader which was already implemented for Nightscout Follower. It also logs the TLS version used to connect to the NS instance, if extra logging is enabled for NS uploader (`NightscoutUploader:v`), but without intercepting the communication if the extra logging is not enabled.
Also, OkHttp library and logger is updated to [v3.2.13](https://square.github.io/okhttp/changelog_3x/#version-31213), which is just a bug fixed version without new features.