### PR TITLE
Add more logging to help users understand why libre 2 does not communicate with bluetooth.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/ErrorListAdapter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ErrorListAdapter.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 /**
  * Created by Emma Black on 8/4/15.
+ * Used with old activity.
  */
 public class ErrorListAdapter  extends BaseAdapter {
     private List<UserError> list;
@@ -66,11 +67,11 @@ public class ErrorListAdapter  extends BaseAdapter {
     private int backgroundFor(int severity) {
         switch (severity) {
             case 1:
-                return Color.rgb(255, 204, 102);
+                return Color.rgb(255, 204, 102); // yellow
             case 2:
-                return Color.rgb(255, 153, 102);
+                return Color.rgb(255, 153, 102); // orange
         }
-        return Color.rgb(255, 102, 102);
+        return Color.rgb(255, 102, 102); // red
     }
 
     private String dateformatter(double timestamp) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ErrorsActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ErrorsActivity.java
@@ -27,6 +27,7 @@ import static com.eveningoutpost.dexdrip.Home.startWatchUpdaterService;
 
 /**
  * Created by Emma Black on 8/3/15.
+ * This is the old logs activity.
  */
 public class ErrorsActivity extends ActivityWithMenu {
     public static final String menu_name = "Errors";

--- a/app/src/main/java/com/eveningoutpost/dexdrip/EventLogActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EventLogActivity.java
@@ -548,9 +548,9 @@ public class EventLogActivity extends BaseAppCompatActivity {
                 case 4:
                     return Color.DKGRAY;
                 case 5:
-                    return Color.parseColor("#ff337777");
+                    return Color.parseColor("#ff337777"); // turquoise
                 case 6:
-                    return Color.parseColor("#ff337733");
+                    return Color.parseColor("#ff337733"); // green
 
                 default:
                     return Color.TRANSPARENT;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -968,6 +968,8 @@ public class BgReading extends Model implements ShareUploadableBg {
         final ProcessInitialDataQuality.InitialDataQuality idq = ProcessInitialDataQuality.getInitialDataQuality(uncalculated);
         if (!idq.pass) {
             UserError.Log.d(TAG, "Data quality failure for double calibration: " + idq.advice);
+        } else {
+            UserError.Log.d(TAG, "Data quality allows double calibration.");
         }
         return idq.pass || Pref.getBooleanDefaultFalse("bypass_calibration_quality_check");
     }

--- a/app/src/main/res/layout/activity_stop_sensor.xml
+++ b/app/src/main/res/layout/activity_stop_sensor.xml
@@ -43,7 +43,7 @@
             <Button
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="STOP SENSOR"
+                android:text="@string/stop_sensor"
                 android:id="@+id/stop_sensor"
                 android:layout_toEndOf="@+id/sensor_age_container"
                 android:layout_alignParentBottom="true"


### PR DESCRIPTION
I have received a few complaints that xDrip does not work with libre2.
Usually this things are solved when the user retries the connection a few times.
This change high level logging weather scanning the sensor and enabling BT has worked correctly, in order to make users know whether they enabled the sensor successfully or not.
