### PR TITLE
Update channel selection dependency

### DIFF
--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -985,7 +985,6 @@
             android:title="@string/automatic_update_check" />
         <ListPreference
             android:defaultValue="beta"
-            android:dependency="auto_update_download"
             android:entries="@array/UpdateChannelDetail"
             android:entryValues="@array/UpdateChannel"
             android:key="update_channel"


### PR DESCRIPTION
The following image shows the xDrip Update Settings page.
![Screenshot_20211207-113642](https://user-images.githubusercontent.com/51497406/145070372-c7c061b3-e5af-4893-aeb8-7eafbb74e8ba.png)

The option to update the channel is only available if the "Automatic update check" is enabled.  If it is disabled, the setting is grayed out.  
However, the selected channel doesn't just affect the behavior of xDrip when automatic update check is enabled.
Even if it is disabled, you can manually check for updates from the top right menu button from the main screen (3 dots). 

This PR removes the dependency.  So, the setting to change the update channel becomes available (not grayed out any more) regardless of the automatic update check setting.  

**Why do we need this?**
There are users who like to disable automatic update check and check for it manually.  This PR allows them to do that and easily select the channel setting they like to be on.    