### PR TITLE
Update stop sensor warning

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -901,7 +901,7 @@
     <string name="bluetooth_scan">Bluetooth Scan</string>
     <string name="level_alerts">Level Alerts</string>
     <string name="override_calibration">Override Calibration</string>
-    <string name="only_stop_your_sensor_when_you_actually_plan">Only stop your sensor when you actually plan to remove it, otherwise leave it running!</string>
+    <string name="only_stop_your_sensor_when_you_actually_plan">Only stop sensor if you actually intend to end the session. Otherwise, leave it running!</string>
     <string name="restart_collector">Restart Collector</string>
     <string name="forget_device">Forget Device</string>
     <string name="other_notes">Other Notes:</string>


### PR DESCRIPTION
This is what the user sees after tapping on stop sensor:
![1](https://user-images.githubusercontent.com/51497406/149385569-a7232040-0ba1-4458-a635-50d9f16a42ca.png)

This is confusing for someone who wants to restart a G6.  There was a post on facebook asking if they could stop sensor to restart considering there is a warning not to.
The fact is that you can stop sensor any time in order to do a restart.

This is what the user will see after this PR if they tap on stop sensor:
![2](https://user-images.githubusercontent.com/51497406/149387148-3377f5d5-cb18-4f33-908f-4661cfd4464d.png)


@tzachi-dar 
Would this change make the warning confusing for a Libre user?