### PR TITLE
Add Range Settings to the first statistics page

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -73,11 +73,11 @@ public class FirstPageFragment extends Fragment {
             TextView lowView = (TextView) localView.findViewById(R.id.textView_stats_low);
             //update stats_high/low
             if (!mgdl) {
-                updateText(localView, highView, (Math.round(stats_high * 10) / 10d) + " mmol/L");
-                updateText(localView, lowView, (Math.round(stats_low * 10) / 10d) + " mmol/L");
+                updateText(localView, highView, (Math.round(stats_high * 10) / 10d) + " mmol/l");
+                updateText(localView, lowView, (Math.round(stats_low * 10) / 10d) + " mmol/l");
             } else {
-                updateText(localView, highView, Math.round(stats_high) + " mg/dL");
-                updateText(localView, lowView, Math.round(stats_low) + " mg/dL");
+                updateText(localView, highView, Math.round(stats_high) + " mg/dl");
+                updateText(localView, lowView, Math.round(stats_low) + " mg/dl");
             }
 
             if (context == null) {
@@ -110,10 +110,10 @@ public class FirstPageFragment extends Fragment {
                 TextView medianView = (TextView) localView.findViewById(R.id.textView_median);
 
                 if (mgdl) {
-                    updateText(localView, medianView, Math.round(median * 10) / 10d + " mg/dL");
+                    updateText(localView, medianView, Math.round(median * 10) / 10d + " mg/dl");
 
                 } else {
-                    updateText(localView, medianView, Math.round(median * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d + " mmol/L");
+                    updateText(localView, medianView, Math.round(median * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d + " mmol/l");
 
                 }
 
@@ -127,9 +127,9 @@ public class FirstPageFragment extends Fragment {
                 TextView meanView = (TextView) localView.findViewById(R.id.textView_mean);
                 //update mean
                 if (mgdl) {
-                    updateText(localView, meanView, (Math.round(mean * 10) / 10d) + " mg/dL");
+                    updateText(localView, meanView, (Math.round(mean * 10) / 10d) + " mg/dl");
                 } else {
-                    updateText(localView, meanView, (Math.round(mean * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d) + " mmol/L");
+                    updateText(localView, meanView, (Math.round(mean * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d) + " mmol/l");
 
                 }
                 //update A1c
@@ -145,9 +145,9 @@ public class FirstPageFragment extends Fragment {
                 stdev = Math.sqrt(stdev);
                 TextView stdevView = (TextView) localView.findViewById(R.id.textView_stdev);
                 if (mgdl) {
-                    updateText(localView, stdevView, (Math.round(stdev * 10) / 10d) + " mg/dL");
+                    updateText(localView, stdevView, (Math.round(stdev * 10) / 10d) + " mg/dl");
                 } else {
-                    updateText(localView, stdevView, (Math.round(stdev * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d) + " mmol/L");
+                    updateText(localView, stdevView, (Math.round(stdev * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d) + " mmol/l");
                 }
 
                 TextView coefficientOfVariation = (TextView) localView.findViewById(R.id.textView_coefficient_of_variation);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -7,6 +7,8 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+
+import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -15,6 +17,8 @@ import android.widget.TextView;
 
 import com.eveningoutpost.dexdrip.ImportedLibraries.dexcom.Dex_Constants;
 import com.eveningoutpost.dexdrip.R;
+import com.eveningoutpost.dexdrip.UtilityModels.Constants;
+import com.mongodb.Tag;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -63,13 +67,27 @@ public class FirstPageFragment extends Fragment {
             super.run();
             Log.d("DrawStats", "FirstPageFragment CalculationThread started");
 
+            // Let's put the High and Low Values on screen so that this becomes a self-contained page.
+            // Navid (Navid200), June 5, 2022
             SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
             boolean mgdl = "mgdl".equals(settings.getString("units", "mgdl"));
-
-            if (context == null) {
-                Log.d("DrawStats", "FirstPageFragment context == null, do not calculate if fragment is not attached");
-                return;
+            double stats_high = Double.parseDouble(settings.getString("highValue", "170"));
+            double stats_low = Double.parseDouble(settings.getString("lowValue", "70"));
+            TextView highView = (TextView) localView.findViewById(R.id.textView_stats_high);
+            TextView lowView = (TextView) localView.findViewById(R.id.textView_stats_low);
+            //update stats_high/low
+            if (!mgdl) {
+                updateText(localView, highView, (Math.round(stats_high * 10) / 10d) + " mmol/L");
+                updateText(localView, lowView, (Math.round(stats_low * 10) / 10d) + " mmol/L");
+            } else {
+                updateText(localView, highView, Math.round(stats_high) + " mg/dL");
+                updateText(localView, lowView, Math.round(stats_low) + " mg/dL");
             }
+
+      //      if (context == null) {
+      //          Log.d("DrawStats", "FirstPageFragment context == null, do not calculate if fragment is not attached");
+      //          return;
+      //      }
 
             //Ranges
             long aboveRange = DBSearchUtil.noReadingsAboveRange(context);
@@ -96,10 +114,10 @@ public class FirstPageFragment extends Fragment {
                 TextView medianView = (TextView) localView.findViewById(R.id.textView_median);
 
                 if (mgdl) {
-                    updateText(localView, medianView, Math.round(median * 10) / 10d + " mg/dl");
+                    updateText(localView, medianView, Math.round(median * 10) / 10d + " mg/dL");
 
                 } else {
-                    updateText(localView, medianView, Math.round(median * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d + " mmol/l");
+                    updateText(localView, medianView, Math.round(median * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d + " mmol/L");
 
                 }
 
@@ -113,9 +131,9 @@ public class FirstPageFragment extends Fragment {
                 TextView meanView = (TextView) localView.findViewById(R.id.textView_mean);
                 //update mean
                 if (mgdl) {
-                    updateText(localView, meanView, (Math.round(mean * 10) / 10d) + " mg/dl");
+                    updateText(localView, meanView, (Math.round(mean * 10) / 10d) + " mg/dL");
                 } else {
-                    updateText(localView, meanView, (Math.round(mean * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d) + " mmol/l");
+                    updateText(localView, meanView, (Math.round(mean * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d) + " mmol/L");
 
                 }
                 //update A1c
@@ -131,9 +149,9 @@ public class FirstPageFragment extends Fragment {
                 stdev = Math.sqrt(stdev);
                 TextView stdevView = (TextView) localView.findViewById(R.id.textView_stdev);
                 if (mgdl) {
-                    updateText(localView, stdevView, (Math.round(stdev * 10) / 10d) + " mg/dl");
+                    updateText(localView, stdevView, (Math.round(stdev * 10) / 10d) + " mg/dL");
                 } else {
-                    updateText(localView, stdevView, (Math.round(stdev * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d) + " mmol/l");
+                    updateText(localView, stdevView, (Math.round(stdev * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d) + " mmol/L");
                 }
 
                 TextView coefficientOfVariation = (TextView) localView.findViewById(R.id.textView_coefficient_of_variation);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -80,10 +80,10 @@ public class FirstPageFragment extends Fragment {
                 updateText(localView, lowView, Math.round(stats_low) + " mg/dL");
             }
 
-      //      if (context == null) {
-      //          Log.d("DrawStats", "FirstPageFragment context == null, do not calculate if fragment is not attached");
-      //          return;
-      //      }
+            if (context == null) {
+                Log.d("DrawStats", "FirstPageFragment context == null, do not calculate if fragment is not attached");
+                return;
+            }
 
             //Ranges
             long aboveRange = DBSearchUtil.noReadingsAboveRange(context);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -7,8 +7,6 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-
-import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -17,8 +15,6 @@ import android.widget.TextView;
 
 import com.eveningoutpost.dexdrip.ImportedLibraries.dexcom.Dex_Constants;
 import com.eveningoutpost.dexdrip.R;
-import com.eveningoutpost.dexdrip.UtilityModels.Constants;
-import com.mongodb.Tag;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -63,22 +63,8 @@ public class FirstPageFragment extends Fragment {
             super.run();
             Log.d("DrawStats", "FirstPageFragment CalculationThread started");
 
-            // Let's put the High and Low Values on screen so that this becomes a self-contained page.
-            // Navid (Navid200), June 5, 2022
             SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
             boolean mgdl = "mgdl".equals(settings.getString("units", "mgdl"));
-            double stats_high = Double.parseDouble(settings.getString("highValue", "170"));
-            double stats_low = Double.parseDouble(settings.getString("lowValue", "70"));
-            TextView highView = (TextView) localView.findViewById(R.id.textView_stats_high);
-            TextView lowView = (TextView) localView.findViewById(R.id.textView_stats_low);
-            //update stats_high/low
-            if (!mgdl) {
-                updateText(localView, highView, (Math.round(stats_high * 10) / 10d) + " mmol/l");
-                updateText(localView, lowView, (Math.round(stats_low * 10) / 10d) + " mmol/l");
-            } else {
-                updateText(localView, highView, Math.round(stats_high) + " mg/dl");
-                updateText(localView, lowView, Math.round(stats_low) + " mg/dl");
-            }
 
             if (context == null) {
                 Log.d("DrawStats", "FirstPageFragment context == null, do not calculate if fragment is not attached");
@@ -99,9 +85,21 @@ public class FirstPageFragment extends Fragment {
             int inPercent = 100 - abovePercent - belowPercent;
 
             TextView rangespercent = (TextView) localView.findViewById(R.id.textView_ranges_percent);
-            TextView rangesabsolute = (TextView) localView.findViewById(R.id.textView_ranges_absolute);
-
             updateText(localView, rangespercent, inPercent + "%/" + abovePercent + "%/" + belowPercent + "%");
+
+            // Let's put the range settings on screen so that this becomes a self-contained page.
+            // Navid200
+            double stats_high = Double.parseDouble(settings.getString("highValue", "170"));
+            double stats_low = Double.parseDouble(settings.getString("lowValue", "70"));
+            TextView rangeView = (TextView) localView.findViewById(R.id.textView_stats_range_set);
+            //update stats_high/low
+            if (!mgdl) {
+                updateText(localView, rangeView, (Math.round(stats_low * 10) / 10d) + " - " + (Math.round(stats_high * 10) / 10d) + " mmol/l");
+            } else {
+                updateText(localView, rangeView, Math.round(stats_low) + " - " + (Math.round(stats_high)) + " mg/dl");
+            }
+
+            TextView rangesabsolute = (TextView) localView.findViewById(R.id.textView_ranges_absolute);
             updateText(localView, rangesabsolute, inRange + "/" + aboveRange + "/" + belowRange);
 
             List<BgReadingStats> bgList = DBSearchUtil.getReadings(true);

--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -29,7 +29,7 @@
                     android:paddingStart="5dp"
                     android:paddingEnd="0dp"
                     android:text="@string/stats_high_value"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    android:textAppearance="?android:attr/textAppearanceLarge" />
 
                 <TextView
                     android:id="@+id/textView_stats_high"
@@ -39,7 +39,7 @@
                     android:paddingStart="5dp"
                     android:paddingEnd="5dp"
                     android:text=": ---"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
 
             <LinearLayout
@@ -57,7 +57,7 @@
                     android:paddingStart="5dp"
                     android:paddingEnd="0dp"
                     android:text="@string/stats_low_value"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    android:textAppearance="?android:attr/textAppearanceLarge" />
 
                 <TextView
                     android:id="@+id/textView_stats_low"
@@ -67,7 +67,7 @@
                     android:paddingStart="5dp"
                     android:paddingEnd="5dp"
                     android:text=": ---"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -22,62 +22,6 @@
                 android:padding="5dp">
 
                 <TextView
-                    android:id="@+id/textView20"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="0dp"
-                    android:text="@string/stats_high_value"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-
-                <TextView
-                    android:id="@+id/textView_stats_high"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text=": ---"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
-
-                <TextView
-                    android:id="@+id/textView21"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="0dp"
-                    android:text="@string/stats_low_value"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-
-                <TextView
-                    android:id="@+id/textView_stats_low"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text=": ---"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
-
-                <TextView
                     android:id="@+id/textView4"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -95,6 +39,34 @@
                     android:paddingStart="5dp"
                     android:paddingEnd="5dp"
                     android:text="--%/--%/--%"
+                    android:textAppearance="?android:attr/textAppearanceLarge" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="left"
+                android:orientation="horizontal"
+                android:padding="5dp">
+
+                <TextView
+                    android:id="@+id/textView20"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:text="@string/stats_range_settings"
+                    android:textAppearance="?android:attr/textAppearanceLarge" />
+
+                <TextView
+                    android:id="@+id/textView_stats_range_set"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
+                    android:text=": ---"
                     android:textAppearance="?android:attr/textAppearanceLarge" />
             </LinearLayout>
 

--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -22,6 +22,62 @@
                 android:padding="5dp">
 
                 <TextView
+                    android:id="@+id/textView20"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:text="@string/stats_high_value"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                    android:id="@+id/textView_stats_high"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
+                    android:text=": ---"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="left"
+                android:orientation="horizontal"
+                android:padding="5dp">
+
+                <TextView
+                    android:id="@+id/textView21"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:text="@string/stats_low_value"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                    android:id="@+id/textView_stats_low"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
+                    android:text=": ---"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="left"
+                android:orientation="horizontal"
+                android:padding="5dp">
+
+                <TextView
                     android:id="@+id/textView4"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,8 +204,7 @@
     <string name="general_settings">General Settings</string>
     <string name="high_value">High Value</string>
     <string name="low_value">Low Value</string>
-    <string name="stats_high_value">High Value: </string>
-    <string name="stats_low_value">Low Value: </string>
+    <string name="stats_range_settings">Range Settings: </string>
     <string name="end_user_license_agreement">End User License Agreement</string>
     <string name="save">Save</string>
     <string name="view_important_warning">View Important Warning</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,8 @@
     <string name="general_settings">General Settings</string>
     <string name="high_value">High Value</string>
     <string name="low_value">Low Value</string>
+    <string name="stats_high_value">High Value: </string>
+    <string name="stats_low_value">Low Value: </string>
     <string name="end_user_license_agreement">End User License Agreement</string>
     <string name="save">Save</string>
     <string name="view_important_warning">View Important Warning</string>


### PR DESCRIPTION
The time in-range parameter, included on the first statistics page is a very important parameter.  However, it is meaningless without specifying what the range is.
Currently, that page does not show the range.  If you change your High and Low Values, you can see that the time in-range as well as PGS change accordingly.

This PR adds the High and Low values to the first statistics page as shown below.
![Screenshot_20220705-115855](https://user-images.githubusercontent.com/51497406/177369548-da415712-7e15-4692-b3e2-dbeff3b8feed.png)




Edit:
I have changed the font size to be identical to everything else on the screen.  I personally believe the font should be smaller because the high and low values are not values that have been calculated.  Rather those are parameters the user has entered.  So, it's best to have a way of separating them from the rest of the data.

I have opened another PR to make all the blood glucose units in xDrip including the ones on the statistics page consistent:
https://github.com/NightscoutFoundation/xDrip/pull/2166