### PR TITLE
Rename engineering mode to test mode

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2286,9 +2286,11 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         initializeGraphicTrendArrow();
         final TextView notificationText = (TextView) findViewById(R.id.notices);
         final TextView lowPredictText = (TextView) findViewById(R.id.lowpredict);
+        final TextView testText = (TextView) findViewById(R.id.testtext);
         if (BgGraphBuilder.isXLargeTablet(getApplicationContext())) {
             notificationText.setTextSize(40);
             lowPredictText.setTextSize(30);
+            testText.setTextSize(30);
         }
         notificationText.setText("");
         notificationText.setTextColor(Color.RED);
@@ -2421,6 +2423,11 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                 lowPredictText.setVisibility(View.VISIBLE);
             }
             BgGraphBuilder.previous_low_occurs_at = BgGraphBuilder.low_occurs_at;
+        }
+        testText.setText("Testing");
+        testText.setVisibility(View.INVISIBLE);
+        if (get_engineering_mode()) { // If engineering mode is enabled
+            testText.setVisibility(View.VISIBLE); // Put "Testing" on screen.
         }
 
         if (navigationDrawerFragment == null) Log.e("Runtime", "navigationdrawerfragment is null");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2424,7 +2424,8 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             }
             BgGraphBuilder.previous_low_occurs_at = BgGraphBuilder.low_occurs_at;
         }
-        testText.setText("Testing");
+        testText.setText("");
+        testText.append(getString(R.string.test_warning));
         testText.setVisibility(View.INVISIBLE);
         if (get_engineering_mode()) { // If engineering mode is enabled
             testText.setVisibility(View.VISIBLE); // Put "Testing" on screen.

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/VoiceCommands.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/VoiceCommands.java
@@ -36,9 +36,9 @@ public class VoiceCommands {
             Calibration.clearLastCalibration();
         } else if (allWords.contentEquals("force google reboot")) {
             SdcardImportExport.forceGMSreset();
-        } else if (allWords.contentEquals("enable engineering mode")) {
+        } else if (allWords.contentEquals("enable test mode")) {
             Pref.setBoolean("engineering_mode", true);
-            JoH.static_toast_long("Engineering mode enabled - be careful");
+            JoH.static_toast_long("Test mode enabled - be careful");
         } else if (get_engineering_mode() && allWords.contentEquals("enable fake data source")) {
             Pref.setString(DexCollectionType.DEX_COLLECTION_METHOD, DexCollectionType.Mock.toString());
             JoH.static_toast_long("YOU ARE NOW USING FAKE DATA!!!");

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -187,6 +187,25 @@
                     android:textColor="#C30909"
                     android:textStyle="bold" />
 
+                <TextView
+                    android:id="@+id/testtext"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/lowpredict"
+                    android:layout_alignParentStart="true"
+                    android:layout_marginTop="-2dp"
+                    android:layout_marginRight="5dp"
+                    android:background="@android:color/transparent"
+                    android:gravity="left|top"
+                    android:paddingStart="35dp"
+                    android:paddingEnd="30dp"
+                    android:shadowColor="#ff212121"
+                    android:shadowDx="0"
+                    android:shadowDy="0"
+                    android:shadowRadius="14"
+                    android:text="Testing"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
+
                 <ImageButton
                     android:id="@+id/btnTreatment"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -662,7 +662,7 @@
     <string name="store_logs">Store logs for troubleshooting</string>
     <string name="show_datatables_in_app_drawer">Show Calibration and BG datatables in the app drawer.</string>
     <string name="disable_log_transmitter_battery_warning">Disable the warning for low transmitter battery state on the home screen. (Only relevant for DIY receivers.)</string>
-    <string name="engineering_mode">Engineering mode</string>
+    <string name="engineering_mode">Test mode</string>
     <string name="allow_unsafe_settings">Allows changing the most unsafe settings which could break everything!</string>
     <string name="daily_save_db">Save Database Daily</string>
     <string name="allow_daily_db_save">Allows the Daily Intent Service to save the database before purging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -664,6 +664,7 @@
     <string name="disable_log_transmitter_battery_warning">Disable the warning for low transmitter battery state on the home screen. (Only relevant for DIY receivers.)</string>
     <string name="engineering_mode">Test mode</string>
     <string name="allow_unsafe_settings">Allows changing the most unsafe settings which could break everything!</string>
+    <string name="test_warning">Testing</string>
     <string name="daily_save_db">Save Database Daily</string>
     <string name="allow_daily_db_save">Allows the Daily Intent Service to save the database before purging</string>
     <string name="options_for_extra_line">Options for the extra line</string>


### PR DESCRIPTION
Users enable engineering mode and leave it enabled.
This is not what engineering mode is meant for.
Engineering mode should only be used when absolutely necessary, which should be for testing.
If a setting that is only available in engineering mode needs to be enabled continuously, the users should inform the developers with an explanation.  In that case, the developers can move the setting out of engineering mode when possible.

This PR changes the name of the setting, only from the point of view of the user, to "Test mode".   The parameter is still called the same.  So, anyone updating to this release with engineering mode enabled, will have Test mode enabled instead automatically.
![Screenshot_20220528-000626](https://user-images.githubusercontent.com/51497406/170809226-67687332-f289-4abc-a315-e06aead73ff5.jpg)


The name "engineering" has a positive connotation.  There are individuals who feel having it enabled means they have earned a badge.  We shouldn't be encouraging people to enable it.
Calling it test mode is more representative of what it is meant for.

There are posts in the facebook group asking for help.  After spending time going through the settings, there are times we find out the engineering mode is enabled and that's the only reason the system is broken.  But, most users are not aware that they should not use the engineering mode under normal conditions for day-to-day use.

This PR also places a text on the main screen reading "Testing" as shown below when the Test mode is enabled.
This let's those who provide support see it on the main screen.  But, more importantly, it is hoped that it would encourage the users to disable it.
The text is placed right under the predicted low text in white.
![Screenshot_20220528-074457](https://user-images.githubusercontent.com/51497406/170824259-6daf68b0-577d-4a58-8466-8ebe828c70b9.jpg)

  
![Screenshot 2022-05-28 000301](https://user-images.githubusercontent.com/51497406/170809103-9feaa436-2625-481d-a917-2b0436c1921f.png)
