### PR TITLE
Remove emphasis from SD card

### DIFF
--- a/app/src/main/res/layout/activity_sdcard_import_export.xml
+++ b/app/src/main/res/layout/activity_sdcard_import_export.xml
@@ -35,6 +35,7 @@
             android:text="@string/save_all_settings_to_sdcard"
             android:id="@+id/saveallsettings"
             android:onClick="savePreferencesToSD"
+            android:textAllCaps="false"
             android:layout_centerVertical="true"
             android:layout_alignParentStart="true" />
 
@@ -45,6 +46,7 @@
             android:text="@string/load_all_settings_from_sdcard"
             android:id="@+id/buttonload"
             android:onClick="loadPreferencesToSD"
+            android:textAllCaps="false"
             android:layout_below="@+id/saveallsettings"
             android:layout_alignStart="@+id/saveallsettings" />
 
@@ -55,6 +57,7 @@
             android:text="@string/delete_any_settings_on_sdcard"
             android:id="@+id/buttondelete"
             android:onClick="deletePreferencesOnSD"
+            android:textAllCaps="false"
             android:layout_below="@+id/buttonload"
             android:layout_alignStart="@+id/buttonload" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,10 +369,10 @@
     <string name="version_details">Version details</string>
     <string name="download_now">Download Now</string>
     <string name="automatically_check_for_updates">Automatically check for updates</string>
-    <string name="here_you_can_save_the_settings_to_the_external_storage_sdcard">Here, you can save the settings to the internal storage (or SD card).\n\nOnce saved to a file, it is potentially possible for any app to read the settings which might contain sensitive information.\n\nYou are advised to delete the settings once you have imported them again if you are concerned about this.</string>
+    <string name="here_you_can_save_the_settings_to_the_external_storage_sdcard">Here, you can save the settings to the internal storage (Download/xDrip-export/com.eveningoutpost.dexdrip_preferences.xml).\n\nOnce saved to a file, it is potentially possible for any app to read the settings which might contain sensitive information.\n\nYou are advised to delete the settings once you have imported them again if you are concerned about this.</string>
     <string name="save_all_settings_to_sdcard">Save all Settings to the settings file</string>
     <string name="load_all_settings_from_sdcard">Load all settings from the settings file</string>
-    <string name="delete_any_settings_on_sdcard">Delete settings file</string>
+    <string name="delete_any_settings_on_sdcard">Delete settings folder (Download/xDrip-export)</string>
     <string name="use_qr_codes_to_transfer_settings_using_settings_auto_configure_feature"><![CDATA[Use QR codes to transfer settings using Settings->Auto Configure feature]]></string>
     <string name="xdrip_plus_security_key_settings_only">xDrip Plus Security Key Settings only</string>
     <string name="show_general_and_collection_settings">Show General and Collection Settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,7 +223,7 @@
     <string name="send_feedback_message">Send Feedback Message</string>
     <string name="copying_settings">Copying Settings</string>
     <string name="show_settings_qr_codes">Show Settings QR codes</string>
-    <string name="load_save_settings_to_sdcard">Load / Save settings to SD card</string>
+    <string name="load_save_settings_to_sdcard">Load / Save settings</string>
     <string name="alarms_and_alerts">Alarms and Alerts</string>
     <string name="alerts_and_notifications">Alerts and Notifications</string>
     <string name="glucose_level_alerts_list">Glucose Level Alerts List</string>
@@ -369,10 +369,10 @@
     <string name="version_details">Version details</string>
     <string name="download_now">Download Now</string>
     <string name="automatically_check_for_updates">Automatically check for updates</string>
