### PR TITLE
add Estonian language support

### DIFF
--- a/app/src/main/res/values/locales.xml
+++ b/app/src/main/res/values/locales.xml
@@ -5,6 +5,7 @@
         <item>български език</item>
         <item>čeština</item>
         <item>Deutsch</item>
+        <item>eesti keel</item>
         <item>English</item>
         <item>Español</item>
         <item>Français</item>
@@ -29,6 +30,7 @@
         <item>bg</item>
         <item>cs</item>
         <item>de</item>
+        <item>et</item>
         <item>en</item>
         <item>es</item>
         <item>fr</item>


### PR DESCRIPTION
The translation to Estonian has [started at Crowdin](https://crowdin.com/project/xdrip/et) and currently four translators including two proofreaders working on it..
This PR enables this language in xDrip and helps the translation process further.