### PR TITLE
closes the media player correctly and releases resources

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,6 +128,7 @@ android {
         animationsDisabled = true
         unitTests {
             includeAndroidResources = true
+            returnDefaultValues = true
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -1066,6 +1066,19 @@ public class JoH {
             JoH.getWakeLock("joh-playsound", 10000);
             final MediaPlayer player = MediaPlayer.create(xdrip.getAppContext(), Uri.parse(soundUri));
             player.setLooping(false);
+            player.setOnCompletionListener(mp -> {
+                UserError.Log.i(TAG, "playSoundUri: onCompletion called (finished playing) ");
+                try {
+                    player.stop();
+                } catch (IllegalStateException e) {
+                    //
+                }
+                try {
+                    player.release();
+                } catch (IllegalStateException e) {
+                    //
+                }
+            });
             player.start();
             return player;
         } catch (Exception e) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -1073,11 +1073,7 @@ public class JoH {
                 } catch (IllegalStateException e) {
                     //
                 }
-                try {
-                    player.release();
-                } catch (IllegalStateException e) {
-                    //
-                }
+                player.release();
             });
             player.start();
             return player;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
@@ -20,7 +20,6 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
-import android.media.MediaPlayer;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
@@ -577,30 +576,20 @@ public class Reminders extends ActivityWithRecycler implements SensorEventListen
         showReminderDialog(v, null, 0);
     }
 
