### PR TITLE
Keep G6 battery voltage logs for 7 days

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
@@ -1537,7 +1537,7 @@ public class Ob1G5StateMachine {
         if (transmitterId.length() != 6) return false;
         if (data.length < 10) return false;
         final BatteryInfoRxMessage batteryInfoRxMessage = new BatteryInfoRxMessage(data);
-        UserError.Log.e(TAG, "Saving battery data: " + batteryInfoRxMessage.toString());
+        UserError.Log.ueh(TAG, "Saving battery data: " + batteryInfoRxMessage.toString());
         PersistentStore.setBytes(G5_BATTERY_MARKER + transmitterId, data);
         PersistentStore.setLong(G5_BATTERY_FROM_MARKER + transmitterId, tsl());
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/G5Model/Ob1G5StateMachine.java
@@ -1537,7 +1537,7 @@ public class Ob1G5StateMachine {
         if (transmitterId.length() != 6) return false;
         if (data.length < 10) return false;
         final BatteryInfoRxMessage batteryInfoRxMessage = new BatteryInfoRxMessage(data);
-        UserError.Log.ueh(TAG, "Saving battery data: " + batteryInfoRxMessage.toString());
+        UserError.Log.uel(TAG, "Saving battery data: " + batteryInfoRxMessage.toString());
         PersistentStore.setBytes(G5_BATTERY_MARKER + transmitterId, data);
         PersistentStore.setLong(G5_BATTERY_FROM_MARKER + transmitterId, tsl());
 


### PR DESCRIPTION
This will keep the G6 battery voltage logs for 7 days instead of just one day.

In simplest ways, it's enough to know what the battery voltage is to judge the health of the battery.
But, there are many factors affecting the recorded voltage.  Those include temperature, voltage monitor accuracy, battery production variation, battery production batch, noise at the voltage sample time ...

Keeping the logs for 7 days let's us more confidently judge if the battery is the cause of malfunction or not.

This is what the log looks like now before this PR:
![1](https://user-images.githubusercontent.com/51497406/151859211-e6785389-a84c-4e45-a24a-09e914291e78.png)

This is what the log looks like after this PR:
![3](https://user-images.githubusercontent.com/51497406/151911633-c9421603-2c89-4d98-8c52-08713b58ceeb.png)
So, the log will become teal.

This will be helpful for those who help people use xDrip.  Low battery voltage is one of many factors causing malfunction.  It (having a 7-day period instead of only 1 day) will be very helpful to confirm that with certainty instead of just a possibility.