### PR TITLE
upgrade setup-java and gradle-build actions to v2

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -17,11 +17,9 @@ jobs:
       with:
         java-version: 8
         distribution: adopt
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Run Compile Tests
-      run: ./gradlew assembleRelease
-    - name: Run Unit Tests
-      run: ./gradlew :app:testProdReleaseUnitTest :wear:testProdReleaseUnitTest
+    - name: Run unit tests and assemble APKs
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: assembleProdRelease testProdReleaseUnitTest
     - name: Check Output
       run: bash ./etc/CheckBuild/check-release.sh test

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        java-version: 8
+        distribution: adopt
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Run Compile Tests


### PR DESCRIPTION
This PR upgrades [setup-java](https://github.com/actions/setup-java) and [gradle-build](https://github.com/gradle/gradle-build-action) actions to version 2. It also aggregates the gradle executions into one call and builds only production release APKs. These changes results in a workflow runtime decrease by about 50%.