### PR TITLE
AAPS profile import Log instead of toast message

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ImportAapsProfile.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ImportAapsProfile.java
@@ -71,7 +71,7 @@ public class ImportAapsProfile {
             if (Pref.getBooleanDefaultFalse("profile_import_sound")) {
                 BackgroundQueue.post(() -> JoH.playSoundUri(JoH.getResourceURI(R.raw.labbed_musical_chime)));
             }
-            JoH.static_toast_long("xDrip imported AAPS profile");
+            UserError.Log.e(TAG, "xDrip imported AAPS profile");
         }
     }
 


### PR DESCRIPTION
Those who use AAPS have an option to disable the sound.  But, there is no way to disable the toast message.
It seems the toast message can be annoying.  https://github.com/NightscoutFoundation/xDrip/discussions/2092 
This changes it to a log message.  

I cannot 100% test this because I don't use AAPS!
I have compiled and am using it on my mission mode device right now.
But, I cannot tell you that I have verified the log.