### PR TITLE
Speak twice bug in German

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SpeechUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/SpeechUtil.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 public class SpeechUtil {
 
     public static final String TAG = "SpeechUtil";
-    public static final String TWICE_DELIMITER = "... "; // creates a pause hopefully works on all locales
+    public static final String TWICE_DELIMITER = " ... "; // creates a pause hopefully works on all locales
     private static volatile TextToSpeech tts = null; // maintained instance
 
     // delay parameter allows you to force a millis delay before playing to avoid clash with notification sounds triggered at the same time


### PR DESCRIPTION
**Why we need this**
The bug is described here:
https://github.com/NightscoutFoundation/xDrip/commit/52b1ef5937f0816bbd99d99f47911952879fe7c1#commitcomment-57648510
It results in a wrong spoken word in German.  There is no issue with English.
This is on my phone:
https://drive.google.com/file/d/1rEff_6gDdLQGc9hzr5QYZzkrWwfaWi4P/view

This is after the change:
https://drive.google.com/file/d/160eJWnpk7YJAkQFszAR6dfg9wjm-TqpI/view?usp=sharing

**Is there a workaround?**
No

**Are there any side effects?**
No

**Tests**
Tested with an Android 8 follower