### PR TITLE
Fix "Never use them"

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -809,6 +809,10 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                     alert.show();
                 }
                 // offer choice to enable auto-calibration mode if not already enabled on pratelimit
+            } else if (calibration_type.equals("never")) {
+                Log.d(TAG, "Creating bloodtest record");
+                BloodTest.createFromCal(glucosenumber, timeoffset, "Manual Entry");
+                GcmActivity.syncBloodTests();
             } else {
                 // if use for calibration == "no" then this is a "note_only" type, otherwise it isn't
                 calintent.putExtra("note_only", calibration_type.equals("never") ? "true" : "false");


### PR DESCRIPTION
**Why we need this**
Having automatic calibration disabled and selecting "Never use them" on this form sends entered blood test value for calibration.
![Screenshot_20210816-121504](https://user-images.githubusercontent.com/51497406/129652260-79fc4542-abb8-4971-bac8-866c1fc243e6.png)
There are individuals, facebook group, who have stopped entering their blood test results because of the unexpected behavior of xDrip.

**Is there a work-around?**
User can select "Automatic mode" and answer no.  That's a work-around for the user who needs to enter their blood test results.  However, it does not address the incorrect behavior of "Never use them" setting.

**Are there any side effects?**
No

**Tests**
Tested with an Android 9 master collecting from G6.