### PR TITLE
Status page transmitter days highlighted depending on the number of days

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
@@ -27,6 +27,7 @@ import com.eveningoutpost.dexdrip.G5Model.BatteryInfoRxMessage;
 import com.eveningoutpost.dexdrip.G5Model.BluetoothServices;
 import com.eveningoutpost.dexdrip.G5Model.CalibrationState;
 import com.eveningoutpost.dexdrip.G5Model.DexSyncKeeper;
+import com.eveningoutpost.dexdrip.G5Model.DexTimeKeeper;
 import com.eveningoutpost.dexdrip.G5Model.FirmwareCapability;
 import com.eveningoutpost.dexdrip.G5Model.Ob1DexTransmitterBattery;
 import com.eveningoutpost.dexdrip.G5Model.Ob1G5StateMachine;
@@ -2111,7 +2112,14 @@ public class Ob1G5CollectionService extends G5BaseService {
                     l.add(new StatusItem("Transmitter Status", battery_status, BAD));
             }
 
-            l.add(new StatusItem("Transmitter Days", parsedBattery.daysEstimate()));
+            if (vr != null && (FirmwareCapability.isTransmitterRawCapable(getTransmitterID())) || DexTimeKeeper.getTransmitterAgeInDays(tx_id) < 69) {
+                // Transmitter days < 69 or G5 or old G6 or modified Firefly
+                l.add(new StatusItem("Transmitter Days", parsedBattery.daysEstimate()));
+            } else if (DexTimeKeeper.getTransmitterAgeInDays(tx_id) < 100) { // Unmodified Firefly with 68 < Transmitter days < 100
+                l.add(new StatusItem("Transmitter Days", parsedBattery.daysEstimate(), Highlight.NOTICE));
+            } else { // Unmodified Firefly with transmitter days > 99
+                l.add(new StatusItem("Transmitter Days", parsedBattery.daysEstimate(), Highlight.BAD));
+            }
             l.add(new StatusItem("Voltage A", parsedBattery.voltageA(), parsedBattery.voltageAWarning() ? BAD : NORMAL));
             l.add(new StatusItem("Voltage B", parsedBattery.voltageB(), parsedBattery.voltageBWarning() ? BAD : NORMAL));
             if (vr != null && FirmwareCapability.isFirmwareResistanceCapable(vr.firmware_version_string)) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
@@ -2111,15 +2111,17 @@ public class Ob1G5CollectionService extends G5BaseService {
                 if (!battery_status.equals("OK"))
                     l.add(new StatusItem("Transmitter Status", battery_status, BAD));
             }
-
-            if (vr != null && (FirmwareCapability.isTransmitterRawCapable(getTransmitterID())) || DexTimeKeeper.getTransmitterAgeInDays(tx_id) < 69) {
+            Highlight TX_dys_highlight; // Transmitter Days highlight
+            final int TX_dys = DexTimeKeeper.getTransmitterAgeInDays(tx_id); // Transmitter days
+            if (vr != null && (FirmwareCapability.isTransmitterRawCapable(getTransmitterID())) || TX_dys < 69) {
                 // Transmitter days < 69 or G5 or old G6 or modified Firefly
-                l.add(new StatusItem("Transmitter Days", parsedBattery.daysEstimate()));
-            } else if (DexTimeKeeper.getTransmitterAgeInDays(tx_id) < 100) { // Unmodified Firefly with 68 < Transmitter days < 100
-                l.add(new StatusItem("Transmitter Days", parsedBattery.daysEstimate(), Highlight.NOTICE));
+                TX_dys_highlight = NORMAL;
+            } else if (TX_dys < 100) { // Unmodified Firefly with 68 < Transmitter days < 100
+                TX_dys_highlight = NOTICE;
             } else { // Unmodified Firefly with transmitter days > 99
-                l.add(new StatusItem("Transmitter Days", parsedBattery.daysEstimate(), Highlight.BAD));
+                TX_dys_highlight = BAD;
             }
+            l.add(new StatusItem("Transmitter Days", parsedBattery.daysEstimate(), TX_dys_highlight));
             l.add(new StatusItem("Voltage A", parsedBattery.voltageA(), parsedBattery.voltageAWarning() ? BAD : NORMAL));
             l.add(new StatusItem("Voltage B", parsedBattery.voltageB(), parsedBattery.voltageBWarning() ? BAD : NORMAL));
             if (vr != null && FirmwareCapability.isFirmwareResistanceCapable(vr.firmware_version_string)) {


### PR DESCRIPTION
The transmitter days line on the system status page (for Dexcom) is highlighted if the transmitter is not resettable depending on how many days are left to the end of life.  

If transmitter days is less than 69, or if the transmitter is resettable, the Transmitter Days line will be as is now.

Only if the transmitter is Firefly and is not modified, the color will change when the transmitter days is greater than 68.  

![Screenshot_20220530-193639](https://user-images.githubusercontent.com/51497406/171069697-07f416dc-8bd2-4844-80d8-ac2d85d0d1a4.png)  

This serves as a reminder for the user to plan to order the next transmitter and plan the timing of the following sensors accordingly if the user intends to maximize the number of days they can use the transmitter.
It also highlights when no more sensors can be started.

This PR addresses the number 1 item from the three items identified here:
https://github.com/NightscoutFoundation/xDrip/pull/2143#issuecomment-1140510928

I will open another PR shortly to address 2 from the same list.

