### PR TITLE
Disable Predictive simulation by default

### DIFF
--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -609,7 +609,7 @@
             android:key="xdrip_plus_profile_category"
             android:title="@string/xdrip_plus_prediction_settings">
             <SwitchPreference
-                android:defaultValue="true"
+                android:defaultValue="false"
                 android:key="simulations_enabled"
                 android:summary="@string/display_mathamatical_simulations"
                 android:switchTextOff="@string/short_off_text_for_switches"


### PR DESCRIPTION
**Why we need this**  
New users often post on facebook asking what everything shown on screen means.  When, they should focus on learning the basics of xDrip and not be distracted by the simulation parameters or curves.  

**Is there a workaround?**  
No  

**Are there any side effects?**  
No  

**Tests**  
Tested on an Android 8  