### PR TITLE
Dex share email ID

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionHelper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionHelper.java
@@ -86,7 +86,7 @@ public class DexCollectionHelper {
                 textSettingDialog(activity,
                         "shfollow_user", "Dex Share Username",
                         "Enter Share Follower Username",
-                        InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD,
+                        InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
                         new Runnable() {
                             @Override
                             public void run() {


### PR DESCRIPTION
New Dex share IDs are email addresses.
This adds email format as one of the accepted options.

I have only compiled this.  But, cannot test it because I don't have a Dex share account.