### PR TITLE
remove last usage of bindPreferenceTitleAppendToIntegerValueFromLogSlider

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1849,7 +1849,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
 
             final NamedSliderProcessor tidepoolProcessor = new UploadChunk();
-            bindPreferenceTitleAppendToIntegerValueFromLogSlider(findPreference("tidepool_window_latency"), tidepoolProcessor, "latency", false);
+            bindPreferenceSummaryAppendToIntegerValueFromLogSlider(findPreference("tidepool_window_latency"), tidepoolProcessor, "latency", false);
 
 
             wifiRecievers.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip.utils;
 
+import static com.eveningoutpost.dexdrip.xdrip.gs;
+
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -121,8 +123,6 @@ import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-
-import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 /**
  * A {@link PreferenceActivity} that presents a set of application settings. On
@@ -782,38 +782,6 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
         try {
             preference.setOnPreferenceChangeListener(sBindPreferenceTitleAppendToIntegerValueListener);
             sBindPreferenceTitleAppendToIntegerValueListener.onPreferenceChange(preference,
-                    PreferenceManager
-                            .getDefaultSharedPreferences(preference.getContext())
-                            .getInt(preference.getKey(), 0));
-        } catch (Exception e) {
-            Log.e(TAG, "Got exception binding preference title: " + e.toString());
-        }
-    }
-
-    private static void bindPreferenceTitleAppendToIntegerValueFromLogSlider(Preference preference, NamedSliderProcessor ref, String name, boolean unitize) {
-
-        final Preference.OnPreferenceChangeListener listener = new Preference.OnPreferenceChangeListener() {
-            @Override
-            public boolean onPreferenceChange(Preference preference, Object value) {
-
-                boolean do_update = false;
-                // detect not first run
-                if (preference.getTitle().toString().contains("(")) {
-                    do_update = true;
-                }
-                final int result = ref.interpolate(name, (int)value);
-
-                preference.setTitle(preference.getTitle().toString().replaceAll("  \\([a-z0-9A-Z \\.]+\\)$", "") + "  (" + (unitize ? BgGraphBuilder.unitized_string_static_no_interpretation_short(result) : result) + ")");
-                if (do_update) {
-                    preference.getEditor().putInt(preference.getKey(), (int) value).apply(); // update prefs now
-                }
-                return true;
-            }
-        };
-
-        try {
-            preference.setOnPreferenceChangeListener(listener);
-            listener.onPreferenceChange(preference,
                     PreferenceManager
                             .getDefaultSharedPreferences(preference.getContext())
                             .getInt(preference.getKey(), 0));

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -275,8 +275,8 @@
                 <SeekBarPreference
                     android:key="tidepool_window_latency"
                     android:dependency="cloud_storage_tidepool_enable"
-                    android:title="@string/title_tidepool_window_latency"
-                    android:summary=""
+                    android:title=""
+                    android:summary="@string/title_tidepool_window_latency"
                     android:max="300"
                     android:min="0"
                     android:defaultValue="0" />


### PR DESCRIPTION
This is a code cleanup of #2076 to remove code duplication. The function `bindPreferenceTitleAppendToIntegerValueFromLogSlider` is not used anywhere else.