### PR TITLE
Update google truth

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -380,7 +380,7 @@ dependencies {
     testImplementation 'org.objenesis:objenesis:2.5.1'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation "org.robolectric:robolectric:4.2.1"
-    testImplementation "com.google.truth:truth:0.39"
+    testImplementation "com.google.truth:truth:1.1.3"
 
     testImplementation 'org.mockito:mockito-core:2.4.0'
     testImplementation 'org.powermock:powermock-core:1.7.1'

--- a/app/src/test/java/com/eveningoutpost/dexdrip/Models/ForecastTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/Models/ForecastTest.java
@@ -123,7 +123,7 @@ public class ForecastTest extends RobolectricTestWithConfig {
         Truth.assertThat(result).hasLength(5);
         Truth.assertThat(result)
                 .usingTolerance(0.001)
-                .containsAllOf(new double[]{1, 2, 3, 4, 5})
+                .containsExactly(new double[]{1, 2, 3, 4, 5})
                 .inOrder();
     }
 

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -221,7 +221,7 @@ dependencies {
     implementation 'org.apache.commons:commons-math3:3.6'
     testImplementation "org.robolectric:robolectric:4.2.1"
     testImplementation 'junit:junit:4.12'
-    testImplementation "com.google.truth:truth:0.39"
+    testImplementation "com.google.truth:truth:1.1.3"
 
     implementation 'uk.com.robust-it:cloning:1.9.5'
     // you will want to install the android studio lombok plugin


### PR DESCRIPTION
* Updated to latest GoogleTruth
* Fixed compile error after change in API

Rationale is to keep dependencies up to date, and to be able to use latest version of Truth when writing more tests.

This update of GoogleTruth (which I introduced to xDrip in 2018) needs manual code changes to compile