### PR TITLE
Don't offer to hard reset Firefly

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/DexTimeKeeper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/DexTimeKeeper.java
@@ -4,6 +4,8 @@ import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 
+import static com.eveningoutpost.dexdrip.Services.Ob1G5CollectionService.getTransmitterID;
+
 /**
  * Created by jamorham on 25/11/2016.
  */
@@ -32,7 +34,11 @@ public class DexTimeKeeper {
         if (dexTimeStamp < 1) {
             UserError.Log.e(TAG, "Invalid dex timestamp in updateAge: " + dexTimeStamp);
             if (dexTimeStamp == 0 && absolute) {
-                DexResetHelper.offer("Your transmitter clock has stopped or never started. Do you want to hard reset it?");
+                if (FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) { // Firefly, which cannot be hard reset
+                    UserError.Log.e(TAG, "Your transmitter clock has stopped or never started.");
+                } else {
+                    DexResetHelper.offer("Your transmitter clock has stopped or never started. Do you want to hard reset it?");
+                }
             }
             return;
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
@@ -610,7 +610,9 @@ public class Ob1G5StateMachine {
                                 UserError.Log.ueh(TAG, "Session Start failed info: " + JoH.dateTimeText(session_start.getSessionStart()) + " " + JoH.dateTimeText(session_start.getRequestedStart()) + " " + JoH.dateTimeText(session_start.getTransmitterTime()));
                                 if (session_start.isFubar()) {
                                     final long tk = DexTimeKeeper.getDexTime(getTransmitterID(), tsl());
-                                    if (tk > 0) {
+                                    if (tk > 0 & FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) { // Firefly, which cannot be hard reset
+                                        UserError.Log.e(TAG, "Unusual session start failure");
+                                    } else if (tk > 0) {
                                         DexResetHelper.offer("Unusual session start failure, is transmitter crashed? Try Hard Reset?");
                                     } else {
                                         UserError.Log.e(TAG, "No reset as TimeKeeper reports invalid: " + tk);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
@@ -610,10 +610,12 @@ public class Ob1G5StateMachine {
                                 UserError.Log.ueh(TAG, "Session Start failed info: " + JoH.dateTimeText(session_start.getSessionStart()) + " " + JoH.dateTimeText(session_start.getRequestedStart()) + " " + JoH.dateTimeText(session_start.getTransmitterTime()));
                                 if (session_start.isFubar()) {
                                     final long tk = DexTimeKeeper.getDexTime(getTransmitterID(), tsl());
-                                    if (tk > 0 & FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) { // Firefly, which cannot be hard reset
-                                        UserError.Log.e(TAG, "Unusual session start failure");
-                                    } else if (tk > 0) {
-                                        DexResetHelper.offer("Unusual session start failure, is transmitter crashed? Try Hard Reset?");
+                                    if (tk > 0) {
+                                        if (FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) {// Firefly, which cannot be hard reset
+                                            UserError.Log.e(TAG, "Unusual session start failure");
+                                        } else {
+                                            DexResetHelper.offer("Unusual session start failure, is transmitter crashed? Try Hard Reset?");
+                                        }
                                     } else {
                                         UserError.Log.e(TAG, "No reset as TimeKeeper reports invalid: " + tk);
                                     }


### PR DESCRIPTION
**Why we need this**
It's confusing if the user of a Firefly G6 sees an offer to hard reset transmitter.
This PR removes the offer, if the transmitter is a Firefly, and replaces it with a log.
Over the period of 3 years, I have only seen may be 5 cases of this on facebook.  The last time was less than a month or so ago.  But, I'm not sure what xDrip version they were using.

This is one of the actions listed in this issue:  https://github.com/NightscoutFoundation/xDrip/issues/1736

**Is there a workaround?**
The user can ignore the message if they are knowledgeable that xDrip has not been updated after the G6 firmware change.

**Are there any side effects?**
No

**Tests**
I am running this build on my main device now.  But, I don't know how to trigger the error that would execute the new conditional.

