### PR TITLE
Gray out unnecessary and apply recommended settings

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -434,6 +434,28 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     //
                 }
             }
+            if (!prefs.getBoolean("enable_experiment", false)) { // If Experiment is disabled
+                try { // Apply recommended settings
+                    prefs.edit().putBoolean("automatically_turn_bluetooth_on", true).apply(); // Enable auto Bluetooth
+                    prefs.edit().putBoolean("bluetooth_watchdog", true).apply(); // Enable Bluetooth watchdog
+                    prefs.edit().putBoolean("bluetooth_allow_background_scans", true).apply(); // Enable background scan
+                    prefs.edit().putBoolean("bluetooth_frequent_reset", false).apply(); // Disable constant Bluetooth reset
+                    prefs.edit().putBoolean("use_transmiter_pl_bluetooth", false).apply(); // Disable TX PL support
+                    prefs.edit().putBoolean("use_rfduino_bluetooth", false).apply(); // Disable RF Duino
+                    prefs.edit().putBoolean("pref_dex_collection_polling", false).apply(); // Disable xBridge polling mode
+                    prefs.edit().putBoolean("run_service_in_foreground", true).apply(); // Enable running collector in foreground
+                    prefs.edit().putBoolean("requested_ignore_battery_optimizations_new", false).apply(); // Ensure bat optimization is disabled
+                    prefs.edit().putBoolean("allow_samsung_workaround", true).apply(); // Allow Samsung workaround
+                    prefs.edit().putBoolean("use_ob1_g5_collector_service", true).apply(); // Enable OB1
+                    prefs.edit().putBoolean("ob1_g5_fallback_to_xdrip", false).apply(); // Disable fallback
+                    prefs.edit().putBoolean("ob1_initiate_bonding_flag", true).apply(); // Enable allow initiate bonding
+                    prefs.edit().putBoolean("always_get_new_keys", true).apply(); // Enable Authenticate G5 b4 each read
+                    prefs.edit().putBoolean("always_unbond_G5", false).apply(); // Disable unbond G5 b4 each read
+                    prefs.edit().putBoolean("aggressive_service_restart", true).apply(); // Enable aggressive service restarts
+                } catch (Exception e) {
+                    //
+                }
+            }
         } catch (Exception e) {
             //
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1606,4 +1606,6 @@
     <string name="enable_streaming_dialog_title">Connecting Libre sensor to Bluetooth</string>
     <string name="title_lower_fuzzer">Lower FUZZER</string>
     <string name="summary_lower_fuzzer">Lower the FUZZER value from 2.5 minutes to 37.5 seconds</string>
+    <string name="title_enable_experiments">Experiment</string>
+    <string name="summary_enable_experiments">Allows other than recommended settings - Disable to return to recommended settings</string>
 </resources>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1226,11 +1226,13 @@
                 android:summary="@string/advanced_bluetooth_settings"
                 android:title="@string/bluetooth_settings">
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="true"
                     android:key="automatically_turn_bluetooth_on"
                     android:summary="@string/auto_turn_on_bluetooth"
                     android:title="@string/turn_bluetooth_on" />
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="true"
                     android:key="bluetooth_watchdog"
                     android:summary="@string/reset_bluetooth"
@@ -1264,6 +1266,7 @@
                     android:summary="@string/summary_Use_and_trust_Android_bluetooth_auto_connect_feature"
                     android:title="@string/title_Trust_Auto_Connect" />
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="true"
                     android:key="bluetooth_allow_background_scans"
                     android:summary="Use Android 8+ background scanning feature"
@@ -1274,21 +1277,25 @@
                     android:summary="@string/older_bluetooth_wakelocks"
                     android:title="@string/bluetooth_wakelocks" />
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="false"
                     android:key="bluetooth_frequent_reset"
                     android:summary="@string/reset_bluetooth_on_off"
                     android:title="@string/constantly_reset_bluetooth" />
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="false"
                     android:key="use_transmiter_pl_bluetooth"
                     android:summary="@string/experimental_transmitter_fpv_uav"
                     android:title="@string/transmitter_pl_support" />
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="false"
                     android:key="use_rfduino_bluetooth"
                     android:summary="@string/experimental_rdfuino_support"
                     android:title="@string/rfduino_support" />
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="false"
                     android:key="pref_dex_collection_polling"
                     android:summary="@string/summary_Experimental_support_for_xBridge_polling_feature"
@@ -1355,6 +1362,7 @@
             </PreferenceScreen>
 
             <CheckBoxPreference
+                android:dependency="enable_experiment"
                 android:defaultValue="true"
                 android:key="aggressive_service_restart"
                 android:summary="@string/repeatedly_restart_collection_service"
@@ -1426,6 +1434,7 @@
                 android:summary=""
                 android:title="@string/title_Other_misc_options">
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="true"
                     android:key="run_service_in_foreground"
                     android:summary="@string/shows_a_persistent_notification"
@@ -1437,12 +1446,14 @@
                     android:summary="@string/allow_unsafe_settings"
                     android:title="@string/engineering_mode" />
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="false"
                     android:key="requested_ignore_battery_optimizations_new"
                     android:summaryOff="@string/battery_optimization_off"
                     android:summaryOn="@string/battery_optimization_on"
                     android:title="@string/battery_optimization_prompt" />
                 <CheckBoxPreference
+                    android:dependency="enable_experiment"
                     android:defaultValue="true"
                     android:key="allow_samsung_workaround"
                     android:summary="@string/summary_allow_samsung_workaround"
@@ -1498,6 +1509,11 @@
                     android:key="allow_testing_with_dead_sensor"
                     android:summary="@string/summary_allow_testing_with_dead_sensor"
                     android:title="@string/title_NOT_FOR_PRODUCTION_USE" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="enable_experiment"
+                    android:summary="@string/summary_enable_experiments"
+                    android:title="@string/title_enable_experiments" />
 
             </PreferenceScreen>
             <PreferenceCategory

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -275,11 +275,13 @@
                 android:title="@string/force_g5_ui_thread" />
             <CheckBoxPreference
                 android:defaultValue="true"
+                android:dependency="enable_experiment"
                 android:key="always_get_new_keys"
                 android:summary="@string/g5_full_authentification"
                 android:title="@string/authentificate_before_reading" />
             <CheckBoxPreference
                 android:defaultValue="false"
+                android:dependency="enable_experiment"
                 android:key="always_unbond_G5"
                 android:summary="@string/g5_remove_before_read"
                 android:title="@string/unbond_g5_before_read" />


### PR DESCRIPTION
**Why we need this**
To make xDrip less confusing for newcomers.
See details here: https://github.com/NightscoutFoundation/xDrip/issues/1740
Fixes https://github.com/NightscoutFoundation/xDrip/issues/1740

The new setting (Experiment) is shown below.
![Screenshot_20210918-003537](https://user-images.githubusercontent.com/51497406/133872630-d900d273-d7de-4bd3-b84c-7af53dd21943.png)
It is disabled by default, which forces the recommended settings.

**Is there a workaround?**
No, there are too many settings available for anyone to change hoping for a solution.  But, changing the numerous settings usually doesn't solve the problem for inexperienced people and they ask for help in the facebook group.

**Are there any side effects?**
The idea is that none of these recommended settings should cause a problem for anyone.  Therefore, there should be no side effect.  But, if you notify me before merging, I will announce on facbook and suggest that they save their settings.  

**Tests**
Tested with a Firefly G6 on Android 8 and Android 11.

**Notes**
Please have a look at the list of settings (Preferences.java) and let me know if:
1- we should add any other setting if you believe there are any other settings that we can recommend to everyone.
2- we should remove any setting if you believe there is a setting that could cause a problem for a particular device or Android level.