### PR TITLE
"when" is very confusing, as people usually respond "x minutes ago". It's asking for a time (24hr).

### DIFF
--- a/app/src/main/res/values-en/strings-en.xml
+++ b/app/src/main/res/values-en/strings-en.xml
@@ -9,4 +9,5 @@
     <!-- Amazfit Settings -->
     <string name="retrieve_blukon_history_summary">Retrieve missed history from Blucon device when reconnecting to sensor.</string>
     <!-- trend arrow for speak -->
+    <string name="when">time</string>
 </resources>


### PR DESCRIPTION
The first natural thought (unless you already knew) would be to input "1", an integer, just like the other 4 treatment variables. Then it's natural to look for whether it was seconds, minutes, or hours. Then, the frustration kicks in. 

Of course, developers get tunnel vision and are already working with a 24 hr time, so they won't see this issue. But a new user will get stuck.

The solution is to call this "time", not "when".