### PR TITLE
Enable override silent mode and force speaker for the 2 existing alarms

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/IdempotentMigrations.java
@@ -69,15 +69,15 @@ public class IdempotentMigrations {
                 highMark = highMark * Constants.MMOLL_TO_MGDL;
                 lowMark = lowMark * Constants.MMOLL_TO_MGDL;
             }
-            boolean bg_sound_in_silent = prefs.getBoolean("bg_sound_in_silent", false);
+            boolean bg_sound_in_silent = prefs.getBoolean("bg_sound_in_silent", true);
             String bg_notification_sound = prefs.getString("bg_notification_sound", "content://settings/system/notification_sound");
 
             int bg_high_snooze = Integer.parseInt(prefs.getString("bg_snooze",  Integer.toString(SnoozeActivity.getDefaultSnooze(true))));
             int bg_low_snooze = Integer.parseInt(prefs.getString("bg_snooze",  Integer.toString(SnoozeActivity.getDefaultSnooze(false))));
 
 
-            AlertType.add_alert(null, mContext.getString(R.string.high_alert), true, highMark, true, 1, bg_notification_sound, 0, 0, bg_sound_in_silent, false, bg_high_snooze, true, true);
-            AlertType.add_alert(null, mContext.getString(R.string.low_alert), false, lowMark, true, 1, bg_notification_sound, 0, 0, bg_sound_in_silent, false, bg_low_snooze, true, true);
+            AlertType.add_alert(null, mContext.getString(R.string.high_alert), true, highMark, true, 1, bg_notification_sound, 0, 0, bg_sound_in_silent, true, bg_high_snooze, true, true);
+            AlertType.add_alert(null, mContext.getString(R.string.low_alert), false, lowMark, true, 1, bg_notification_sound, 0, 0, bg_sound_in_silent, true, bg_low_snooze, true, true);
             prefs.edit().putBoolean("bg_notifications", false).apply();
         }
     }


### PR DESCRIPTION
**Why we need this**
When xDrip is installed, there are two existing alarms.  They have override silent mode and force speaker disabled.
If you create a new alert, override silent mode and force speaker are enabled by default.
This is a discrepancy in defaults that this PR resolves.
If this is merged, after installing xDrip, override silent mode and force speaker will be enabled on the two existing alerts.

I kept looking for where the settings for the existing alerts came from.  But, couldn't find it, and eventually, gave up and reached out to Adrian.  He pointed out where the settings were.
Thanks, @AdrianLxM. 


**Is there  a workaround?**
No.

**Are there any side effects?**
No

**Tests**
Tested on an Android 8 phone.