### PR TITLE
declares Foreground service types for FollowServices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -710,11 +710,15 @@
         <service android:name=".watch.miband.MiBandService"
             android:foregroundServiceType="connectedDevice|location"
             />
-        <service android:name=".cgm.nsfollow.NightscoutFollowService" />
+        <service android:name=".cgm.nsfollow.NightscoutFollowService"
+            android:foregroundServiceType="dataSync"
+            />
         <service android:name=".insulin.inpen.InPenService"
             android:foregroundServiceType="connectedDevice|location"
             />
-        <service android:name=".cgm.sharefollow.ShareFollowService" />
+        <service android:name=".cgm.sharefollow.ShareFollowService"
+            android:foregroundServiceType="dataSync"
+            />
 
         <activity
             android:name=".EventLogActivity"

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ForegroundServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ForegroundServiceStarter.java
@@ -9,7 +9,7 @@ import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 
-import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION;
+import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST;
 import static com.eveningoutpost.dexdrip.UtilityModels.Notifications.ongoingNotificationId;
 
 /**
@@ -65,7 +65,7 @@ public class ForegroundServiceStarter {
                   Even then the restrictions seem to be applied inconsistently!
                  */
                 try {
-                    mService.startForeground(ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext), FOREGROUND_SERVICE_TYPE_LOCATION);
+                    mService.startForeground(ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext), FOREGROUND_SERVICE_TYPE_MANIFEST);
                 } catch (IllegalArgumentException e) {
                     UserError.Log.e(TAG, "Got exception trying to use Android 10+ service starting for " + mService.getClass().getSimpleName() + " " + e);
                     mService.startForeground(ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext));


### PR DESCRIPTION
Android 10 and newer require the declaration of the foreground service type. This is added for NightscoutFollowService and ShareFollowService as FOREGROUND_SERVICE_TYPE_DATA_SYNC.

Fixes #1831