### PR TITLE
Discussions before issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: xDrip Discussions
-    url: https://github.com/Navid200/xDrip/discussions
+    url: https://github.com/NightscoutFoundation/xDrip/discussions
     about: If you are an xDrip user and need support (how to, new feature, or bug), please post here. It's a forum. So, all posts related to your question or proposal stay together and are easy to find. All developers and users can access them.
   - name: xDrip Community Support at Gitter
     url: https://gitter.im/jamorham/xDrip-plus

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Reporting Issues with xDrip
 
 Before opening an issue, please communicate with us by posting in the support channels:  
+https://github.com/Navid200/xDrip/discussions  
 https://www.facebook.com/groups/xDripG5  
 https://gitter.im/jamorham/xDrip-plus  
 We will encourage you to open an issue if it is not already known and there is no work-around.  
 
-### Please try to provide as much information as possible when raising an issue:
+### Please provide as much information as possible when communicating your concerns with us:
 
 * If it is a bug, please try to explain how to reproduce it, roughly which settings you are using, what you are seeing or not seeing. Screenshots welcomed.
 * If it relates to a new feature, please explain the rationale for the feature, use cases and detail your suggestion.  
@@ -16,7 +17,7 @@ We will encourage you to open an issue if it is not already known and there is n
 
 Patches are welcomed! To ensure the best all round results they need be a good fit with the project roadmap, the ecosystem of users and respect overall project stability and good practice.
 
-The best way to get patches accepted is to discuss your ideas with project maintainers prior to implementation and discuss how to structure things so that they can fit well within the project and also the rationale for the change.
+The best way to get patches accepted is to discuss your ideas with project maintainers using [Discussions](https://github.com/Navid200/xDrip/discussions) prior to implementation and discuss how to structure things so that they can fit well within the project and also the rationale for the change.  
 
 #### Project reviewers are likely to use criteria similar to that outlined below:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ We will encourage you to open an issue if it is not already known and there is n
 
 Patches are welcomed! To ensure the best all round results they need be a good fit with the project roadmap, the ecosystem of users and respect overall project stability and good practice.
 
-The best way to get patches accepted is to discuss your ideas with project maintainers using [Discussions](https://github.com/NightscoutFoundation/xDrip/discussions) prior to implementation and discuss how to structure things so that they can fit well within the project and also the rationale for the change.  
+The best way to get patches accepted is to discuss your ideas with project maintainers using [Discussions](https://github.com/NightscoutFoundation/xDrip/discussions) prior to implementation and discuss how to structure things so that they can fit well within the project and also the rationale for the change.
 
 #### Project reviewers are likely to use criteria similar to that outlined below:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Reporting Issues with xDrip
 
 Before opening an issue, please communicate with us by posting in the support channels:  
-https://github.com/Navid200/xDrip/discussions  
+https://github.com/NightscoutFoundation/xDrip/discussions    
 https://www.facebook.com/groups/xDripG5  
 https://gitter.im/jamorham/xDrip-plus  
 We will encourage you to open an issue if it is not already known and there is no work-around.  
@@ -17,7 +17,7 @@ We will encourage you to open an issue if it is not already known and there is n
 
 Patches are welcomed! To ensure the best all round results they need be a good fit with the project roadmap, the ecosystem of users and respect overall project stability and good practice.
 
-The best way to get patches accepted is to discuss your ideas with project maintainers using [Discussions](https://github.com/Navid200/xDrip/discussions) prior to implementation and discuss how to structure things so that they can fit well within the project and also the rationale for the change.  
+The best way to get patches accepted is to discuss your ideas with project maintainers using [Discussions](https://github.com/NightscoutFoundation/xDrip/discussions) prior to implementation and discuss how to structure things so that they can fit well within the project and also the rationale for the change.  
 
 #### Project reviewers are likely to use criteria similar to that outlined below:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Your data is yours and can be exported in many different ways. xDrip also interc
 * More Nightscout and APS integration
 
 ## Collaboration
-We are very happy if people want to collaborate with this project. Please contact us at [Discussions](https://github.com/Navid200/xDrip/discussions) if you want to get involved and study the [collaboration guidelines](CONTRIBUTING.md) before submitting any patches or pull requests.
+We are very happy if people want to collaborate with this project. Please contact us at [Discussions](https://github.com/NightscoutFoundation/xDrip/discussions) if you want to get involved and study the [collaboration guidelines](CONTRIBUTING.md) before submitting any patches or pull requests.
 
 ## Thanks
 None of this would be possible without all the hard work of the xDrip and Nightscout communities who have developed such excellent software and allowed us to build upon it.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Your data is yours and can be exported in many different ways. xDrip also interc
 * More Nightscout and APS integration
 
 ## Collaboration
-We are very happy if people want to collaborate with this project. Please contact us at [Gitter](https://gitter.im/jamorham/xDrip-plus) if you want to get involved and study the [collaboration guidelines](CONTRIBUTING.md) before submitting any patches or pull requests.
+We are very happy if people want to collaborate with this project. Please contact us at [Discussions](https://github.com/Navid200/xDrip/discussions) if you want to get involved and study the [collaboration guidelines](CONTRIBUTING.md) before submitting any patches or pull requests.
 
 ## Thanks
 None of this would be possible without all the hard work of the xDrip and Nightscout communities who have developed such excellent software and allowed us to build upon it.


### PR DESCRIPTION
This change asks contributors to use discussions to communicate with us before opening issues or PRs.

Before:  
![Screenshot 2021-12-23 112145](https://user-images.githubusercontent.com/51497406/147267817-097bdc57-66c9-4d36-a6be-fca8eaa13cc0.png)  

After:  
![Screenshot 2021-12-23 112259](https://user-images.githubusercontent.com/51497406/147267977-f73c5d31-d763-45c7-a885-cff546824796.png)

Before:  
![Screenshot 2021-12-23 112415](https://user-images.githubusercontent.com/51497406/147267689-e9b6b6aa-8144-410a-b894-b64e0d627d38.png)  

After:  
![Screenshot 2022-01-04 124503](https://user-images.githubusercontent.com/51497406/148101624-696671c1-2768-4829-bcd1-4279c7d9467b.png)
