### PR TITLE
Ask users to use discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,11 +1,12 @@
 ---
 name: "\U0001F41BBug report\U0001F41B"
-about: Create a report to help us improve things
+about: Create a report only if the developers asked you to do so
 label: bug
 ---
 
-### If you need support for xDrip, PLEASE DO NOT FILE A TICKET HERE
-- For support, please post a question to the xDripG5 group at Facebook (https://www.facebook.com/groups/xDripG5) or visit the Gitter room at https://gitter.im/jamorham/xDrip-plus.
+### Please don't open an issue if you haven't already consulted with the developers
+- Pease go back and use one of the suggested support channels (on the previous page) to present your case if you haven't already.
+- If you have consulted with the developers and were asked to open an issue, please proceed.
 - Please also search the existing issues for similar problems before opening a new one.
 - Please do not prefix you issue title with BUG: or LIBRE: for instance. The issue maintainer will tag every issue with appropriate labels.
 - Add screenshots only if necessary, e.g. write the version number instead of adding a screenshot of the system status page.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,6 +12,7 @@ label: bug
 - Add screenshots only if necessary, e.g. write the version number instead of adding a screenshot of the system status page.
 
 ### Subject of the issue
+Link to the discussion thread:
 A clear and concise description of what the bug is.
 Example: The BG graph shows negative data points between 3 and 5 am, which is incorrect and can only be an artefact.
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,7 +12,7 @@ label: bug
 - Add screenshots only if necessary, e.g. write the version number instead of adding a screenshot of the system status page.
 
 ### Subject of the issue
-Link to the discussion thread:
+Link to the discussion thread:  
 A clear and concise description of what the bug is.
 Example: The BG graph shows negative data points between 3 and 5 am, which is incorrect and can only be an artefact.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,10 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: xDrip Discussions
     url: https://github.com/Navid200/xDrip/discussions
-    about: If you are an xDrip user and need support (how to, new feature, or bug), please post here.  It's a forum.  So, all posts related to your question or proposal stays together and easy to find.  All developers and users can access.
+    about: If you are an xDrip user and need support (how to, new feature, or bug), please post here. It's a forum. So, all posts related to your question or proposal stay together and are easy to find. All developers and users can access them.
   - name: xDrip Community Support at Gitter
     url: https://gitter.im/jamorham/xDrip-plus
     about: If you are an xDrip user and have trouble with the app, you can post questions here.  
   - name: xDrip Community Support at Facebook
     url: https://www.facebook.com/groups/xDripG5
-    about: If you are an xDrip user and have trouble with the app, you can post questions here. Not every developer has a facebook account.  So, you may be asked to post in the Discussions (see above).
+    about: If you are an xDrip user and have trouble with the app, you can post questions here. Not every developer has a facebook account. So, you may be asked to post in the Discussions (see above).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: xDrip Community Support at Facebook
-    url: https://www.facebook.com/groups/xDripG5
-    about: If you're a xDrip user and have trouble with the app or any connected device, please post questions here. We don't have the resources to answer support questions posted here as tickets.
+  - name: xDrip Discussions
+    url: https://github.com/Navid200/xDrip/discussions
+    about: If you are an xDrip user and need support (how to, new feature, or bug), please post here.  It's a forum.  So, all posts related to your question or proposal stays together and easy to find.  All developers and users can access.
   - name: xDrip Community Support at Gitter
     url: https://gitter.im/jamorham/xDrip-plus
-    about: If you're a xDrip user and have trouble with the app or any connected device, please post questions here. We don't have the resources to answer support questions posted here as tickets.
+    about: If you are an xDrip user and have trouble with the app, you can post questions here.  
+  - name: xDrip Community Support at Facebook
+    url: https://www.facebook.com/groups/xDripG5
+    about: If you are an xDrip user and have trouble with the app, you can post questions here. Not every developer has a facebook account.  So, you may be asked to post in the Discussions (see above).

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -4,13 +4,13 @@ about: Open an issue only if requested by a developer
 label: enhancement
 ---
 
-### Please don't open an issue if you haven't already consulted with the devlopers
+### Please don't open an issue if you haven't already consulted with the developers
 - Please go back and use one of the suggested support channels (on the previous page) to present your case if you haven't already.
 - Please also search the existing issues for similar ideas before opening a new feature request.
 
 ### Subject of the issue
-Link to the discussion thread:  
-A clear and concise description of what the request is  
+Link to the discussion thread: 
+A clear and concise description of what the request is about.
 
 ### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,12 +1,16 @@
 ---
 name: "\U0001F4A1Feature request\U0001F4A1"
-about: Suggest an idea for this project
+about: Open an issue only if requested by a developer
 label: enhancement
 ---
 
-### If you need support for xDrip, PLEASE DO NOT FILE A TICKET HERE
-For support, please post a question to the xDripG5 group at Facebook (https://www.facebook.com/groups/xDripG5) or visit the Gitter room at https://gitter.im/jamorham/xDrip-plus.
-Please also search the existing issues for similar ideas before opening a new feature request.
+### Please don't open an issue if you haven't already consulted with the devlopers
+- Please go back and use one of the suggested support channels (on the previous page) to present your case if you haven't already.
+- Please also search the existing issues for similar ideas before opening a new feature request.
+
+### Subject of the issue
+Link to the discussion thread:  
+A clear and concise description of what the request is  
 
 ### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is.


### PR DESCRIPTION
I have only edited issues.  Not feature requests yet because I have questions.  After I understand, because there are similarities between the two, I will make the necessary changes once and then create the feature requests form from it.

I'm not clear about the role of the link to the discussion.  I have no problem with it.   But, what should we do if we see a comment in the Gitter room that raises a need for a new issue? 

I have changed the page that showed facebook and Gitter rooms as well as the options to open issues and feature request.
I added the option to post in discussions and put that up as the first option.
Is there a way to move the three options up before the options to open an issue and  a feature request?  I don't know how to do that.