### PR TITLE
Bugfix: Wear complication null with Share and Nightscout follow sources

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NSClientReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NSClientReceiver.java
@@ -199,7 +199,6 @@ public class NSClientReceiver extends BroadcastReceiver {
         JSONObject jsonObject = new JSONObject();
         try {
             jsonObject.put("uuid", UUID.randomUUID().toString());
-            //TODO: Determine impact of making this not-null - scan all code
             jsonObject.put("source_info", "NSClient Follow");
 
             jsonObject.put("timestamp", sgv_map.get("mills"));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NSClientReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NSClientReceiver.java
@@ -199,6 +199,8 @@ public class NSClientReceiver extends BroadcastReceiver {
         JSONObject jsonObject = new JSONObject();
         try {
             jsonObject.put("uuid", UUID.randomUUID().toString());
+            //TODO: Determine impact of making this not-null - scan all code
+            jsonObject.put("source_info", "NSClient Follow");
 
             jsonObject.put("timestamp", sgv_map.get("mills"));
             jsonObject.put("calculated_value", sgv_map.get("mgdl"));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
@@ -360,6 +360,7 @@ public class NSEmulatorReceiver extends BroadcastReceiver {
             faux_bgr.put("calculated_value", sgv);
             faux_bgr.put("filtered_calculated_value", sgv);
             faux_bgr.put("calculated_value_slope", slope);
+            faux_bgr.put("source_info", "NSEmulator Follow");
             // sanity checking???
             // fake up some extra data
             faux_bgr.put("raw_data", sgv);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/EntryProcessor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/EntryProcessor.java
@@ -8,6 +8,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Unitized;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.messages.Entry;
 
 import java.util.List;
+import java.util.UUID;
 
 import static com.eveningoutpost.dexdrip.Models.BgReading.SPECIAL_FOLLOWER_PLACEHOLDER;
 
@@ -40,6 +41,7 @@ public class EntryProcessor {
 
                         if (live) {
                             final BgReading bg = new BgReading();
+                            bg.uuid = UUID.randomUUID().toString();
                             bg.timestamp = recordTimestamp;
                             bg.calculated_value = entry.sgv;
                             bg.raw_data = entry.unfiltered != 0 ? entry.unfiltered : SPECIAL_FOLLOWER_PLACEHOLDER;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/EntryProcessor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/EntryProcessor.java
@@ -7,6 +7,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Inevitable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static com.eveningoutpost.dexdrip.Models.BgReading.SPECIAL_FOLLOWER_PLACEHOLDER;
 
@@ -42,6 +43,7 @@ public class EntryProcessor {
 
                         if (live) {
                             final BgReading bg = new BgReading();
+                            bg.uuid = UUID.randomUUID().toString();
                             bg.timestamp = recordTimestamp;
                             bg.calculated_value = entry.Value;
                             bg.raw_data = SPECIAL_FOLLOWER_PLACEHOLDER;

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
@@ -2416,7 +2416,7 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                                     changed = true;
                                     bgData.save();
                                 } else {
-                                    if (bgData.source_info != null && bgData.source_info.contains("Native")) {
+                                    if (bgData.source_info != null && (bgData.source_info.contains("Native") || bgData.source_info.contains("Share Follow"))) {
                                         UserError.Log.d(TAG, "Saving BgData without calibration as source info is native");
                                         bgData.sensor = sensor;
                                         bgData.sensor_uuid = sensor.uuid;

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
@@ -2416,7 +2416,7 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                                     changed = true;
                                     bgData.save();
                                 } else {
-                                    if (bgData.source_info != null && (bgData.source_info.contains("Native") || bgData.source_info.contains("Share Follow"))) {
+                                    if (bgData.source_info != null && (bgData.source_info.contains("Native") || bgData.source_info.contains("Follow"))) {
                                         UserError.Log.d(TAG, "Saving BgData without calibration as source info is native");
                                         bgData.sensor = sensor;
                                         bgData.sensor_uuid = sensor.uuid;

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
@@ -2417,7 +2417,7 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                                     bgData.save();
                                 } else {
                                     if (bgData.source_info != null && (bgData.source_info.contains("Native") || bgData.source_info.contains("Follow"))) {
-                                        UserError.Log.d(TAG, "Saving BgData without calibration as source info is native");
+                                        UserError.Log.d(TAG, "Saving BgData without calibration as source info is native or follow");
                                         bgData.sensor = sensor;
                                         bgData.sensor_uuid = sensor.uuid;
                                         changed = true;

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
@@ -147,6 +147,7 @@ public class NSEmulatorReceiver extends BroadcastReceiver {
         faux_bgr.put("timestamp", timestamp);
         faux_bgr.put("calculated_value", sgv);
         faux_bgr.put("filtered_calculated_value", sgv);
+        faux_bgr.put("source_info", "NSEmulator Follow");
         // sanity checking???
         // fake up some extra data
         faux_bgr.put("raw_data", sgv);


### PR DESCRIPTION
Fix for issue #303 - confirmed fixed using Follow Share source.

1. Updated Listener service on WearOS to apply the calibration-ignoring logic previously exclusive to Dexcom Native, to now include Dexcom Share Follow. This is appropriate as Follow BG values are identical to Native values and do not require calibration. Credit to @gregorybel for finding this one!
2. Populating the BgReading uuid in the ShareFollow and NightscoutFollow source entry processors


The null uuid in the BgReading values created by the follow sources were causing a nulPointerException in BgReading.getByUuid(). This was causing BgReading.last() to always return null.
The most visible consequence was the complication provider always getting null values, however BgReading.last() is used extensively throughout the Wear OS side code (one example is in checking to see if it needs to perform an update - without the uuid, the answer was always yes)

These are the only instances in the app-side code of "new BgReading" (outside of the BgReading class itself) that do not populate the uuid. The same method is used here as in the Native Dex source.


Confirmed working on Wear OS emulator and Galaxy Watch 4.

NOTE: If it was intended that the uuid be null, a condition to check for a null parameter can be added to getByUuid(). (This is what I did first, but it felt like a hack given my limited understanding of the codebase)

![Demo_Follow_Complication_Working](https://user-images.githubusercontent.com/29778397/136631843-e99389fa-a2ad-42d5-b302-ec5ae04b359f.png)


