### PR TITLE
Remember long pressed time buttons

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2025,15 +2025,10 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             chart.setCurrentViewport(holdViewport);
             previewChart.setCurrentViewport(holdViewport);
         } else {
-            if (homeShelf.get("time_buttons")) {
-                final long which_hour = PersistentStore.getLong("home-locked-hours");
-                if (which_hour > 0) {
-                    hours = which_hour;
-                    setHoursViewPort();
-                } else {
-                    hours = DEFAULT_CHART_HOURS;
-                }
-
+            final long which_hour = PersistentStore.getLong("home-locked-hours");
+            if (which_hour > 0) {
+                hours = which_hour;
+                setHoursViewPort();
             } else {
                 hours = DEFAULT_CHART_HOURS;
             }


### PR DESCRIPTION
If you bring the time buttons on screen and long press any of them, you will be defining the default time span.
After that you can pinch the screen to change the span.  As soon as you minimize xDrip and reopen, the time span will go to your chosen default.

However, if you remove the time buttons from the screen, xDrip ignores your chosen default.

This PR changes that last behavior.  Even if you remove the time buttons from the main screen, the one that you have long pressed will still define your default time span.

Fixes: https://github.com/NightscoutFoundation/xDrip/discussions/1910