### PR TITLE
DexShareFollow service to support trend as a number and as a string

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Dex_Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Dex_Constants.java
@@ -93,7 +93,7 @@ public class Dex_Constants {
         SINGLE_DOWN(6,"\u2193", "SingleDown", -2d),
         DOUBLE_DOWN(7,"\u21CA", "DoubleDown", -3.5d),
         NOT_COMPUTABLE(8, "", "NotComputable"),
-        OUT_OF_RANGE(9, "", "OutOfRange");
+        OUT_OF_RANGE(9, "", "RateOutOfRange");
 
         private String arrowSymbol;
         private String trendName;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Dex_Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Dex_Constants.java
@@ -92,8 +92,8 @@ public class Dex_Constants {
         DOWN_45(5,"\u2198", "FortyFiveDown", -1d),
         SINGLE_DOWN(6,"\u2193", "SingleDown", -2d),
         DOUBLE_DOWN(7,"\u21CA", "DoubleDown", -3.5d),
-        NOT_COMPUTABLE(8, "", "NOT_COMPUTABLE"),
-        OUT_OF_RANGE(9, "", "OUT_OF_RANGE");
+        NOT_COMPUTABLE(8, "", "NotComputable"),
+        OUT_OF_RANGE(9, "", "OutOfRange");
 
         private String arrowSymbol;
         private String trendName;
@@ -131,9 +131,9 @@ public class Dex_Constants {
 
         public String friendlyTrendName() {
             if (trendName == null) {
-                return this.name().replace("_", " ");
+                return name().replace("_", " ");
             } else {
-                return this.trendName;
+                return trendName;
             }
         }
 
@@ -160,6 +160,26 @@ public class Dex_Constants {
                 if (trend.trendName.equalsIgnoreCase(value))
                     return trend.threshold;
             throw new IllegalArgumentException();
+        }
+
+        public static TREND_ARROW_VALUES getEnum(int id) {
+            for (TREND_ARROW_VALUES t : values()) {
+                if (t.myID == id)
+                    return t;
+            }
+            return OUT_OF_RANGE;
+        }
+
+        public static TREND_ARROW_VALUES getEnum(String value) {
+            try {
+                int val = Integer.parseInt(value);
+                return getEnum(val);
+            } catch (NumberFormatException e) {
+                for (TREND_ARROW_VALUES trend : values())
+                    if (trend.friendlyTrendName().equalsIgnoreCase(value) || trend.name().equalsIgnoreCase(value))
+                        return trend;
+            }
+            return OUT_OF_RANGE;
         }
 
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/RetrofitBase.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/RetrofitBase.java
@@ -50,9 +50,9 @@ public class RetrofitBase {
                     httpLoggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
                 }
                 final OkHttpClient client = enableTls12OnPreLollipop(new OkHttpClient.Builder())
-                        .addInterceptor(httpLoggingInterceptor)
                         .addInterceptor(new InfoInterceptor(TAG))
                         .addInterceptor(useGzip ? new GzipRequestInterceptor() : new NullInterceptor())
+                        .addInterceptor(httpLoggingInterceptor)
                         .build();
 
                 instances.put(TAG, instance = new retrofit2.Retrofit.Builder()

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/RetrofitBase.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/RetrofitBase.java
@@ -2,16 +2,21 @@ package com.eveningoutpost.dexdrip.cgm.sharefollow;
 
 import android.support.annotation.NonNull;
 
+import com.eveningoutpost.dexdrip.ImportedLibraries.dexcom.Dex_Constants;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.GzipRequestInterceptor;
 import com.eveningoutpost.dexdrip.tidepool.InfoInterceptor;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.concurrent.ConcurrentHashMap;
 
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
@@ -33,6 +38,13 @@ public class RetrofitBase {
 
     private static final ConcurrentHashMap<String, Retrofit> instances = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, String> urls = new ConcurrentHashMap<>();
+
+    private static Converter.Factory createGsonConverter(Type type, Object typeAdapter) {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(type, typeAdapter);
+        Gson gson = gsonBuilder.create();
+        return GsonConverterFactory.create(gson);
+    }
 
     // TODO make fully reusable
     public static Retrofit getRetrofitInstance(final String TAG, final String url, boolean useGzip) throws IllegalArgumentException {
@@ -58,7 +70,7 @@ public class RetrofitBase {
                 instances.put(TAG, instance = new retrofit2.Retrofit.Builder()
                         .baseUrl(url)
                         .client(client)
-                        .addConverterFactory(GsonConverterFactory.create())
+                        .addConverterFactory(createGsonConverter(Dex_Constants.TREND_ARROW_VALUES.class, new ShareTrendDeserializer()))
                         .build());
                 urls.put(TAG, url); // save creation url for quick search
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareGlucoseRecord.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareGlucoseRecord.java
@@ -1,5 +1,6 @@
 package com.eveningoutpost.dexdrip.cgm.sharefollow;
 
+import com.eveningoutpost.dexdrip.ImportedLibraries.dexcom.Dex_Constants;
 import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.UtilityModels.Unitized;
@@ -23,37 +24,15 @@ public class ShareGlucoseRecord {
     public String WT;
 
     @Expose
-    public double Trend;
+    public Dex_Constants.TREND_ARROW_VALUES Trend;
 
     @Expose
     public double Value;
 
     public long timestamp = -1;
 
-
-    public String slopeDirection() {
-        switch ((int) Trend) {
-            case 1:
-                return "DoubleUp";
-            case 2:
-                return "SingleUp";
-            case 3:
-                return "FortyFiveUp";
-            case 4:
-                return "Flat";
-            case 5:
-                return "FortyFiveDown";
-            case 6:
-                return "SingleDown";
-            case 7:
-                return "DoubleDown";
-            default:
-                return "";
-        }
-    }
-
     public Double slopePerMsFromDirection() {
-        final String slope_name = slopeDirection();
+        final String slope_name = Trend.trendName();
         return slope_name == null ? null : BgReading.slopefromName(slope_name);
     }
 
@@ -69,7 +48,7 @@ public class ShareGlucoseRecord {
     }
 
     public String toS() {
-        return DT + " " + ST + " " + WT + " " + Value + " " + Trend + " " + JoH.dateTimeText(getTimestamp()) + " " + Unitized.unitized_string_static(Value) + " " + slopeDirection();
+        return DT + " " + ST + " " + WT + " " + Value + " " + Trend + " " + JoH.dateTimeText(getTimestamp()) + " " + Unitized.unitized_string_static(Value) + " " + Trend.trendName();
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareTrendDeserializer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareTrendDeserializer.java
@@ -1,0 +1,16 @@
+package com.eveningoutpost.dexdrip.cgm.sharefollow;
+
+import com.eveningoutpost.dexdrip.ImportedLibraries.dexcom.Dex_Constants;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
+public class ShareTrendDeserializer implements JsonDeserializer<Dex_Constants.TREND_ARROW_VALUES> {
+    @Override
+    public Dex_Constants.TREND_ARROW_VALUES deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+        return Dex_Constants.TREND_ARROW_VALUES.getEnum(jsonElement.getAsString());
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareGlucoseRecordTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareGlucoseRecordTest.java
@@ -1,26 +1,67 @@
 package com.eveningoutpost.dexdrip.cgm.sharefollow;
 
+import com.eveningoutpost.dexdrip.ImportedLibraries.dexcom.Dex_Constants;
 import com.eveningoutpost.dexdrip.Models.BgReading;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+
 import static com.google.common.truth.Truth.assertWithMessage;
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ShareGlucoseRecordTest {
 
-    @Test
-    public void slopeDirectionTest() {
-        // TODO
+    private GsonBuilder gsonBuilder;
+    private static Gson gson;
+
+    @BeforeClass
+    public static void setUp() {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(Dex_Constants.TREND_ARROW_VALUES.class, new ShareTrendDeserializer());
+        gson = gsonBuilder.create();
     }
 
     @Test
     public void slopePerMsFromDirectionTest() {
-
         for (int direction = 1; direction < 8; direction++) {
             final ShareGlucoseRecord record = new ShareGlucoseRecord();
-            record.Trend = direction;
-            assertWithMessage("Slope check " + direction).that(BgReading.slopeName(record.slopePerMsFromDirection() * 60000)).isEqualTo(record.slopeDirection());
+            record.Trend = Dex_Constants.TREND_ARROW_VALUES.getEnum(direction);
+            assertWithMessage("Slope check " + direction).that(BgReading.slopeName(record.slopePerMsFromDirection() * 60000)).isEqualTo(record.Trend.friendlyTrendName());
         }
-
     }
+
+    @Test
+    public void deserializeTrendNumber() {
+        String json = "{\"WT\":\"Date(1638396953000)\",\"ST\":\"Date(1638396953000)\",\"DT\":\"Date(1638396953000+0000)\",\"Value\":167,\"Trend\":4,\"extraString\":\"two\",\"extraFloat\":2.2}";
+        ShareGlucoseRecord record = gson.fromJson(json, ShareGlucoseRecord.class);
+        assertEquals(new Double(167), record.Value);
+        assertEquals(Dex_Constants.TREND_ARROW_VALUES.FLAT, record.Trend);
+    }
+
+    @Test
+    public void deserializeTrendText() {
+        String json = "{\"WT\":\"Date(1638396953000)\",\"ST\":\"Date(1638396953000)\",\"DT\":\"Date(1638396953000+0000)\",\"Value\":167,\"Trend\":\"Flat\"}";
+        ShareGlucoseRecord record = gson.fromJson(json, ShareGlucoseRecord.class);
+        assertEquals(new Double(167), record.Value);
+        assertEquals(Dex_Constants.TREND_ARROW_VALUES.FLAT, record.Trend);
+    }
+
+    @Test
+    public void deserializeIntoArray() {
+        String json = "[{\"WT\":\"Date(1638396953000)\",\"ST\":\"Date(1638396953000)\",\"DT\":\"Date(1638396953000+0000)\",\"Value\":167,\"Trend\":\"Flat\"},{\"WT\":\"Date(1638386459000)\",\"ST\":\"Date(1638386459000)\",\"DT\":\"Date(1638386459000+0000)\",\"Value\":147,\"Trend\":\"SINGLE_DOWN\"}]";
+        Type targetClassType = new TypeToken<ArrayList<ShareGlucoseRecord>>() { }.getType();
+        Collection<ShareGlucoseRecord> records = gson.fromJson(json, targetClassType);
+        assertTrue(records instanceof ArrayList);
+        assertEquals(2, records.size());
+        assertEquals(Dex_Constants.TREND_ARROW_VALUES.SINGLE_DOWN, ((ArrayList<ShareGlucoseRecord>) records).get(1).Trend);
+    }
+
 }

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Constants.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Constants.java
@@ -94,8 +94,8 @@ public class Constants {
         DOWN_45(5,"\u2198", "FortyFiveDown", -1d),
         SINGLE_DOWN(6,"\u2193", "SingleDown", -2d),
         DOUBLE_DOWN(7,"\u21CA", "DoubleDown", -3.5d),
-        NOT_COMPUTABLE(8, "", "NOT_COMPUTABLE"),
-        OUT_OF_RANGE(9, "", "OUT_OF_RANGE");
+        NOT_COMPUTABLE(8, "", "NotComputable"),
+        OUT_OF_RANGE(9, "", "OutOfRange");
 
         private String arrowSymbol;
         private String trendName;
@@ -114,6 +114,7 @@ public class Constants {
             this.trendName = name;
             this.threshold = threshold;
         }
+
         TREND_ARROW_VALUES(int id) {
             this(id,null, null, null);
         }
@@ -132,20 +133,22 @@ public class Constants {
 
         public String friendlyTrendName() {
             if (trendName == null) {
-                return this.name().replace("_", " ");
+                return name().replace("_", " ");
             } else {
-                return this.trendName;
+                return trendName;
             }
         }
 
-        public int getID(){
+        public int getID() {
             return myID;
         }
+
         public static TREND_ARROW_VALUES getTrend(double value) {
             TREND_ARROW_VALUES finalTrend = NONE;
             for (TREND_ARROW_VALUES trend : values()) {
                 if (trend.threshold == null)
                     continue;
+
                 if (value > trend.threshold)
                     return finalTrend;
                 else
@@ -158,6 +161,26 @@ public class Constants {
                 if (trend.trendName.equalsIgnoreCase(value))
                     return trend.threshold;
             throw new IllegalArgumentException();
+        }
+
+        public static TREND_ARROW_VALUES getEnum(int id) {
+            for (TREND_ARROW_VALUES t : values()) {
+                if (t.myID == id)
+                    return t;
+            }
+            return OUT_OF_RANGE;
+        }
+
+        public static TREND_ARROW_VALUES getEnum(String value) {
+            try {
+                int val = Integer.parseInt(value);
+                return getEnum(val);
+            } catch (NumberFormatException e) {
+                for (TREND_ARROW_VALUES trend : values())
+                    if (trend.friendlyTrendName().equalsIgnoreCase(value) || trend.name().equalsIgnoreCase(value))
+                        return trend;
+            }
+            return OUT_OF_RANGE;
         }
 
     }

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Constants.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Constants.java
@@ -95,7 +95,7 @@ public class Constants {
         SINGLE_DOWN(6,"\u2193", "SingleDown", -2d),
         DOUBLE_DOWN(7,"\u21CA", "DoubleDown", -3.5d),
         NOT_COMPUTABLE(8, "", "NotComputable"),
-        OUT_OF_RANGE(9, "", "OutOfRange");
+        OUT_OF_RANGE(9, "", "RateOutOfRange");
 
         private String arrowSymbol;
         private String trendName;

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Dex_Constants.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Dex_Constants.java
@@ -93,7 +93,7 @@ public class Dex_Constants {
         SINGLE_DOWN(6,"\u2193", "SingleDown", -2d),
         DOUBLE_DOWN(7,"\u21CA", "DoubleDown", -3.5d),
         NOT_COMPUTABLE(8, "", "NotComputable"),
-        OUT_OF_RANGE(9, "", "OutOfRange");
+        OUT_OF_RANGE(9, "", "RateOutOfRange");
 
         private String arrowSymbol;
         private String trendName;

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Dex_Constants.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Dex_Constants.java
@@ -92,8 +92,8 @@ public class Dex_Constants {
         DOWN_45(5,"\u2198", "FortyFiveDown", -1d),
         SINGLE_DOWN(6,"\u2193", "SingleDown", -2d),
         DOUBLE_DOWN(7,"\u21CA", "DoubleDown", -3.5d),
-        NOT_COMPUTABLE(8, "", "NOT_COMPUTABLE"),
-        OUT_OF_RANGE(9, "", "OUT_OF_RANGE");
+        NOT_COMPUTABLE(8, "", "NotComputable"),
+        OUT_OF_RANGE(9, "", "OutOfRange");
 
         private String arrowSymbol;
         private String trendName;
@@ -131,9 +131,9 @@ public class Dex_Constants {
 
         public String friendlyTrendName() {
             if (trendName == null) {
-                return this.name().replace("_", " ");
+                return name().replace("_", " ");
             } else {
-                return this.trendName;
+                return trendName;
             }
         }
 
@@ -160,6 +160,26 @@ public class Dex_Constants {
                 if (trend.trendName.equalsIgnoreCase(value))
                     return trend.threshold;
             throw new IllegalArgumentException();
+        }
+
+        public static TREND_ARROW_VALUES getEnum(int id) {
+            for (TREND_ARROW_VALUES t : values()) {
+                if (t.myID == id)
+                    return t;
+            }
+            return OUT_OF_RANGE;
+        }
+
+        public static TREND_ARROW_VALUES getEnum(String value) {
+            try {
+                int val = Integer.parseInt(value);
+                return getEnum(val);
+            } catch (NumberFormatException e) {
+                for (TREND_ARROW_VALUES trend : values())
+                    if (trend.friendlyTrendName().equalsIgnoreCase(value) || trend.name().equalsIgnoreCase(value))
+                        return trend;
+            }
+            return OUT_OF_RANGE;
         }
 
     }


### PR DESCRIPTION
On 1 December 2021, Dexcom changed their EU servers to serve the trend arrow in text representation (i. e. "Flat") instead of the former numerical representation (i. e. 4 [= flat]). This PR supports both representations.

Fixes #1884