### PR TITLE
Add Levemir to the insulin profile list

### DIFF
--- a/app/src/main/res/raw/insulin_profiles.txt
+++ b/app/src/main/res/raw/insulin_profiles.txt
@@ -133,6 +133,25 @@
           "duration": "2160"
         }
       }
+    },
+    {
+      "name": "Levemir",
+      "displayName": "Levemir (long acting)",
+      "PPN":
+      [
+        "LevemirU100"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "180",
+          "peak": "180-480",
+          "duration": "1440"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
This adds NovoNordisk Levemir (long acting) to the insulin profiles list. Numbers based on:

*  https://www.racgp.org.au/clinical-resources/clinical-guidelines/key-racgp-guidelines/view-all-racgp-guidelines/diabetes/appendices/appendix-1-types-of-insulin-available
* https://www.accessdata.fda.gov/drugsatfda_docs/label/2007/021536s015lbl.pdf

Question for reviewers: Is this all I need to do to have it added to the insulin list in the app, or is there another step?