### PR TITLE
Fix check of Wear OS

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -20,7 +20,6 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
-import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -1400,8 +1399,7 @@ public class JoH {
 
     public static boolean areWeRunningOnAndroidWear() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH
-                && (xdrip.getAppContext().getResources().getConfiguration().uiMode
-                & Configuration.UI_MODE_TYPE_MASK) == Configuration.UI_MODE_TYPE_WATCH;
+                && xdrip.getAppContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_WATCH);
     }
 
     public static boolean isAirplaneModeEnabled(Context context) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -19,7 +19,6 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.PendingIntent;
 import android.app.Service;
-import android.app.UiModeManager;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
@@ -34,7 +33,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.content.res.Configuration;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -82,7 +80,6 @@ import java.nio.ByteOrder;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -819,10 +816,10 @@ public class DexCollectionService extends Service implements BtCallBack {
     }
 
     @SuppressLint("ObsoleteSdkInt")
-    private static boolean shouldServiceRun() {
+    private boolean shouldServiceRun() {
         if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) return false;
         final boolean result = (DexCollectionType.hasXbridgeWixel() || DexCollectionType.hasBtWixel())
-                && ((!Home.get_forced_wear() && (((UiModeManager) xdrip.getAppContext().getSystemService(UI_MODE_SERVICE)).getCurrentModeType() != Configuration.UI_MODE_TYPE_WATCH))
+                && ((!Home.get_forced_wear() && !JoH.areWeRunningOnAndroidWear())
                 || PersistentStore.getBoolean(CollectionServiceStarter.pref_run_wear_collector));
         if (d) Log.d(TAG, "shouldServiceRun() returning: " + result);
         return result;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
@@ -12,7 +12,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.content.res.Configuration;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -28,8 +28,8 @@ import com.eveningoutpost.dexdrip.G5Model.BluetoothServices;
 import com.eveningoutpost.dexdrip.G5Model.CalibrationState;
 import com.eveningoutpost.dexdrip.G5Model.DexSyncKeeper;
 import com.eveningoutpost.dexdrip.G5Model.FirmwareCapability;
-import com.eveningoutpost.dexdrip.G5Model.Ob1G5StateMachine;
 import com.eveningoutpost.dexdrip.G5Model.Ob1DexTransmitterBattery;
+import com.eveningoutpost.dexdrip.G5Model.Ob1G5StateMachine;
 import com.eveningoutpost.dexdrip.G5Model.TransmitterStatus;
 import com.eveningoutpost.dexdrip.G5Model.VersionRequest1RxMessage;
 import com.eveningoutpost.dexdrip.G5Model.VersionRequest2RxMessage;
@@ -969,7 +969,7 @@ public class Ob1G5CollectionService extends G5BaseService {
             checkAlwaysScanModels();
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
-                android_wear = (getResources().getConfiguration().uiMode & Configuration.UI_MODE_TYPE_MASK) == Configuration.UI_MODE_TYPE_WATCH;
+                android_wear = JoH.areWeRunningOnAndroidWear();
                 if (android_wear) {
                     UserError.Log.d(TAG, "We are running on Android Wear");
                     wear_broadcast = Pref.getBooleanDefaultFalse("ob1_wear_broadcast");

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -16,16 +16,11 @@ import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
 import android.content.Context;
-//KS import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
-import android.content.res.Configuration;
 import android.graphics.Bitmap;
-//KS import android.graphics.Canvas;
-//KS import android.graphics.Color;
-//KS import android.graphics.Paint;
 import android.graphics.Point;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
@@ -42,10 +37,6 @@ import android.os.IBinder;
 import android.os.PowerManager;
 import android.os.Vibrator;
 import android.provider.Settings;
-//KS import android.support.v7.app.AlertDialog;
-//KS import android.support.v4.app.NotificationCompat;
-//KS import android.support.v7.app.AppCompatActivity;
-//KS import android.support.v7.view.ContextThemeWrapper;
 import android.text.InputType;
 import android.text.method.DigitsKeyListener;
 import android.util.Base64;
@@ -61,7 +52,6 @@ import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.utils.BestGZIPOutputStream;
-//KS import com.eveningoutpost.dexdrip.utils.CipherUtils;
 import com.eveningoutpost.dexdrip.xdrip;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.UnsignedInts;
@@ -100,6 +90,16 @@ import java.util.zip.Inflater;
 import static android.bluetooth.BluetoothDevice.PAIRING_VARIANT_PIN;
 import static android.content.Context.ALARM_SERVICE;
 import static android.content.Context.VIBRATOR_SERVICE;
+
+//KS import android.content.DialogInterface;
+//KS import android.graphics.Canvas;
+//KS import android.graphics.Color;
+//KS import android.graphics.Paint;
+//KS import android.support.v7.app.AlertDialog;
+//KS import android.support.v4.app.NotificationCompat;
+//KS import android.support.v7.app.AppCompatActivity;
+//KS import android.support.v7.view.ContextThemeWrapper;
+//KS import com.eveningoutpost.dexdrip.utils.CipherUtils;
 //KS import static com.eveningoutpost.dexdrip.stats.StatsActivity.SHOW_STATISTICS_PRINT_COLOR;
 
 /**
@@ -1222,8 +1222,7 @@ public class JoH {
 
     public static boolean areWeRunningOnAndroidWear() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH
-                && (xdrip.getAppContext().getResources().getConfiguration().uiMode
-                & Configuration.UI_MODE_TYPE_MASK) == Configuration.UI_MODE_TYPE_WATCH;
+                && xdrip.getAppContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_WATCH);
     }
 
     public static boolean isAirplaneModeEnabled(Context context) {

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -19,7 +19,6 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.PendingIntent;
 import android.app.Service;
-import android.app.UiModeManager;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
@@ -34,7 +33,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.content.res.Configuration;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -772,10 +770,10 @@ public class DexCollectionService extends Service implements BtCallBack {
     }
 
     @SuppressLint("ObsoleteSdkInt")
-    private static boolean shouldServiceRun() {
+    private boolean shouldServiceRun() {
         if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) return false;
         final boolean result = (DexCollectionType.hasXbridgeWixel() || DexCollectionType.hasBtWixel())
-                && ((!Home.get_forced_wear() && (((UiModeManager) xdrip.getAppContext().getSystemService(UI_MODE_SERVICE)).getCurrentModeType() != Configuration.UI_MODE_TYPE_WATCH))
+                && ((!Home.get_forced_wear() && !JoH.areWeRunningOnAndroidWear())
                 || PersistentStore.getBoolean(CollectionServiceStarter.pref_run_wear_collector));
         if (d) Log.d(TAG, "shouldServiceRun() returning: " + result);
         return result;

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
@@ -12,7 +12,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.content.res.Configuration;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -907,7 +906,7 @@ public class Ob1G5CollectionService extends G5BaseService {
             checkAlwaysScanModels();
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
-                android_wear = (getResources().getConfiguration().uiMode & Configuration.UI_MODE_TYPE_MASK) == Configuration.UI_MODE_TYPE_WATCH;
+                android_wear = JoH.areWeRunningOnAndroidWear();
                 if (android_wear) {
                     UserError.Log.d(TAG, "We are running on Android Wear");
                     wear_broadcast = Pref.getBooleanDefaultFalse("ob1_wear_broadcast");


### PR DESCRIPTION
Some newer watches do not run Wear OS, instead the full Android version is running. xDrip wrongly detects Wear OS in this case and the Bluetooth service does not start as described in https://github.com/Navid200/xDrip/discussions/161.

The current discussion is #1973.

This PR corrects the detection routine and use it as a centralized static function.

Fixes #1972 