### PR TITLE
execute unit tests just once

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -19,9 +19,9 @@ jobs:
         java-version: 1.8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Run Unit Tests
-      run: ./gradlew :app:testProdReleaseUnitTest :wear:testProdReleaseUnitTest
     - name: Run Compile Tests
       run: ./gradlew assembleRelease
+    - name: Run Unit Tests
+      run: ./gradlew :app:testProdReleaseUnitTest :wear:testProdReleaseUnitTest
     - name: Check Output
       run: bash ./etc/CheckBuild/check-release.sh test

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Run Unit Tests
-      run: ./gradlew test
+      run: ./gradlew :app:testProdDebugUnitTest :wear:testProdDebugUnitTest
     - name: Run Compile Tests
       run: ./gradlew assembleRelease
     - name: Check Output

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Run Unit Tests
-      run: ./gradlew :app:testProdDebugUnitTest :wear:testProdDebugUnitTest
+      run: ./gradlew :app:testProdReleaseUnitTest :wear:testProdReleaseUnitTest
     - name: Run Compile Tests
       run: ./gradlew assembleRelease
     - name: Check Output


### PR DESCRIPTION
Currently, unit tests are executed for every combination of build type and product flavor. This results in unnecessary recurring tests and elongates the CI workflows significantly.
With this PR only the unit tests of the production release builds are executed but after the compile tests. This reduces the total workflow time by 65 % from about 15m 45s to about 6m 40s.

Take the wasted CPU time and the CO2 impact into account! :smile: 