### PR TITLE
Tzachi libretrendutilfix

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -1278,7 +1278,7 @@ public class BgReading extends Model implements ShareUploadableBg {
                     Log.d(TAG, "Ignoring duplicate bgr record due to timestamp: " + json);
                 }
             } catch (Exception e) {
-                Log.d(TAG, "Could not save BGR: " + e.toString());
+                Log.e(TAG, "Could not save BGR bgReading: ", e);
             }
         } else {
             Log.e(TAG,"Got null bgr from json");
@@ -1329,7 +1329,7 @@ public class BgReading extends Model implements ShareUploadableBg {
                     Log.d(TAG, "Ignoring duplicate bgr record due to timestamp: " + timestamp);
                 }
             } catch (Exception e) {
-                Log.d(TAG, "Could not save BGR: " + e.toString());
+                Log.e(TAG, "Could not save BGR: ", e);
             }
         } else {
             Log.e(TAG,"Got null bgr from create");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreOOPAlgorithm.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/LibreOOPAlgorithm.java
@@ -25,6 +25,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import java.util.ArrayList;
+
+import static com.eveningoutpost.dexdrip.NFCReaderX.verifyTime;
 import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 class UnlockBuffers {
@@ -264,6 +266,7 @@ public class LibreOOPAlgorithm {
         glucoseData.glucoseLevel = (int)(oOPResults.currentBg * factor);
         glucoseData.glucoseLevelRaw = (int)(oOPResults.currentBg * factor);
 
+        verifyTime( glucoseData.sensorTime, "LibreOOPAlgorithm", null);
         readingData.trend.add(glucoseData);
         
         // TODO: Add here data of last 10 minutes or whatever.
@@ -361,7 +364,9 @@ public class LibreOOPAlgorithm {
             int relative_time = LIBRE2_SHIFT[i];
             glucoseData.realDate = captureDateTime - relative_time * Constants.MINUTE_IN_MS;
             glucoseData.sensorTime = sensorTime - relative_time;
-            trendList.add(glucoseData);
+            if(verifyTime( glucoseData.sensorTime, "parseBleDataPerMinute ", ble_data)) {
+                trendList.add(glucoseData);
+            }
         }
         return trendList;
     }
@@ -389,7 +394,9 @@ public class LibreOOPAlgorithm {
                 break;
             }
             glucoseData.realDate = captureDateTime  + (final_time - sensorTime) * Constants.MINUTE_IN_MS;
-            glucoseData.sensorTime = final_time;
+            if(verifyTime( final_time, "parseBleDataHistory", ble_data)) {
+                glucoseData.sensorTime = final_time;
+            }
             historyList.add(glucoseData);
         }
         return historyList;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/ReadingData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/ReadingData.java
@@ -33,6 +33,19 @@ public class ReadingData {
         this.history = history;
     }
 
+    public String toString() {
+        String ret = "ternd ";
+        for (GlucoseData gd : trend) {
+            ret += gd.toString();
+            ret += " ";
+        }
+        ret += "history ";
+        for (GlucoseData gd : history) {
+            ret += gd.toString();
+            ret += " ";
+        }
+        return "{" + ret +  "}";
+    }
 
     public static class TransferObject {
         public ReadingData data;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -287,7 +287,7 @@ public class NFCReaderX {
 
         if(LibreOOPAlgorithm.isDecodeableData(patchInfo) && decripted_data == false
                 && !Pref.getBooleanDefaultFalse("external_blukon_algorithm")) {
-            // Send to OOP2 for drcryption.
+            // Send to OOP2 for decryption.
             LibreOOPAlgorithm.logIfOOP2NotAlive();
             LibreOOPAlgorithm.sendData(data1, CaptureDateTime, patchUid, patchInfo, tagId);
             return true;
@@ -797,8 +797,8 @@ public class NFCReaderX {
             //       getGlucose(new byte[]{data[(i * 6 + 125)], data[(i * 6 + 124)]});
 
             // If the data is decoded for some reason, we might have a wrong index.
-
-            if(i * 6 + 125 >= data.length) {
+            // The 6 is because we read up to 6 bytes.
+            if(i * 6 + 124 + 6 >= data.length) {
                 Log.e(TAG, "Failing to parse data from " + JoH.dateTimeText(CaptureDateTime));
                 return null;
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -45,6 +45,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 
 import com.eveningoutpost.dexdrip.Models.LibreOOPAlgorithm.SensorType;
+import com.eveningoutpost.dexdrip.utils.LibreTrendUtil;
 
 
 import java.io.IOException;
@@ -770,6 +771,14 @@ public class NFCReaderX {
         }
 
     }
+    public static boolean verifyTime(long time, String caller, byte[] extra_data) {
+        if((time < 0 ) || time >= LibreTrendUtil.MAX_POINTS) {
+            // This is an illegal value
+            Log.e(TAG, "We have an illegal time at " + caller + " " + time + JoH.bytesToHex(extra_data));
+            return false;
+        }
+        return true;
+    }
 
     public static ReadingData parseData(int attempt, String tagId, byte[] data, Long CaptureDateTime) {
 
@@ -813,7 +822,9 @@ public class NFCReaderX {
 
             glucoseData.realDate = sensorStartTime + time * MINUTE;
             glucoseData.sensorTime = time;
-            historyList.add(glucoseData);
+            if(verifyTime(time, "parseData history", data)) {
+                historyList.add(glucoseData);
+            }
         }
 
 
@@ -839,7 +850,9 @@ public class NFCReaderX {
 
             glucoseData.realDate = sensorStartTime + time * MINUTE;
             glucoseData.sensorTime = time;
-            trendList.add(glucoseData);
+            if(verifyTime(time, "parseData trendList", data)) {
+                trendList.add(glucoseData);
+            }
         }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/LibreTrendUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/LibreTrendUtil.java
@@ -76,7 +76,7 @@ public class LibreTrendUtil {
     private static LibreTrendUtil singleton;
     private static final String TAG = "LibreTrendGraph";
     private static final boolean debug_per_minute = false;
-    final int MAX_POINTS = 16 * 24 * 60; // Assume that there will not be data for longer than 14 days + some extra.
+    public final static int MAX_POINTS = 16 * 24 * 60; // Assume that there will not be data for longer than 14 days + some extra.
 
     private LibreTrendLatest m_libreTrendLatest;
     

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/LibreTrendUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/LibreTrendUtil.java
@@ -71,6 +71,23 @@ class LibreTrendLatest {
     }
 }
 
+class LazyLibreList extends ArrayList<LibreTrendPoint> {
+
+    public LazyLibreList(int max_points) {
+        super(max_points);
+    }
+
+    @Override
+    public LibreTrendPoint get(int index) {
+        LibreTrendPoint v = super.get(index);
+        if (v == null) {
+            v = new LibreTrendPoint();
+            super.set(index, v);
+        }
+        return v;
+    }
+}
+
 public class LibreTrendUtil {
 
     private static LibreTrendUtil singleton;
@@ -105,10 +122,7 @@ public class LibreTrendUtil {
     }
     
     void ResetPoints() {
-        m_points = new ArrayList<LibreTrendPoint>(MAX_POINTS);
-        while(m_points.size() < MAX_POINTS) {
-            m_points.add(m_points.size(), new LibreTrendPoint());
-        }
+        m_points = new LazyLibreList(MAX_POINTS);
     }
     
     void Reset() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/LibreTrendUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/LibreTrendUtil.java
@@ -75,6 +75,9 @@ class LazyLibreList extends ArrayList<LibreTrendPoint> {
 
     public LazyLibreList(int max_points) {
         super(max_points);
+        while(super.size() < max_points) {
+            super.add(null);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/LibreTrendUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/LibreTrendUtil.java
@@ -12,6 +12,7 @@ import com.eveningoutpost.dexdrip.Models.GlucoseData;
 import com.eveningoutpost.dexdrip.Models.LibreBlock;
 import com.eveningoutpost.dexdrip.Models.ReadingData;
 
+import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.utils.LibreTrendPoint;
 
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
@@ -83,7 +84,10 @@ public class LibreTrendUtil {
 
     public void updateLastReading(LibreBlock libreBlock) {
         // Before we update m_libreTrendLatest we call getData as it affects the cache.
-        getData(m_libreTrendLatest.timestamp, libreBlock.timestamp, false);
+        // If there is no timestamp, only take the last 60 minutes.
+        long startTime = m_libreTrendLatest.timestamp > 0 ? m_libreTrendLatest.timestamp :
+                libreBlock.timestamp - 60 * Constants.MINUTE_IN_MS;
+        getData(startTime, libreBlock.timestamp, false);
         m_libreTrendLatest.updateLastReading(libreBlock);
     }
 


### PR DESCRIPTION

The main issue fixed here is that fact that on a first call of LibreTrendUtil.getData the value of m_libreTrendLatest.timestamp might be zero. In this case the data that will be read from the DB will be the entire data.
Depending on how big your DB is, it might take a long time, and creates an ANR.
After that, xdrip might also remove LibreTrendUtil from memory.

The fix is simple: only read the last 60 minutes if nothing else was specified.
