### PR TITLE
Log the call stack of exception for log.e calls

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserError.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/UserError.java
@@ -284,7 +284,16 @@ public class UserError extends Model {
 
         public static void e(String tag, String b, Exception e){
             android.util.Log.e(tag, b, e);
-            new UserError(tag, b + "\n" + e.toString());
+            StringBuilder sb = new StringBuilder();
+            sb.append(b);
+            sb.append("\n");
+            sb.append(e.toString());
+            sb.append("\n");
+            StackTraceElement[] ste = e.getStackTrace();
+            for (StackTraceElement ee : ste) {
+                sb.append("    " +  ee.toString() + "\n");
+            }
+            new UserError(tag, sb.toString()) ;
         }
 
         public static void w(String tag, String b){

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -297,7 +297,7 @@ public class AlertPlayer {
             mp.setDataSource(context, uri);
             return true;
         } catch (IOException | NullPointerException | IllegalArgumentException | SecurityException ex) {
-            Log.e(TAG, "setMediaDataSource from uri failed:", ex);
+            Log.e(TAG, "setMediaDataSource from uri failed: uri = " + uri.toString(), ex);
             // fall through
         }
         return false;


### PR DESCRIPTION
Log the call stack of exceptions for all `log.e(TAG, message, exception)` calls.

Here is an example:
<img width="500" src="https://user-images.githubusercontent.com/7942372/161404692-2aa040e5-7fba-4281-8360-9c880ce33c81.png" />