-    private synchronized MediaPlayer playSelectedSound() {
-        return JoH.playSoundUri((selectedSound != null) ? selectedSound : JoH.getResourceURI(R.raw.reminder_default_notification));
+    private synchronized void playSelectedSound() {
+        JoH.playSoundUri((selectedSound != null) ? selectedSound : JoH.getResourceURI(R.raw.reminder_default_notification));
     }
 
     public void chooseReminderSound(View v) {
-        final MediaPlayer player = playSelectedSound();
+        playSelectedSound();
 
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(R.string.select_new_sound_source)
                 .setOnDismissListener(dialog -> {
-                    try {
-                        player.stop();
-                        player.release();
-                    } catch (Exception e) {
-                        //
-                    }
+                        JoH.stopSoundUri();
                 })
                 .setItems(R.array.reminderAlertType, (dialog, which) -> {
-                    try {
-                        player.stop();
-                        player.release();
-                    } catch (Exception e) {
-                        //
-                    }
+                    JoH.stopSoundUri();
                     if (which == 0) {
                         final Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
                         intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, xdrip.getAppContext().getString(R.string.select_tone_alert));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -174,11 +174,7 @@ public class AlertPlayer {
             } catch (IllegalStateException e) {
                 UserError.Log.e(TAG, "Exception when stopping media player: " + e);
             }
-            try {
-                mediaPlayer.release();
-            } catch (IllegalStateException e) {
-                UserError.Log.e(TAG, "Exception releasing media player: " + e);
-            }
+            mediaPlayer.release();
             mediaPlayer = null;
         }
         revertCurrentVolume(streamType);
@@ -328,11 +324,7 @@ public class AlertPlayer {
 
         if (mediaPlayer != null) {
             Log.i(TAG, "ERROR, playFile:going to leak a mediaplayer !!!");
-            try {
-                mediaPlayer.release();
-            } catch (IllegalStateException e) {
-                //
-            }
+            mediaPlayer.release();
             mediaPlayer = null;
         }
 
@@ -370,11 +362,7 @@ public class AlertPlayer {
                 } catch (IllegalStateException e) {
                     //
                 }
-                try {
-                    mediaPlayer.release();
-                } catch (IllegalStateException e) {
-                    //
-                }
+                mediaPlayer.release();
                 mediaPlayer = null;
                 revertCurrentVolume(streamType);
             });

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -482,7 +482,7 @@ public class AlertPlayer {
     }
     
     public static boolean isAscendingMode(Context ctx){
-        Log.d("Adrian", "(getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING): " + (getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING));
+        Log.d(TAG, "(getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING): " + (getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING));
         return getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -317,7 +317,7 @@ public class AlertPlayer {
         return false;
     }
 
-    private synchronized void playFile(final Context ctx, final String fileName, final float volumeFrac, final boolean forceSpeaker, final boolean overrideSilentMode) {
+    protected synchronized void playFile(final Context ctx, final String fileName, final float volumeFrac, final boolean forceSpeaker, final boolean overrideSilentMode) {
         Log.i(TAG, "playFile: called fileName = " + fileName);
         if (volumeFrac <= 0) {
             UserError.Log.e(TAG, "Not playing file " + fileName + " as requested volume is " + volumeFrac);
@@ -490,7 +490,7 @@ public class AlertPlayer {
         return !(Pref.getBooleanDefaultFalse("no_alarms_during_calls") && (JoH.isOngoingCall()));
     }
 
-    private void VibrateNotifyMakeNoise(Context context, AlertType alert, String bgValue, int minsFromStartPlaying) {
+    protected void VibrateNotifyMakeNoise(Context context, AlertType alert, String bgValue, int minsFromStartPlaying) {
         Log.d(TAG, "VibrateNotifyMakeNoise called minsFromStartedPlaying = " + minsFromStartPlaying);
         Log.d("ALARM", "setting vibrate alarm");
         int profile = getAlertProfile(context);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/watch/miband/MiBandService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/watch/miband/MiBandService.java
@@ -5,7 +5,6 @@ import android.app.PendingIntent;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
 import android.content.Intent;
-import android.media.MediaPlayer;
 import android.os.PowerManager;
 import android.util.Pair;
 
@@ -116,7 +115,6 @@ public class MiBandService extends JamBaseBluetoothSequencer {
     static BatteryInfo batteryInfo = new BatteryInfo();
     private FirmwareOperations firmware;
     private Subscription watchfaceSubscription;
-    private MediaPlayer player;
 
     private PendingIntent bgServiceIntent;
     static private long bgWakeupTime;
@@ -450,13 +448,13 @@ public class MiBandService extends JamBaseBluetoothSequencer {
             case DeviceEvent.FIND_PHONE_START:
                 UserError.Log.d(TAG, "find phone started");
                 if ((JoH.ratelimit("band_find phone_sound", 3))) {
-                    player = JoH.playSoundUri(getResourceURI(R.raw.default_alert));
+                    JoH.playSoundUri(getResourceURI(R.raw.default_alert));
                 }
                 acknowledgeFindPhone();
                 break;
             case DeviceEvent.FIND_PHONE_STOP:
                 UserError.Log.d(TAG, "find phone stopped");
-                if (player != null && player.isPlaying()) player.stop();
+                JoH.stopSoundUri();
                 break;
             case DeviceEvent.MUSIC_CONTROL:
                 UserError.Log.d(TAG, "got music control");

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -47,6 +47,7 @@ android {
         animationsDisabled = true
         unitTests {
             includeAndroidResources = true
+            returnDefaultValues = true
         }
     }
 

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -909,16 +909,44 @@ public class JoH {
         return ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + xdrip.getAppContext().getPackageName() + "/" + id;
     }
 
-    public static synchronized MediaPlayer playSoundUri(String soundUri) {
+    private static MediaPlayer player;
+    public static synchronized void playSoundUri(String soundUri) {
         try {
             JoH.getWakeLock("joh-playsound", 10000);
-            final MediaPlayer player = MediaPlayer.create(xdrip.getAppContext(), Uri.parse(soundUri));
+            if (player != null) {
+                UserError.Log.i(TAG, "playSoundUri: media player still exists. Releasing it.");
+                player.release();
+                player = null;
+            }
+            player = MediaPlayer.create(xdrip.getAppContext(), Uri.parse(soundUri));
+            player.setOnCompletionListener(mp -> {
+                UserError.Log.i(TAG, "playSoundUri: onCompletion called (finished playing) ");
+                player.release();
+                player = null;
+            });
+            player.setOnErrorListener((mp, what, extra) -> {
+                UserError.Log.e(TAG, "playSoundUri: onError called (what: " + what + ", extra: " + extra);
+                // possibly media player error; release is handled in onCompletionListener
+                return false;
+            });
             player.setLooping(false);
             player.start();
-            return player;
         } catch (Exception e) {
             Log.wtf(TAG, "Failed to play audio: " + soundUri + " exception:" + e);
-            return null;
+        }
+    }
+
+    public static synchronized void stopSoundUri() {
+        if (player != null) {
+            if (player.isPlaying()) {
+                try {
+                    player.stop();
+                } catch (IllegalStateException e) {
+                    UserError.Log.e(TAG, "Exception when stopping sound URI media player: " + e);
+                }
+            }
+            player.release();
+            player = null;
         }
     }
 

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -300,7 +300,7 @@ public class AlertPlayer {
         return false;
     }
 
-    private synchronized void PlayFile(final Context ctx, String FileName, float VolumeFrac) {
+    protected synchronized void PlayFile(final Context ctx, String FileName, float VolumeFrac) {
         Log.i(TAG, "PlayFile: called FileName = " + FileName);
 
         if(mediaPlayer != null) {

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -430,7 +430,7 @@ public class AlertPlayer {
     }
     
     public static boolean isAscendingMode(Context ctx){
-        Log.d("Adrian", "(getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING): " + (getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING));
+        Log.d(TAG, "(getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING): " + (getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING));
         return getAlertProfile(ctx) == ALERT_PROFILE_ASCENDING;
     }
 


### PR DESCRIPTION
This is an extended PR of the code @gruoner provided with #1715.

Basically, it defines an error handler and an complete listener to release resources of the media player after errors and completion of media playing. This is the recommend usage according to the [Android MediaPlayer docs](https://developer.android.com/reference/android/media/MediaPlayer#release()).

Gruoner reported that "after a while this results in silent alarm without any sound" if not properly handled.

The last two commits are preparations for unit testing.