### PR TITLE
Data table two words

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -465,7 +465,7 @@
     <string name="special_glucose_value_to_display_message">Special glucose value to display the message below</string>
     <string name="bluetooth_wakelocks">Bluetooth Wakelocks</string>
     <string name="compatible_broadcast">Compatible Broadcast</string>
-    <string name="show_datatables">Show Datatables</string>
+    <string name="show_datatables">Show Data tables</string>
     <string name="display_bridge_battery">Display Bridge Battery</string>
     <string name="close_gatt_on_ble_disconnect">Close GATT on BLE disconnect</string>
     <string name="disable_battery_warning">Disable Battery Warning</string>
@@ -660,7 +660,7 @@
     <string name="set_logging_appid">Set Logging AppID</string>
     <string name="only_enable_on_trouble">Only enable if you are having trouble with the app.</string>
     <string name="store_logs">Store logs for troubleshooting</string>
-    <string name="show_datatables_in_app_drawer">Show Calibration and BG datatables in the app drawer.</string>
+    <string name="show_datatables_in_app_drawer">Show Calibration and BG data tables in the app drawer.</string>
     <string name="disable_log_transmitter_battery_warning">Disable the warning for low transmitter battery state on the home screen. (Only relevant for DIY receivers.)</string>
     <string name="engineering_mode">Engineering mode</string>
     <string name="allow_unsafe_settings">Allows changing the most unsafe settings which could break everything!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -465,7 +465,7 @@
     <string name="special_glucose_value_to_display_message">Special glucose value to display the message below</string>
     <string name="bluetooth_wakelocks">Bluetooth Wakelocks</string>
     <string name="compatible_broadcast">Compatible Broadcast</string>
-    <string name="show_datatables">Show Data tables</string>
+    <string name="show_datatables">Show Data Tables</string>
     <string name="display_bridge_battery">Display Bridge Battery</string>
     <string name="close_gatt_on_ble_disconnect">Close GATT on BLE disconnect</string>
     <string name="disable_battery_warning">Disable Battery Warning</string>


### PR DESCRIPTION
Unless this is intentional, please let's fix it.
Right now it reads datatables. 

This is what it will look like after this PR:
![Screenshot_20220625-180029](https://user-images.githubusercontent.com/51497406/175791725-4f591001-c1fe-4565-a464-8311b3c6dab2.jpg)
