### PR TITLE
create code coverage reports

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -21,9 +21,15 @@ jobs:
       with:
         java-version: ${{ matrix.java-version }}
         distribution: adopt
-    - name: Run unit tests and assemble APKs
+    - name: Run unit tests, assemble APKs and generate code coverage report
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: assembleProdRelease testProdReleaseUnitTest
+        arguments: assembleProdRelease testProdReleaseUnitTestCoverage
+    - name: Upload coverage report to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        verbose: true # optional (default = false)
+        directory: app/build/reports/jacoco/testProdReleaseUnitTestCoverage
+        files: testProdReleaseUnitTestCoverage.xml
     - name: Check Output
       run: bash ./etc/CheckBuild/check-release.sh test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
  <img align="right" src="Documentation/images/download-xdrip-plus-qr-code.png">
  Info page and APK download: https://jamorham.github.io/#xdrip-plus
 
-<img align="right" src="https://travis-ci.org/jamorham/xDrip-plus.svg?branch=master"><a align="right" title="Crowdin" target="_blank" href="https://crowdin.com/project/xdrip"><img align="right" src="https://badges.crowdin.net/xdrip/localized.svg"></a>
+<img align="right" src="https://travis-ci.org/jamorham/xDrip-plus.svg?branch=master"><a align="right" title="Crowdin" target="_blank" href="https://crowdin.com/project/xdrip"><img align="right" src="https://badges.crowdin.net/xdrip/localized.svg"></a><a align="right" title="CodeCov" target="_blank" href="https://codecov.io/gh/NightscoutFoundation/xDrip"><img src="https://codecov.io/gh/NightscoutFoundation/xDrip/branch/master/graph/badge.svg"/></a>
 
 ## Features
 * Voice, Keypad or Watch input of Treatments (Insulin/Carbs/Notes)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -338,3 +338,4 @@ tasks.withType(Test) {
 }
 
 apply plugin: 'com.google.gms.google-services'
+apply from: '../jacoco.gradle'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: no

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  token: 0e67eb01-5257-41ab-805d-a896e3de107d
+
 comment:
   layout: "diff, files"
   behavior: default

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -7,6 +7,7 @@ jacoco {
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 project.afterEvaluate {

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -2,7 +2,7 @@ apply plugin: 'jacoco'
 
 jacoco {
     // This version should be same as the one defined in root project build.gradle file :
-    toolVersion = "0.8.6"
+    toolVersion = "0.8.8"
 }
 
 tasks.withType(Test) {

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,0 +1,53 @@
+apply plugin: 'jacoco'
+
+jacoco {
+    // This version should be same as the one defined in root project build.gradle file :
+    toolVersion = "0.8.6"
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
+
+project.afterEvaluate {
+    android.applicationVariants.all { variant ->
+        def testTaskName = "test${variant.name.capitalize()}UnitTest"
+        task "${testTaskName}Coverage"(type: JacocoReport, dependsOn: "$testTaskName") {
+            group = "Reporting"
+            description = "Generate Jacoco coverage reports on the ${variant.name.capitalize()} build."
+            def excludes = [
+                    '**/R.class',
+                    '**/R$*.class',
+                    '**/*$ViewInjector*.*',
+                    '**/*$ViewBinder*.*',
+                    '**/BuildConfig.*',
+                    '**/Manifest*.*'
+            ]
+
+            //Tree for all the Java classes
+            def javaClasses = fileTree(dir: variant.javaCompiler.destinationDir, excludes: excludes)
+            println "Test : " + javaClasses
+
+            //Tree for all the Kotlin classes
+            def kotlinClasses = fileTree(dir: "${buildDir}/tmp/kotlin-classes/${variant.name}", excludes: excludes)
+
+            //combined source directories
+            classDirectories.from = files([javaClasses, kotlinClasses])
+
+            def coverageSourceDirs = [
+                    "$project.projectDir/src/main/java",
+                    "$project.projectDir/src/${variant.name}/java",
+                    "$project.projectDir/src/main/kotlin",
+                    "$project.projectDir/src/${variant.name}/kotlin"
+            ]
+            additionalSourceDirs.from = files(coverageSourceDirs)
+            sourceDirectories.from = files(coverageSourceDirs)
+            executionData.from = files("${project.buildDir}/jacoco/${testTaskName}.exec")
+            reports {
+                xml.enabled = true
+                html.enabled = false
+                html.destination = file("${project.buildDir}/jacoco/")
+            }
+        }
+    }
+}

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -26,7 +26,6 @@ project.afterEvaluate {
 
             //Tree for all the Java classes
             def javaClasses = fileTree(dir: variant.javaCompiler.destinationDir, excludes: excludes)
-            println "Test : " + javaClasses
 
             //Tree for all the Kotlin classes
             def kotlinClasses = fileTree(dir: "${buildDir}/tmp/kotlin-classes/${variant.name}", excludes: excludes)
@@ -45,7 +44,7 @@ project.afterEvaluate {
             executionData.from = files("${project.buildDir}/jacoco/${testTaskName}.exec")
             reports {
                 xml.enabled = true
-                html.enabled = false
+                html.enabled = project.getProperties().getOrDefault('covHtml', false) == 'true'
                 html.destination = file("${project.buildDir}/jacoco/")
             }
         }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply from: '../app/token-replace.gradle'
 apply from: '../common.gradle'
+apply from: '../jacoco.gradle'
 
 android {
     compileSdkVersion 29


### PR DESCRIPTION
With this PR code coverage reports are created using [JaCoCo](https://www.jacoco.org/jacoco) and uploaded to CodeCov for visualization. An example is shown for my fork at https://codecov.io/gh/tolot27/xDrip.

Also, [code coverage comments](https://docs.codecov.com/docs/pull-request-comments) in the [Diff](https://docs.codecov.com/docs/coverage-diff) layout together with the impact on each changed file are added to new pull requests to get an impression how the overall code coverage increases/decreases with the suggested changes.