### PR TITLE
"when" is very confusing, as people usually respond "x minutes ago". …

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,7 +336,7 @@
     <string name="space_units">" units"</string>
     <string name="units">units</string>
     <string name="carbs">carbs</string>
-    <string name="when">when</string>
+    <string name="when">time</string>
     <string name="speak_your_treatment">Speak your treatment e.g.\nx.x units insulin / xx grams carbs</string>
     <string name="speech_recognition_is_not_supported">Speech recognition is not supported</string>
     <string name="treatment_note">Treatment Note</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,7 +336,7 @@
     <string name="space_units">" units"</string>
     <string name="units">units</string>
     <string name="carbs">carbs</string>
-    <string name="when">time</string>
+    <string name="when">when (HHMM)</string>
     <string name="speak_your_treatment">Speak your treatment e.g.\nx.x units insulin / xx grams carbs</string>
     <string name="speech_recognition_is_not_supported">Speech recognition is not supported</string>
     <string name="treatment_note">Treatment Note</string>


### PR DESCRIPTION
…It's asking for a time (24hr).

The first natural thought (unless you already knew) would be to input "1", an integer, just like the other 4 treatment variables. Then it's natural to look for whether it was seconds, minutes, or hours. Then, the frustration kicks in.

Of course, developers get tunnel vision and are already working with a 24 hr time, so they won't see this issue. But a new user will get stuck.

The solution is to call this "time", not "when".