### PR TITLE
add Java 11 compatibility and cleanup build scripts

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,11 +11,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java-version: [ 8, 11 ]
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        java-version: 8
+        java-version: ${{ matrix.java-version }}
         distribution: adopt
     - name: Run unit tests and assemble APKs
       uses: gradle/gradle-build-action@v2

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 apply plugin: 'com.android.application'
 apply from: 'token-replace.gradle'
 apply from: '../dependencies.gradle'
-
+apply from: '../common.gradle'
 
 if (project.file('local.gradle').exists()) {
     apply from: 'local.gradle'
@@ -36,83 +36,6 @@ repositories {
     flatDir {
         dirs 'libs'
     }
-}
-
-def generateVersionNumber = { ->
-    StringBuilder stringBuilder = new StringBuilder()
-    stringBuilder.append((new Date()).format('yyMMddHHmm'))
-    return Integer.parseInt(stringBuilder.toString())
-}
-
-def generateVersionNumberString = { ->
-    StringBuilder stringBuilder = new StringBuilder()
-    stringBuilder.append((new Date()).format('21yyMMddHH'))
-    return stringBuilder.toString()
-}
-
-def generateTimestamp = { ->
-    StringBuilder stringBuilder = new StringBuilder()
-    stringBuilder.append((new Date()).getTime())
-    stringBuilder.append("L")
-    return stringBuilder.toString()
-}
-
-def generateRandomUUID = { ->
-    StringBuilder stringBuilder = new StringBuilder()
-    stringBuilder.append('"' + UUID.randomUUID().toString() + '"')
-    return stringBuilder.toString()
-}
-
-def generateVersionName = { ->
-
-    StringBuilder stringBuilder = new StringBuilder()
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'describe', '--always'
-            standardOutput = stdout
-        }
-        String commitObject = stdout.toString().trim()
-        try {
-            stdout = new ByteArrayOutputStream()
-            exec {
-                commandLine 'git', 'describe', '--tags'
-                standardOutput = stdout
-            }
-            //stringBuilder.append(stdout.toString().trim())
-            //stringBuilder.append("-")
-        } catch (ignored) {
-            // no tags
-        }
-
-        stringBuilder.append(commitObject)
-        stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', '--show-toplevel'
-            standardOutput = stdout
-        }
-        if (stdout.toString().trim().contains("xDrip-Experimental")) {
-            stringBuilder.append("-experimental")
-        }
-
-        stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
-            standardOutput = stdout
-        }
-        String branch = stdout.toString().trim()
-        if (!branch.equals("master")) {
-            stringBuilder.append('-')
-            stringBuilder.append(branch)
-        }
-
-    } catch (ignored) {
-        return "NoGitSystemAvailable"
-    }
-    stringBuilder.append('-')
-    stringBuilder.append((new Date()).format('yyyy.MM.dd'))
-    return stringBuilder.toString()
-
 }
 
 /**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,6 @@ buildscript {
 }
 apply plugin: 'com.android.application'
 apply from: 'token-replace.gradle'
-apply from: '../dependencies.gradle'
 apply from: '../common.gradle'
 
 if (project.file('local.gradle').exists()) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -219,6 +219,8 @@ android {
 
     packagingOptions {
         exclude 'META-INF/INDEX.LIST'
+        exclude 'META-INF/NOTICE.md'
+        exclude 'META-INF/LICENSE.md'
     }
 
     compileOptions {
@@ -304,6 +306,11 @@ dependencies {
     implementation project(':localeapi')
     //implementation 'com.nispok:snackbar:2.10.8'
 
+    // add missing JAXB dependencies for JDK 9+
+    if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {
+        annotationProcessor 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.3'
+        annotationProcessor 'org.glassfish.jaxb:jaxb-runtime:2.3.5'
+    }
 
     // use specific version of data binding until google resolves the bugs with mixed case package names
     //noinspection GradleDependency

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,7 @@
 buildscript {
+    repositories {
+        mavenCentral()
+    }
     dependencies {
         if (getGradle().getStartParameter().getTaskRequests().toString().contains("Release]")) {
             println("Enabling New Relic")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,4 @@
 buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
     dependencies {
         if (getGradle().getStartParameter().getTaskRequests().toString().contains("Release]")) {
             println("Enabling New Relic")
@@ -18,7 +13,6 @@ if (project.file('local.gradle').exists()) {
     apply from: 'local.gradle'
 }
 
-
 if (getGradle().getStartParameter().getTaskRequests().toString().contains("Release]")) {
     apply plugin: 'newrelic'
     newrelic {
@@ -26,27 +20,14 @@ if (getGradle().getStartParameter().getTaskRequests().toString().contains("Relea
         uploadMapsForVariant ''
     }
 }
-//apply plugin: 'me.tatarka.retrolambda'
-//apply plugin: 'io.fabric'
-
-//def AAVersion = '4.3.1'
-//dependencies {
-//    annotationProcessor "org.androidannotations:androidannotations:$AAVersion"
-//    implementation "org.androidannotations:androidannotations-api:$AAVersion"
-//}
-
 
 repositories {
-    maven {
-        url "https://maven.google.com"
-    }
     maven {
         url "https://raw.github.com/embarkmobile/zxing-android-minimal/mvn-repo/maven-repository/"
     }
     maven {
         url "https://jitpack.io"
     }
-    maven { url "https://oss.sonatype.org/content/groups/public/" }
     flatDir {
         dirs 'libs'
     }
@@ -67,12 +48,12 @@ def generateVersionNumberString = { ->
 def generateTimestamp = { ->
     StringBuilder stringBuilder = new StringBuilder()
     stringBuilder.append((new Date()).getTime())
-    stringBuilder.append("L");
+    stringBuilder.append("L")
     return stringBuilder.toString()
 }
 
 def generateRandomUUID = { ->
-    StringBuilder stringBuilder = new StringBuilder();
+    StringBuilder stringBuilder = new StringBuilder()
     stringBuilder.append('"' + UUID.randomUUID().toString() + '"')
     return stringBuilder.toString()
 }
@@ -291,8 +272,6 @@ android {
 
 }
 
-
-
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
@@ -304,22 +283,12 @@ dependencies {
     }
 
     implementation project(':localeapi')
-    //implementation 'com.nispok:snackbar:2.10.8'
 
     // add missing JAXB dependencies for JDK 9+
     if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {
         annotationProcessor 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.3'
         annotationProcessor 'org.glassfish.jaxb:jaxb-runtime:2.3.5'
     }
-
-    // use specific version of data binding until google resolves the bugs with mixed case package names
-    //noinspection GradleDependency
-    implementation 'com.android.databinding:adapters:3.1.4'
-    //noinspection GradleDependency
-    implementation 'com.android.databinding:library:3.1.4'
-    //noinspection GradleDependency
-    implementation 'com.android.databinding:baseLibrary:3.1.4'
-    //////
 
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:design:26.1.0'
@@ -396,7 +365,6 @@ dependencies {
     testImplementation 'org.powermock:powermock-classloading-xstream:1.7.1'
     testImplementation 'org.powermock:powermock-api-mockito2:1.7.1'
 
-
     androidTestImplementation(name: 'barista-1.7.0', ext: 'aar') {
         exclude group: 'com.android.support'
     }
@@ -415,7 +383,6 @@ dependencies {
 
     // you will want to install the android studio lombok plugin
     compileOnly 'org.projectlombok:lombok:1.18.10'
-    //  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
     annotationProcessor "org.projectlombok:lombok:1.18.10"
 
     // use lombok in unit tests
@@ -423,12 +390,12 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.10'
 }
 
-tasks.withType(Test) { 
-  testLogging {
-    exceptionFormat "full"
-    events "started", "skipped", "passed", "failed"
-    showStandardStreams true
-  }
+tasks.withType(Test) {
+    testLogging {
+        exceptionFormat "full"
+        events "started", "skipped", "passed", "failed"
+        showStandardStreams true
+    }
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,8 @@ buildscript {
 }
 apply plugin: 'com.android.application'
 apply from: 'token-replace.gradle'
+apply from: '../dependencies.gradle'
+
 
 if (project.file('local.gradle').exists()) {
     apply from: 'local.gradle'
@@ -382,12 +384,12 @@ dependencies {
     //androidTestImplementation 'com.android.support.test.espresso:espresso-web:3.0.1'
 
     // you will want to install the android studio lombok plugin
-    compileOnly 'org.projectlombok:lombok:1.18.10'
-    annotationProcessor "org.projectlombok:lombok:1.18.10"
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor "org.projectlombok:lombok"
 
     // use lombok in unit tests
-    testCompileOnly 'org.projectlombok:lombok:1.18.10'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.10'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.withType(Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,10 @@ buildscript {
         google()
         mavenCentral()
         maven { url "https://jitpack.io" }
-
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.3'
         classpath 'com.google.gms:google-services:4.3.3'
- //       classpath 'me.tatarka:gradle-retrolambda:3.7.0'
         classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.5'
 
         apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ buildscript {
         maven { url "https://jitpack.io" }
     }
     dependencies {
+        // Upgrading AGP to a newer version also updates the data binding library.
+        // This causes build failures with mixed case package names currently in use.
         classpath 'com.android.tools.build:gradle:3.4.3'
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'com.github.jamorham:ReplaceTokenPreprocessor:1.5'

--- a/common.gradle
+++ b/common.gradle
@@ -8,7 +8,7 @@ configurations.all {
 
 ext.generateVersionNumberString = { ->
     StringBuilder stringBuilder = new StringBuilder()
-    stringBuilder.append((new Date()).format('21yyMMddHHmm'))
+    stringBuilder.append((new Date()).format('21yyMMddHH'))
     return stringBuilder.toString()
 }
 

--- a/common.gradle
+++ b/common.gradle
@@ -1,0 +1,76 @@
+configurations.all {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'org.projectlombok') {
+            details.useVersion "1.18.20"
+        }
+    }
+}
+
+ext.generateVersionNumberString = { ->
+    StringBuilder stringBuilder = new StringBuilder()
+    stringBuilder.append((new Date()).format('21yyMMddHHmm'))
+    return stringBuilder.toString()
+}
+
+ext.generateTimestamp = { ->
+    StringBuilder stringBuilder = new StringBuilder()
+    stringBuilder.append((new Date()).getTime())
+    stringBuilder.append("L")
+    return stringBuilder.toString()
+}
+
+ext.generateRandomUUID = { ->
+    StringBuilder stringBuilder = new StringBuilder()
+    stringBuilder.append('"' + UUID.randomUUID().toString() + '"')
+    return stringBuilder.toString()
+}
+
+ext.generateVersionName = { ->
+    StringBuilder stringBuilder = new StringBuilder()
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'describe', '--always'
+            standardOutput = stdout
+        }
+        String commitObject = stdout.toString().trim()
+        try {
+            stdout = new ByteArrayOutputStream()
+            exec {
+                commandLine 'git', 'describe', '--tags'
+                standardOutput = stdout
+            }
+            //stringBuilder.append(stdout.toString().trim())
+            //stringBuilder.append("-")
+        } catch (ignored) {
+            // no tags
+        }
+
+        stringBuilder.append(commitObject)
+        stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-parse', '--show-toplevel'
+            standardOutput = stdout
+        }
+        if (stdout.toString().trim().contains("xDrip-Experimental")) {
+            stringBuilder.append("-experimental")
+        }
+
+        stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
+            standardOutput = stdout
+        }
+        String branch = stdout.toString().trim()
+        if (!branch.equals("master")) {
+            stringBuilder.append('-')
+            stringBuilder.append(branch)
+        }
+
+    } catch (ignored) {
+        return "NoGitSystemAvailable"
+    }
+    stringBuilder.append('-')
+    stringBuilder.append((new Date()).format('yyyy.MM.dd'))
+    return stringBuilder.toString()
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,7 @@
+configurations.all {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'org.projectlombok') {
+            details.useVersion "1.18.22"
+        }
+    }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,0 @@
-configurations.all {
-    resolutionStrategy.eachDependency { details ->
-        if (details.requested.group == 'org.projectlombok') {
-            details.useVersion "1.18.22"
-        }
-    }
-}

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
-    }
-
-}
-
-
 def generateVersionNumberString = { ->
     StringBuilder stringBuilder = new StringBuilder()
     stringBuilder.append((new Date()).format('21yyMMddHH'))
@@ -84,8 +71,6 @@ def generateVersionName = { ->
 
 apply plugin: 'com.android.application'
 apply from: '../app/token-replace.gradle'
-//apply plugin: 'me.tatarka.retrolambda'
-//apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 29
@@ -154,7 +139,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    
+
     flavorDimensions "version"
     productFlavors {
         // When building a variant that uses this flavor, the following configurations
@@ -183,17 +168,8 @@ android {
 
 allprojects {
     repositories {
-        google()
-        mavenCentral()
-        maven {
-            url "https://jitpack.io"
-        }
-
         flatDir {
-            dirs 'libs'
-        }
-        flatDir {
-            dirs '../app/libs'
+            dirs 'libs', '../app/libs'
         }
     }
 }
@@ -203,20 +179,16 @@ dependencies {
     compileOnly 'com.google.android.wearable:wearable:2.5.0'
     implementation 'com.google.android.support:wearable:2.5.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    // implementation 'com.google.android.support:wearable:1.4.0'
-    //implementation 'com.google.android.gms:play-services-wearable:9.4.0'
-    // FIX upgrage to play-services-wearable:17.0.0 requires upgrade to AndroidX libraries, https://developers.google.com/android/guides/releases#june_17_2019
+    // FIX upgrade to play-services-wearable:17.0.0 requires upgrade to AndroidX libraries, https://developers.google.com/android/guides/releases#june_17_2019
     implementation 'com.google.android.gms:play-services-wearable:10.2.1'
     implementation 'com.squareup.wire:wire-runtime:2.2.0'
     //implementation 'com.ustwo.android:clockwise-wearable:1.0.2'
-    //implementation files('libs/hellocharts-library-1.5.5.jar')
     implementation(name: 'ustwo-clockwise-debug', ext: 'aar')
     implementation(name: 'wearpreferenceactivity-0.5.0', ext: 'aar')
     implementation 'com.google.code.gson:gson:2.8.6'
 
     implementation 'com.tananaev:adblib:1.3'
 
-    //implementation 'io.reactivex:rxjava:1.3.2'
     implementation(name: 'thread-safe-active-android-3.1.1', ext: 'aar')
     implementation 'com.google.guava:guava:24.1-jre'
     implementation 'io.reactivex:rxjava:1.3.3'
@@ -234,9 +206,8 @@ dependencies {
     implementation 'uk.com.robust-it:cloning:1.9.5'
     // you will want to install the android studio lombok plugin
     compileOnly 'org.projectlombok:lombok:1.18.10'
-//    compileOnly 'javax.annotation:javax.annotation-api:1.3.1'
     annotationProcessor "org.projectlombok:lombok:1.18.10"
-      // use lombok in unit tests
+    // use lombok in unit tests
     testCompileOnly 'org.projectlombok:lombok:1.18.10'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.10'
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -71,6 +71,7 @@ def generateVersionName = { ->
 
 apply plugin: 'com.android.application'
 apply from: '../app/token-replace.gradle'
+apply from: '../dependencies.gradle'
 
 android {
     compileSdkVersion 29
@@ -205,9 +206,9 @@ dependencies {
 
     implementation 'uk.com.robust-it:cloning:1.9.5'
     // you will want to install the android studio lombok plugin
-    compileOnly 'org.projectlombok:lombok:1.18.10'
-    annotationProcessor "org.projectlombok:lombok:1.18.10"
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor "org.projectlombok:lombok"
     // use lombok in unit tests
-    testCompileOnly 'org.projectlombok:lombok:1.18.10'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.10'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply from: '../app/token-replace.gradle'
-apply from: '../dependencies.gradle'
 apply from: '../common.gradle'
 
 android {

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -1,77 +1,7 @@
-def generateVersionNumberString = { ->
-    StringBuilder stringBuilder = new StringBuilder()
-    stringBuilder.append((new Date()).format('21yyMMddHH'))
-    return stringBuilder.toString()
-}
-
-def generateTimestamp = { ->
-    StringBuilder stringBuilder = new StringBuilder()
-    stringBuilder.append((new Date()).getTime())
-    stringBuilder.append("L")
-    return stringBuilder.toString()
-}
-
-def generateRandomUUID = { ->
-    StringBuilder stringBuilder = new StringBuilder();
-    stringBuilder.append('"' + UUID.randomUUID().toString() + '"')
-    return stringBuilder.toString()
-}
-
-def generateVersionName = { ->
-
-    StringBuilder stringBuilder = new StringBuilder()
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'describe', '--always'
-            standardOutput = stdout
-        }
-        String commitObject = stdout.toString().trim()
-        try {
-            stdout = new ByteArrayOutputStream()
-            exec {
-                commandLine 'git', 'describe', '--tags'
-                standardOutput = stdout
-            }
-            //stringBuilder.append(stdout.toString().trim())
-            //stringBuilder.append("-")
-        } catch (ignored) {
-            // no tags
-        }
-
-        stringBuilder.append(commitObject)
-        stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', '--show-toplevel'
-            standardOutput = stdout
-        }
-        if (stdout.toString().trim().contains("xDrip-Experimental")) {
-            stringBuilder.append("-experimental")
-        }
-
-        stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
-            standardOutput = stdout
-        }
-        String branch = stdout.toString().trim()
-        if (!branch.equals("master")) {
-            stringBuilder.append('-')
-            stringBuilder.append(branch)
-        }
-
-    } catch (ignored) {
-        return "NoGitSystemAvailable"
-    }
-    stringBuilder.append('-')
-    stringBuilder.append((new Date()).format('yyyy.MM.dd'))
-    return stringBuilder.toString()
-
-}
-
 apply plugin: 'com.android.application'
 apply from: '../app/token-replace.gradle'
 apply from: '../dependencies.gradle'
+apply from: '../common.gradle'
 
 android {
     compileSdkVersion 29
@@ -115,18 +45,19 @@ android {
     }
 
     testOptions {
+        animationsDisabled = true
         unitTests {
             includeAndroidResources = true
         }
     }
 
+    packagingOptions {
+        exclude 'META-INF/INDEX.LIST'
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    packagingOptions {
-        exclude 'META-INF/INDEX.LIST'
     }
 
     dataBinding {
@@ -137,7 +68,8 @@ android {
         release {
             minifyEnabled true
             shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android.txt'),
+                    'proguard-rules.pro'
         }
     }
 

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -226,6 +226,11 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "com.google.truth:truth:1.1.3"
 
+    // add missing JAXB dependencies for JDK 9+
+    if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {
+        annotationProcessor 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.3'
+    }
+
     implementation 'uk.com.robust-it:cloning:1.9.5'
     // you will want to install the android studio lombok plugin
     compileOnly 'org.projectlombok:lombok:1.18.10'

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -220,7 +220,7 @@
     <string name="bluereaderoff">blueReader will be turn off, as the battery is lower then </string>
     <string name="bluereader_position">Check position of blueReader on the sensor, as it was not able to read!</string>
     <string name="bluereaderuglystate">The blueReader was found in an ugly state! It will be now turn off now, and you turn it back to on (short press of the button). After that the blueReader should work as expected!</string>
-    <string name="xdrip_software_changed_format">xDrip WATCH software version changed from: %s to %s</string>
+    <string name="xdrip_software_changed_format">xDrip WATCH software version changed from: %1$s to %2$s</string>
     <string name="summary_always_on_screen">Force screen always on prior to BT scanning</string>
     <string name="title_always_on_screen">Force Screen Always-on</string>
     <string name="sumary_alert_use_sounds">Use watch speaker if it has one to play alert sound</string>


### PR DESCRIPTION
To make xDrip forward compatible and use features made available with Android 12 (i. e. new Bluetooth Scan without enabling GPS) it have to be compiled against Android SDK 31 (`compileSdkVersion 31`). This SDK requires at least Java 11. Unfortunately, the [Java Architecture for XML Binding (JAXB)](https://www.oracle.com/technical-resources/articles/javase/jaxb.html) required for data binding is not part of Java 11 anymore [^1]<sup>,</sup>[^2]. This results in the following error during build:

```
org.gradle.execution.MultipleBuildFailures: Build completed with 1 failures. Caused by:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':app:compileDebugJavaWithJavac'.
Caused by: java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException
```

For Java 9 and 10 it can be enabled with a JVM argument `--add-modules` but this is not possible for Java 11 anymore.

This PR adds the JAXB dependencies if required (Java version >= 9) and also cleans up the Gradle build files.

[^1]: [JEP-320](https://openjdk.java.net/jeps/320)
[^2]: [JAXB on Java 9, 10, 11 and beyond](https://jesperdj.com/2018/09/30/jaxb-on-java-9-10-11-and-beyond)
