### PR TITLE
Carb entry error

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1359,7 +1359,6 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         allWords = allWords.trim();
         allWords = allWords.replaceAll(":", "."); // fix real times
         allWords = allWords.replaceAll("(\\d)([a-zA-Z])", "$1 $2"); // fix like 22mm
-
         allWords = allWords.replaceAll("([a-zA-Z]+ \\d{1,3}(?:\\.\\d)*)(\\d+(?:\\.\\d)* [a-zA-Z]+)", "$1 $2"); // fix multi number order like blood 3.622 grams
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             allWords = allWords.replaceAll(new String(RTL_BYTES, StandardCharsets.UTF_8), "");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1360,13 +1360,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         allWords = allWords.replaceAll(":", "."); // fix real times
         allWords = allWords.replaceAll("(\\d)([a-zA-Z])", "$1 $2"); // fix like 22mm
 
-/** The following line converts 1.234 carbs to 1.2 34 carbs.  It inserts a space between 1.2 and 34.  This results in an array of two words
- *  to be converted into an array of 3 words.  This then results in carb entry with more than 2 decimal points to be unintentionally
- *  converted into an integer containing the last 2 decimal points of the original fractional number.
- *  I am commenting it out and will ask the developers if it is really needed.
- *  Navid  August 10, 2021
-*/
-//        allWords = allWords.replaceAll("([0-9]\\.[0-9])([0-9][0-9])", "$1 $2"); // fix multi number order like blood 3.622 grams
+        allWords = allWords.replaceAll("([a-zA-Z]+ \\d{1,3}(?:\\.\\d)*)(\\d+(?:\\.\\d)* [a-zA-Z]+)", "$1 $2"); // fix multi number order like blood 3.622 grams
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             allWords = allWords.replaceAll(new String(RTL_BYTES, StandardCharsets.UTF_8), "");
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1359,7 +1359,14 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         allWords = allWords.trim();
         allWords = allWords.replaceAll(":", "."); // fix real times
         allWords = allWords.replaceAll("(\\d)([a-zA-Z])", "$1 $2"); // fix like 22mm
-        allWords = allWords.replaceAll("([0-9]\\.[0-9])([0-9][0-9])", "$1 $2"); // fix multi number order like blood 3.622 grams
+
+/** The following line converts 1.234 carbs to 1.2 34 carbs.  It inserts a space between 1.2 and 34.  This results in an array of two words
+ *  to be converted into an array of 3 words.  This then results in carb entry with more than 2 decimal points to be unintentionally
+ *  converted into an integer containing the last 2 decimal points of the original fractional number.
+ *  I am commenting it out and will ask the developers if it is really needed.
+ *  Navid  August 10, 2021
+*/
+//        allWords = allWords.replaceAll("([0-9]\\.[0-9])([0-9][0-9])", "$1 $2"); // fix multi number order like blood 3.622 grams
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             allWords = allWords.replaceAll(new String(RTL_BYTES, StandardCharsets.UTF_8), "");
         }


### PR DESCRIPTION
Updated current description

Why we need this
When entering carb values, if the user enters 3 decimal points, what is entered is an integer value equal to the last two digits of the fractional part of the number. For example, if the user enters 1.298, what will be entered is 98, which is a significant error.

Fixes https://github.com/NightscoutFoundation/xDrip/issues/565

Is there a workaround?
The user can avoid entering more than 2 decimal points.
The problem is that anyone could accidentally enter too many digits.

Are there any side effects?
No

Tests
I have tested this on an Android 8 follower

Credits
Thanks to Mathias Walter for suggesting the alternative regex