### PR TITLE
Treatment, prediction and flair color names

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,10 +490,10 @@
     <string name="bad_glucose_values">Bad Glucose Values</string>
     <string name="revert_to_default">Revert to Default</string>
     <string name="filtered_values">Filtered Values</string>
-    <string name="treatment_color">Treatment Color</string>
-    <string name="treatment_color_dark">Treatment Color Dark</string>
-    <string name="predictive_color">Predictive Color</string>
-    <string name="predictive_color_dark">Predictive Color Dark</string>
+    <string name="treatment_color">Insulin on Board</string>
+    <string name="treatment_color_dark">Insulin Activity</string>
+    <string name="predictive_color">Glucose Prediction</string>
+    <string name="predictive_color_dark">Carbs on Board</string>
     <string name="average_and_target_lines">Average and Target Lines</string>
     <string name="eight_hour_average_line">8-Hour Average Line</string>
     <string name="twenty_four_hour_average_line">24-Hour Average Line</string>
@@ -817,9 +817,9 @@
     <string name="step_counter_1st_color">Step counter 1st Color</string>
     <string name="step_counter_2nd_color">Step counter 2nd Color</string>
     <string name="flair_colors">Flair Colors</string>
-    <string name="use_flair_colors">Use Flair Colors</string>
-    <string name="upper_title_bar_flair">Upper Title Bar Flair</string>
-    <string name="lower_button_bar_falir">Lower Button Bar Flair</string>
+    <string name="use_flair_colors">Custom Title/Nav Bar</string>
+    <string name="upper_title_bar_flair">Upper Title Bar</string>
+    <string name="lower_button_bar_falir">Lower Navigation Bar</string>
     <string name="force_english_text">Force English Text</string>
     <string name="using_local_language">Currently using your device\'s local language</string>
     <string name="forcing_alternate_language">Currently forcing use of alternate language</string>


### PR DESCRIPTION
Changes the English titles of the treatment/prediction and flair colors on the legend (xDrip+ Color Settings) page.

Doesn't matter if the credit is given to stephencmorton instead of me for this PR if it is merged. 

The following images show what it will look like after.
![Screenshot_20220304-004534](https://user-images.githubusercontent.com/51497406/156707832-0d8d77ee-4b9a-45fd-a503-fed6b78c18e3.jpg) ![Screenshot_20220304-004551](https://user-images.githubusercontent.com/51497406/156708010-f320cc06-696e-4ea6-9165-9ee8d4e43b07.jpg)
