### PR TITLE
Don't ask to enable oop if libreoop2 is found.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CompatibleApps.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CompatibleApps.java
@@ -105,13 +105,13 @@ public class CompatibleApps extends BroadcastReceiver {
             }
         }
 
-        if (!Pref.getBooleanDefaultFalse("external_blukon_algorithm")) {
-            final String[] oop_package_names = {"info.nightscout.deeplearning", "com.hg4.oopalgorithm.oopalgorithm", "com.hg4.oopalgorithm.oopalgorithm2", "org.andesite.lucky8"};
-            final StringBuilder sb = new StringBuilder();
-            for (String package_name_o : oop_package_names) {
-                if (InstalledApps.checkPackageExists(context, package_name_o)) {
-                    if (sb.length() > 0) sb.append(",");
-                    sb.append(package_name_o);
+        final String[] oop_package_names = {"info.nightscout.deeplearning", "com.hg4.oopalgorithm.oopalgorithm", "com.hg4.oopalgorithm.oopalgorithm2", "org.andesite.lucky8"};
+        final StringBuilder sb = new StringBuilder();
+        for (String package_name_o : oop_package_names) {
+            if (InstalledApps.checkPackageExists(context, package_name_o)) {
+                if (sb.length() > 0) sb.append(",");
+                sb.append(package_name_o);
+                if (!Pref.getBooleanDefaultFalse("external_blukon_algorithm") && !package_name_o.equals("com.hg4.oopalgorithm.oopalgorithm2") ) {
                     if (JoH.pratelimit(package_name_o + NOTIFY_MARKER, RENOTIFY_TIME)) {
                         final String short_package = package_name_o.substring(package_name_o.lastIndexOf(".") + 1).toUpperCase();
                         id = notify(gs(R.string.external_calibration_app),
@@ -120,9 +120,9 @@ public class CompatibleApps extends BroadcastReceiver {
                     }
                 }
             }
-            if (sb.length() > 0) {
-                PersistentStore.setString(EXTERNAL_ALG_PACKAGES, sb.toString());
-            }
+        }
+        if (sb.length() > 0) {
+            PersistentStore.setString(EXTERNAL_ALG_PACKAGES, sb.toString());
         }
 
         checkMemoryConstraints();


### PR DESCRIPTION
oop2 actually does not work when oop is enabled, so we should not offer this option to the users.

Actually, there was another problem here:
The code does a check for which external application is installed, and if one of the oop is found, it is set in the preference (EXTERNAL_ALG_PACKAGES).
Later, EXTERNAL_ALG_PACKAGES is used as a target when sending intents. But this check was only done when external_blukon_algorithm is not turned on.
This is wrong, the check has to be done always. Asking to enable oop should only be done if oop is off.