-    <string name="here_you_can_save_the_settings_to_the_external_storage_sdcard">Here you can save the settings to the external storage (SD card).\n\nOnce saved to the external storage it is potentially possible for any app to read the settings which might contain sensitive information.\n\nYou are advised to delete the settings once you have imported them again if you are concerned about this.</string>
-    <string name="save_all_settings_to_sdcard">Save all Settings to SD card</string>
-    <string name="load_all_settings_from_sdcard">Load all Settings from SD card</string>
-    <string name="delete_any_settings_on_sdcard">Delete any settings on SD card</string>
+    <string name="here_you_can_save_the_settings_to_the_external_storage_sdcard">Here, you can save the settings to the internal storage (or SD card).\n\nOnce saved to a file, it is potentially possible for any app to read the settings which might contain sensitive information.\n\nYou are advised to delete the settings once you have imported them again if you are concerned about this.</string>
+    <string name="save_all_settings_to_sdcard">Save all Settings to the settings file</string>
+    <string name="load_all_settings_from_sdcard">Load all settings from the settings file</string>
+    <string name="delete_any_settings_on_sdcard">Delete settings file</string>
     <string name="use_qr_codes_to_transfer_settings_using_settings_auto_configure_feature"><![CDATA[Use QR codes to transfer settings using Settings->Auto Configure feature]]></string>
     <string name="xdrip_plus_security_key_settings_only">xDrip Plus Security Key Settings only</string>
     <string name="show_general_and_collection_settings">Show General and Collection Settings</string>
@@ -396,7 +396,7 @@
     <string name="search">Search</string>
     <string name="reset_all_language_data">Reset ALL language data</string>
     <string name="show_only_customized_entries">Show only customized entries</string>
-    <string name="settings_on_external_storage">Settings on external storage</string>
+    <string name="settings_on_external_storage">Load/Save settings</string>
     <string name="get_notified_of_new_apk_releases">Get notified of new apk releases</string>
     <string name="choose_stable_beta_or_alpha_releases">Choose Stable, Beta or Alpha releases</string>
     <string name="web_feedback_form_for_sending_messages">Web feedback form for sending messages and ratings of xDrip+ to the developers</string>
@@ -1221,7 +1221,7 @@
     <string name="title_tidepool_dev_servers">Use Integration (test) servers</string>
     <string name="title_tidepool">Tidepool</string>
     <string name="show_help">Show Help</string>
-    <string name="load_save_settings_on_sdcard">Load / Save Settings on SD card</string>
+    <string name="load_save_settings_on_sdcard">Load / Save Settings</string>
     <string name="delete_all_bg_readings">Delete All BG readings</string>
     <string name="debugging_test_feature">Debugging test feature</string>
     <string name="sync_treatments">Sync Treatments</string>


### PR DESCRIPTION
**Why we need this**
Users get the impression that if their phone has no SD card, they cannot save their settings (https://github.com/NightscoutFoundation/xDrip/issues/1631#issue-797838599).  This is because the menu items for saving or loading settings refer to the SD card.   
The following images show what we have now.
![Screenshot_20210924-183219](https://user-images.githubusercontent.com/51497406/134746545-1b8a10bd-8b74-43c5-bc67-19c78cb2e935.jpg)

![Screenshot_20211002-234720](https://user-images.githubusercontent.com/51497406/135738905-eba36d55-6c48-4e9e-8247-eb58ae7e9390.png)

![Screenshot_20210924-181743](https://user-images.githubusercontent.com/51497406/134745536-8bee5e4a-0a8d-4aad-ad0e-1dc4c25816d3.jpg)

But, xDrip can also save to and load from the internal storage.  This PR replaces the wordings of the menu items to reflect that.
The following images show what we will have after this change.
![Screenshot_20210924-183632](https://user-images.githubusercontent.com/51497406/134746561-ee3dad00-cd2a-4fc4-9303-6afce1fbceb5.jpg)

![Screenshot_20211002-233845](https://user-images.githubusercontent.com/51497406/135738749-5e98d6b9-6606-4354-b0d0-2ff177ceccfc.jpg)

![Screenshot_20211004-101147](https://user-images.githubusercontent.com/51497406/135867259-34d4d812-b9f3-469e-813e-a49e25f1063c.jpg)

There is no change to any functionality in this PR; only wordings of the existing buttons and menu items.

**Is there a workaround?**
No

**Are there any side effects?**
No

**Tests**
Tested on an Android 8 phone