### PR TITLE
Warn user about transmitter age on sensor start

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
@@ -27,14 +27,14 @@ import com.eveningoutpost.dexdrip.profileeditor.DatePickerFragment;
 import com.eveningoutpost.dexdrip.profileeditor.ProfileAdapter;
 import com.eveningoutpost.dexdrip.profileeditor.TimePickerFragment;
 import com.eveningoutpost.dexdrip.ui.dialog.G6CalibrationCodeDialog;
-import com.eveningoutpost.dexdrip.ui.dialog.G6EndOfLifeDialog;
 import com.eveningoutpost.dexdrip.utils.ActivityWithMenu;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.utils.LocationHelper;
 import com.eveningoutpost.dexdrip.wearintegration.WatchUpdaterService;
 import com.eveningoutpost.dexdrip.G5Model.DexTimeKeeper;
-import com.eveningoutpost.dexdrip.G5Model.FirmwareCapability;
 import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
+import com.eveningoutpost.dexdrip.G5Model.FirmwareCapability;
+import com.eveningoutpost.dexdrip.ui.dialog.G6EndOfLifeDialog;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -235,7 +235,7 @@ public class StartNewSensor extends ActivityWithMenu {
 
         LibreAlarmReceiver.clearSensorStats();
         // TODO this is just a timer and could be confusing - consider removing this notification
-       // JoH.scheduleNotification(xdrip.getAppContext(), "Sensor should be ready", xdrip.getAppContext().getString(R.string.please_enter_two_calibrations_to_get_started), 60 * 130, Home.SENSOR_READY_ID);
+        // JoH.scheduleNotification(xdrip.getAppContext(), "Sensor should be ready", xdrip.getAppContext().getString(R.string.please_enter_two_calibrations_to_get_started), 60 * 130, Home.SENSOR_READY_ID);
 
         // Add treatment entry in db
         Treatments.sensorStart(startTime, "Started by xDrip");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
@@ -168,7 +168,7 @@ public class StartNewSensor extends ActivityWithMenu {
 
     private void startSensorOrAskForG6Code() {
         if (Ob1G5CollectionService.usingCollector() && Ob1G5StateMachine.usingG6()) {
-            int TX_dys = DexTimeKeeper.getTransmitterAgeInDays(Pref.getString("dex_txid", "NULL"));
+            int TX_dys = DexTimeKeeper.getTransmitterAgeInDays(getTransmitterID());
             G6CalibrationCodeDialog.ask(this, this::startSensorAndSetIntent);
             String strt_warning ="";
             if (FirmwareCapability.isTransmitterModified(getTransmitterID())) { // Modified Firefly

--- a/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
@@ -173,15 +173,15 @@ public class StartNewSensor extends ActivityWithMenu {
             String strt_warning ="";
             if (FirmwareCapability.isTransmitterModified(getTransmitterID())) { // Modified Firefly
                 if (TX_dys > 179) {
-                    strt_warning = "You cannot successfully start a sensor since \"Transmitter Days\" is greater than 179.";
+                    strt_warning = getString(R.string.SensorStart_TX_EOL_Warning1);
                 } else if (TX_dys > 150) {
-                    strt_warning = "When \"Transmitter Days\" on system status page reaches 179 is the last day you can successfully start a sensor.";
+                    strt_warning = getString(R.string.SensorStart_TX_EOL_Warning2);
                 }
             } else { // Unmodified G6
                 if (TX_dys > 99) {
-                    strt_warning = "You cannot successfully start a sensor since \"Transmitter Days\" is greater than 99.";
+                    strt_warning = getString(R.string.SensorStart_TX_EOL_Warning3);
                 } else if (TX_dys > 68) {
-                    strt_warning = "When \"Transmitter Days\" on system status page reaches 99 is the last day you can successfully start a sensor.";
+                    strt_warning = getString(R.string.SensorStart_TX_EOL_Warning4);
                 }
             }
             if (strt_warning != null) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
@@ -27,10 +27,14 @@ import com.eveningoutpost.dexdrip.profileeditor.DatePickerFragment;
 import com.eveningoutpost.dexdrip.profileeditor.ProfileAdapter;
 import com.eveningoutpost.dexdrip.profileeditor.TimePickerFragment;
 import com.eveningoutpost.dexdrip.ui.dialog.G6CalibrationCodeDialog;
+import com.eveningoutpost.dexdrip.ui.dialog.G6EndOfLifeDialog;
 import com.eveningoutpost.dexdrip.utils.ActivityWithMenu;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.utils.LocationHelper;
 import com.eveningoutpost.dexdrip.wearintegration.WatchUpdaterService;
+import com.eveningoutpost.dexdrip.G5Model.DexTimeKeeper;
+import com.eveningoutpost.dexdrip.G5Model.FirmwareCapability;
+import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -39,6 +43,7 @@ import java.util.Locale;
 import static com.eveningoutpost.dexdrip.Home.startWatchUpdaterService;
 import static com.eveningoutpost.dexdrip.Models.BgReading.AGE_ADJUSTMENT_TIME;
 import static com.eveningoutpost.dexdrip.xdrip.gs;
+import static com.eveningoutpost.dexdrip.Services.Ob1G5CollectionService.getTransmitterID;
 
 public class StartNewSensor extends ActivityWithMenu {
     // public static String menu_name = "Start Sensor";
@@ -48,6 +53,8 @@ public class StartNewSensor extends ActivityWithMenu {
     // private TimePicker tp;
     final Activity activity = this;
     Calendar ucalendar = Calendar.getInstance();
+    private static final String TX_EOL = "TX_EOL"; // True when transmitter cannot start more sensors
+    private static final String TX_Mod = "TX_Mod"; // True for modified transmitters
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -168,8 +175,23 @@ public class StartNewSensor extends ActivityWithMenu {
         final int cap = 20;
         if (Ob1G5CollectionService.usingCollector() && Ob1G5StateMachine.usingG6()) {
             if (JoH.pratelimit("dex-stop-start", cap)) {
+                int TX_dys = DexTimeKeeper.getTransmitterAgeInDays(getTransmitterID());
+                PersistentStore.setBoolean(TX_EOL, false);
+                PersistentStore.setBoolean(TX_Mod, false);
+                if (FirmwareCapability.isTransmitterModified(getTransmitterID())) { // Transmitter is modified
+                    PersistentStore.setBoolean(TX_Mod, true);
+                }
+                if (TX_dys > 179 || !PersistentStore.getBoolean("TX_Mod") & TX_dys > 99) { // Cannot start a sensor any longer
+                    PersistentStore.setBoolean(TX_EOL, true);
+                }
                 JoH.clearRatelimit("dex-stop-start");
-                G6CalibrationCodeDialog.ask(this, this::startSensorAndSetIntent);
+                if (TX_dys < 69 || PersistentStore.getBoolean("TX_Mod") & TX_dys < 149) { // More than 30 days left of starting sensors
+                    G6CalibrationCodeDialog.ask(this, this::startSensorAndSetIntent);
+                } else { // 30 or less days left of starting sensors
+                    G6EndOfLifeDialog.show(activity, () -> {
+                        G6CalibrationCodeDialog.ask(this, this::startSensorAndSetIntent);
+                    });
+                }
             } else {
                 JoH.static_toast_long(String.format(Locale.ENGLISH, getString(R.string.please_wait_seconds_before_trying_to_start_sensor), cap));
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/dialog/G6EndOfLifeDialog.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/dialog/G6EndOfLifeDialog.java
@@ -1,0 +1,61 @@
+package com.eveningoutpost.dexdrip.ui.dialog;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import com.eveningoutpost.dexdrip.G5Model.DexTimeKeeper;
+
+import static com.eveningoutpost.dexdrip.Services.Ob1G5CollectionService.getTransmitterID;
+import com.eveningoutpost.dexdrip.R;
+import com.eveningoutpost.dexdrip.UtilityModels.PersistentStore;
+
+// Navid200
+
+public class G6EndOfLifeDialog {
+    // Inform the user of Transmitter Days if it is close to or beyond end of life.
+    public static void show(final Activity activity, Runnable runnable) {
+        String Title = activity.getString(R.string.reminder);
+        String Message = activity.getString(R.string.TX_EOL_reminder);
+        int TX_dys = DexTimeKeeper.getTransmitterAgeInDays(getTransmitterID());
+        if (PersistentStore.getBoolean("TX_EOL")) { // Cannot start sensors
+            Title = activity.getString(R.string.notification);
+            Message = activity.getString(R.string.TX_EOL_notification);
+        } else { // Approaching end of life
+            Title = activity.getString(R.string.reminder);
+            Message = activity.getString(R.string.TX_EOL_reminder);
+            if (PersistentStore.getBoolean("TX_Mod")) { // modified transmitter
+                Message = activity.getString(R.string.TX_EOL_reminder_mod);
+            }
+        }
+        final android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(activity)
+                .setTitle(Title)
+                .setMessage(Message);
+
+        builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                runnable.run();
+            }
+        });
+
+        if (PersistentStore.getBoolean("TX_EOL")) {
+            builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    dialog.cancel();
+                }
+            });
+        }
+
+        final AlertDialog dialog = builder.create();
+        // apparently possible dialog is already showing, probably due to hash code
+        try {
+            if (dialog.isShowing()) {
+                dialog.dismiss();
+            }
+        } catch (Exception e) {
+            //
+        }
+        dialog.show();
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/dialog/G6EndOfLifeDialog.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/dialog/G6EndOfLifeDialog.java
@@ -31,7 +31,7 @@ public class G6EndOfLifeDialog {
                 .setTitle(Title)
                 .setMessage(Message);
 
-        builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+        builder.setPositiveButton(R.string.proceed, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 runnable.run();
@@ -39,7 +39,7 @@ public class G6EndOfLifeDialog {
         });
 
         if (PersistentStore.getBoolean("TX_EOL")) {
-            builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+            builder.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
                     dialog.cancel();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1700,10 +1700,11 @@
     <string name="locked_time_period_always_used">Locked Time Period Always Used</string>
     <string name="show_time_buttons">Show Time Buttons</string>
     <string name="source_wizard_button">Source Wizard Button</string>
-    <string name="please_wait_seconds_before_trying_to_start_sensor">Please wait %d seconds before trying to start sensor</string>
     <string name="reminder">Reminder</string>
     <string name="notification">Notification</string>
     <string name="TX_EOL_reminder">When Transmitter Days, on system status page, reaches 99 will be the last opportunity to start a sensor on this transmitter.</string>
-    <string name="TX_EOL_notification">If you proceed and start sensor, very likely it will fail because of Transmitter Days having reached maximum.  Proceed?</string>
-    <string name="TX_EOL_reminder_mod">Transmitter Days, on system status page, is approaching maximum.  Soon, you will not be able to start sensors on this transmitter.</string>
+    <string name="TX_EOL_notification">If you proceed and start sensor, very likely it will fail because of Transmitter Days having reached maximum.</string>
+    <string name="TX_EOL_reminder_mod">Transmitter Days, on system status page, is approaching maximum. Soon, you will not be able to start sensors on this transmitter.</string>
+    <string name="proceed">Proceed</string>
+    <string name="please_wait_seconds_before_trying_to_start_sensor">Please wait %d seconds before trying to start sensor</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1701,4 +1701,9 @@
     <string name="show_time_buttons">Show Time Buttons</string>
     <string name="source_wizard_button">Source Wizard Button</string>
     <string name="please_wait_seconds_before_trying_to_start_sensor">Please wait %d seconds before trying to start sensor</string>
+    <string name="reminder">Reminder</string>
+    <string name="notification">Notification</string>
+    <string name="TX_EOL_reminder">When Transmitter Days, on system status page, reaches 99 will be the last opportunity to start a sensor on this transmitter.</string>
+    <string name="TX_EOL_notification">If you proceed and start sensor, very likely it will fail because of Transmitter Days having reached maximum.  Proceed?</string>
+    <string name="TX_EOL_reminder_mod">Transmitter Days, on system status page, is approaching maximum.  Soon, you will not be able to start sensors on this transmitter.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
 
     <string name="title_activity_bluetooth_scan">Bluetooth Scan</string>
@@ -1700,8 +1700,5 @@
     <string name="locked_time_period_always_used">Locked Time Period Always Used</string>
     <string name="show_time_buttons">Show Time Buttons</string>
     <string name="source_wizard_button">Source Wizard Button</string>
-    <string name="SensorStart_TX_EOL_Warning1">You cannot successfully start a sensor since "Transmitter Days" is greater than 179.</string>
-    <string name="SensorStart_TX_EOL_Warning2">When "Transmitter Days" on system status page reaches 179 is the last day you can successfully start a sensor.</string>
-    <string name="SensorStart_TX_EOL_Warning3">You cannot successfully start a sensor since "Transmitter Days" is greater than 99.</string>
-    <string name="SensorStart_TX_EOL_Warning4">When "Transmitter Days" on system status page reaches 99 is the last day you can successfully start a sensor.</string>
+    <string name="please_wait_seconds_before_trying_to_start_sensor">Please wait %d seconds before trying to start sensor</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1707,4 +1707,5 @@
     <string name="TX_EOL_reminder_mod">Transmitter Days, on system status page, is approaching maximum. Soon, you will not be able to start sensors on this transmitter.</string>
     <string name="proceed">Proceed</string>
     <string name="please_wait_seconds_before_trying_to_start_sensor">Please wait %d seconds before trying to start sensor</string>
+    <string name="please_update_OOP2_or_move_to_calibrate_based_on_raw_mode">please update OOP2 or move to calibrate based on raw mode</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1700,4 +1700,8 @@
     <string name="locked_time_period_always_used">Locked Time Period Always Used</string>
     <string name="show_time_buttons">Show Time Buttons</string>
     <string name="source_wizard_button">Source Wizard Button</string>
+    <string name="SensorStart_TX_EOL_Warning1">You cannot successfully start a sensor since "Transmitter Days" is greater than 179.</string>
+    <string name="SensorStart_TX_EOL_Warning2">When "Transmitter Days" on system status page reaches 179 is the last day you can successfully start a sensor.</string>
+    <string name="SensorStart_TX_EOL_Warning3">You cannot successfully start a sensor since "Transmitter Days" is greater than 99.</string>
+    <string name="SensorStart_TX_EOL_Warning4">When "Transmitter Days" on system status page reaches 99 is the last day you can successfully start a sensor.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1700,12 +1700,12 @@
     <string name="locked_time_period_always_used">Locked Time Period Always Used</string>
     <string name="show_time_buttons">Show Time Buttons</string>
     <string name="source_wizard_button">Source Wizard Button</string>
+    <string name="please_wait_seconds_before_trying_to_start_sensor">Please wait %d seconds before trying to start sensor</string>
+    <string name="please_update_OOP2_or_move_to_calibrate_based_on_raw_mode">please update OOP2 or move to calibrate based on raw mode</string>
     <string name="reminder">Reminder</string>
     <string name="notification">Notification</string>
     <string name="TX_EOL_reminder">When Transmitter Days, on system status page, reaches 99 will be the last opportunity to start a sensor on this transmitter.</string>
     <string name="TX_EOL_notification">If you proceed and start sensor, very likely it will fail because of Transmitter Days having reached maximum.</string>
     <string name="TX_EOL_reminder_mod">Transmitter Days, on system status page, is approaching maximum. Soon, you will not be able to start sensors on this transmitter.</string>
     <string name="proceed">Proceed</string>
-    <string name="please_wait_seconds_before_trying_to_start_sensor">Please wait %d seconds before trying to start sensor</string>
-    <string name="please_update_OOP2_or_move_to_calibrate_based_on_raw_mode">please update OOP2 or move to calibrate based on raw mode</string>
 </resources>


### PR DESCRIPTION
This PR addresses # 2 from the list identified here:
https://github.com/NightscoutFoundation/xDrip/pull/2143#issuecomment-1140510928

In addition, it also provides a warning ahead of time so that the user can plan the timing of the following few sensors carefully and plan to place an order for a new transmitter or hard reset their transmitter depending on what kind of transmitter they have.

@jamorham I have not tested this yet.  I will have a sensor start coming up and will test then.  That's why this is still a draft.
But, would you please tell me if you see anything in the code that you don't like like code duplication or ...?