### PR TITLE
Ensure current device is Dexcom

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/AddCalibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/AddCalibration.java
@@ -23,6 +23,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.UtilityModels.UndoRedo;
 import com.eveningoutpost.dexdrip.calibrations.NativeCalibrationPipe;
+import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 
 import java.util.UUID;
 
@@ -203,7 +204,7 @@ public class AddCalibration extends AppCompatActivity implements NavigationDrawe
                             final double calValue = JoH.tolerantParseDouble(string_value);
 
                             if (!Home.get_follower()) {
-                                if (FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) { // Firefly only
+                                if (DexCollectionType.hasDexcomRaw() && FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) { // Firefly only
                                     double bg = calValue;
                                     if (unit.compareTo("mgdl") != 0) {
                                         bg = bg * Constants.MMOLL_TO_MGDL;


### PR DESCRIPTION
This is a bug that could cause hardware devices other than Dexcom, like Libre, malfunction if the user switches from Dexcom.

To test this in action, one needs to have a functioning Libre as well as a FireFly G6 transmitter that still has battery.
I don't have a Libre device.  So, I cannot reproduce the problem myself.

If you have those and are willing to test, please install an xDrip release after August 4, 2021 like the current stable release; set xDrip to connect to your G6 transmitter and make sure it establishes connectivity and shows the battery voltages.  The Firmware should confirm that it is FireFly (Greater than 1.6.5.27).

Now, switch to your Libre.  Attempt a calibration.  It should malfunction as the logic (my mistake) still detects a G6 even though you have switched to Libre.

Now, update to this PR.  Your Libre should calibrate properly now.