### PR TITLE
Don't allow xDrip to work with OOP2 versions before 1.2 (unless calibrate raw is used)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiver.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import static com.eveningoutpost.dexdrip.Models.BgReading.bgReadingInsertFromJson;
+import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 /**
  * Created by jamorham on 14/11/2016.
@@ -226,12 +227,26 @@ public class NSEmulatorReceiver extends BroadcastReceiver {
             }
         }.start();
     }
+    private double getOOP2Version(final Bundle bundle) {
+        final Double version = bundle.getDouble(Intents.OOP2_VERSION_NAME, 0);
+        return version;
+    }
 
     private JSONObject extractParams(final Bundle bundle) {
         if (bundle == null) {
             Log.e(TAG, "Null bundle passed to extract params");
             return null;
         }
+        double version = getOOP2Version(bundle);
+        boolean calibrate_raw = Pref.getString("calibrate_external_libre_2_algorithm_type", "calibrate_raw").equals("calibrate_raw");
+        Log.d(TAG, "oop2 version = " + version + " calibarate_raw " + calibrate_raw);
+        if(version < 1.2 && !calibrate_raw) {
+            // Versions before 1.2 had a bug or missed features which allows them only to work on raw mode.
+            JoH.static_toast_long(gs(R.string.please_update_OOP2_or_move_to_calibrate_based_on_raw_mode));
+            Log.ueh(TAG, "OOP2 is too old to use with no calibration mode. Please update OOP2 or move to 'calibrate based on raw' mode.");
+            return null;
+        }
+
         final String json = bundle.getString("json");
         if (json == null) {
             Log.e(TAG, "json == null returning");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Intents.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Intents.java
@@ -86,6 +86,7 @@ public interface Intents {
     String BT_UNLOCK_BUFFER_ARRAY = "BtUnlockBufferArray";
     String TREND_BG = "TrendBg";
     String HISTORIC_BG = "HistoricBg";
+    String OOP2_VERSION_NAME = "OOP2_VERSION";
     
     String TAG_ID = "TagId";
     String ROW_ID = "RowId";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1701,4 +1701,5 @@
     <string name="show_time_buttons">Show Time Buttons</string>
     <string name="source_wizard_button">Source Wizard Button</string>
     <string name="please_wait_seconds_before_trying_to_start_sensor">Please wait %d seconds before trying to start sensor</string>
+    <string name="please_update_OOP2_or_move_to_calibrate_based_on_raw_mode">please update OOP2 or move to calibrate based on raw mode</string>
 </resources>


### PR DESCRIPTION
There have been two versions before the 1.2.
The first version only supported raw calibration mode. Users of this version will not see any difference, and if they try to move to a new mode will get a message saying that they need to upgrade OOP2, or return to "calibrate based on raw" mode.

The second version had a bug and was removed. Still some users might be using it in "no calibration" or "calibrate based on glucose" mode. This users will see xDrip stops working, but this is the preferred way since the banned OOP2 had a bug that might make it show BG values that are very inaccurate (300 instead of 100).
OOP2 does not have an auto-update feature, so this is the only way to revoke it.