### PR TITLE
Make sure that xDrip will not crash in the case that parsing a trade or history sensor will fail.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -944,6 +944,10 @@ public class NFCReaderX {
         } else {
             trendList = parseTrendDataLibrePro(data, sensorTime, sensorStartTime, CaptureDateTime);
         }
+        if(trendList == null || historyList == null) {
+            Log.e(TAG,"Failed parsing trendList or historyList");
+            return null;
+        }
         Collections.sort(trendList);
         Collections.sort(historyList);
         // Adding the bg vals must be done after the sort.


### PR DESCRIPTION
This scenario happens when using OOP1 with EU encrypted sensors.

This fixes https://github.com/NightscoutFoundation/xDrip/issues/2119