### PR TITLE
allow up to two decimal digits for insulin

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1,5 +1,15 @@
 package com.eveningoutpost.dexdrip;
 
+import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+import static com.eveningoutpost.dexdrip.Models.JoH.msSince;
+import static com.eveningoutpost.dexdrip.Models.JoH.tsl;
+import static com.eveningoutpost.dexdrip.UtilityModels.ColorCache.X;
+import static com.eveningoutpost.dexdrip.UtilityModels.ColorCache.getCol;
+import static com.eveningoutpost.dexdrip.UtilityModels.Constants.DAY_IN_MS;
+import static com.eveningoutpost.dexdrip.UtilityModels.Constants.HOUR_IN_MS;
+import static com.eveningoutpost.dexdrip.UtilityModels.Constants.MINUTE_IN_MS;
+import static com.eveningoutpost.dexdrip.xdrip.gs;
+
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
@@ -170,16 +180,6 @@ import lecho.lib.hellocharts.model.Viewport;
 import lecho.lib.hellocharts.view.LineChartView;
 import lecho.lib.hellocharts.view.PreviewLineChartView;
 import lombok.Getter;
-
-import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
-import static com.eveningoutpost.dexdrip.Models.JoH.msSince;
-import static com.eveningoutpost.dexdrip.Models.JoH.tsl;
-import static com.eveningoutpost.dexdrip.UtilityModels.ColorCache.X;
-import static com.eveningoutpost.dexdrip.UtilityModels.ColorCache.getCol;
-import static com.eveningoutpost.dexdrip.UtilityModels.Constants.DAY_IN_MS;
-import static com.eveningoutpost.dexdrip.UtilityModels.Constants.HOUR_IN_MS;
-import static com.eveningoutpost.dexdrip.UtilityModels.Constants.MINUTE_IN_MS;
-import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPermissionsResultCallback {
     private final static String TAG = "jamorham " + Home.class.getSimpleName();
@@ -1459,15 +1459,20 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                 break;
 
             case "rapid":
-                if (!insulinsumset && (thisnumber > 0)) {
-                    thisInsulinSumNumber = thisnumber;
-                    textInsulinSumDose.setText(Double.toString(thisnumber) + " units");
-                    Log.d(TAG, "Rapid dose: " + Double.toString(thisnumber));
-                    textInsulinSumDose.setVisibility(View.VISIBLE);
-                    if (!MultipleInsulins.isEnabled()) {
-                        buttonInsulinSingleDose.setVisibility(View.VISIBLE); // show the button next to the single insulin dose if not using multiples
+                if (!insulinsumset) {
+                    final String thisNumberStr = Double.toString(thisnumber);
+                    if (thisnumber > 0) {
+                        thisInsulinSumNumber = thisnumber;
+                        textInsulinSumDose.setText(thisNumberStr + " units");
+                        Log.d(TAG, "Rapid dose: " + thisNumberStr);
+                        textInsulinSumDose.setVisibility(View.VISIBLE);
+                        if (!MultipleInsulins.isEnabled()) {
+                            buttonInsulinSingleDose.setVisibility(View.VISIBLE); // show the button next to the single insulin dose if not using multiples
+                        }
+                        insulinsumset = true;
+                    } else {
+                        Log.d(TAG, " Insulin dose is too small: " + thisNumberStr);
                     }
-                    insulinsumset = true;
                 } else {
                     Log.d(TAG, "Rapid dose already set");
                     preserve = true;
@@ -1575,13 +1580,18 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                                 thisinsulinprofile[number] = insulin;
                                 break;
                             }
-                        if (!insulinset[number] && (thisnumber > 0)) {
-                            thisinsulinnumber[number] = thisnumber;
-                            textInsulinDose[number].setText(Double.toString(thisnumber) + " " + insulin.getName());
-                            Log.d(TAG, insulin.getName() + " dose: " + Double.toString(thisnumber));
-                            insulinset[number] = true;
-                            btnInsulinDose[number].setVisibility(View.VISIBLE);
-                            textInsulinDose[number].setVisibility(View.VISIBLE);
+                        if (!insulinset[number]) {
+                            final String thisNumberStr = Double.toString(thisnumber);
+                            if (thisnumber > 0) {
+                                thisinsulinnumber[number] = thisnumber;
+                                textInsulinDose[number].setText(thisNumberStr + " " + insulin.getName());
+                                Log.d(TAG, insulin.getName() + " dose: " + thisNumberStr);
+                                insulinset[number] = true;
+                                btnInsulinDose[number].setVisibility(View.VISIBLE);
+                                textInsulinDose[number].setVisibility(View.VISIBLE);
+                            } else {
+                                Log.d(TAG, insulin.getName() + " dose is too small: " + thisNumberStr);
+                            }
                         } else {
                             Log.d(TAG, insulin.getName() + " dose already set");
                             preserve = true;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/PhoneKeypadInputActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/PhoneKeypadInputActivity.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip;
 
+import static com.eveningoutpost.dexdrip.Home.startHomeWithExtra;
+
 import android.graphics.Color;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
@@ -18,10 +20,11 @@ import com.eveningoutpost.dexdrip.insulin.InsulinManager;
 import com.eveningoutpost.dexdrip.insulin.MultipleInsulins;
 import com.eveningoutpost.dexdrip.wearintegration.WatchUpdaterService;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
-
-import static com.eveningoutpost.dexdrip.Home.startHomeWithExtra;
 
 
 /**
@@ -386,6 +389,7 @@ public class PhoneKeypadInputActivity extends BaseActivity {
 
         String mystring = "";
         double units = 0;
+        final DecimalFormat df = new DecimalFormat("0.0#", new DecimalFormatSymbols(Locale.ENGLISH));
         if (timeValue.length() > 0) mystring += timeValue + " time ";
         if (nonzeroBloodValue) mystring += getValue("bloodtest") + " blood ";
         if (nonzeroCarbsValue) mystring += getValue("carbs") + " g carbs ";
@@ -393,24 +397,24 @@ public class PhoneKeypadInputActivity extends BaseActivity {
         {
             double d = Double.parseDouble(getValue("insulin-1"));
             if (multipleInsulins) {
-                mystring += String.format("%.1f", d).replace(",",".") + " " + insulinProfile1.getName() + " ";
+                mystring += df.format(d) + " " + insulinProfile1.getName() + " ";
             }
             units += d;
         }
         if (multipleInsulins) {
             if (nonzeroInsulin2Value && (insulinProfile2 != null)) {
                 double d = Double.parseDouble(getValue("insulin-2"));
-                mystring += String.format("%.1f", d).replace(",", ".") + " " + insulinProfile2.getName() + " ";
+                mystring += df.format(d) + " " + insulinProfile2.getName() + " ";
                 units += d;
             }
             if (nonzeroInsulin3Value && (insulinProfile3 != null)) {
                 double d = Double.parseDouble(getValue("insulin-3"));
-                mystring += String.format("%.1f", d).replace(",", ".") + " " + insulinProfile3.getName() + " ";
+                mystring += df.format(d) + " " + insulinProfile3.getName() + " ";
                 units += d;
             }
         }
         if (units > 0)
-            mystring += String.format("%.1f", units).replace(",",".") + " units ";
+            mystring += df.format(units) + " units ";
 
         if (mystring.length() > 1) {
             //SendData(this, WEARABLE_VOICE_PAYLOAD, mystring.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Currently, treatment values with a size of up to six digits are accepted but only one decimal digit is shown on the input summary dialog and more importantly, only one decimal digit is passed downstream. 

That means for example that 1.2 IE FIASP and 0.04 IE Lantus can be entered but they are reported wrongly. Just 0.0 Lantus in the top notification line but 1.2 Lantus in the treatment list (total insulin line is missing). Also, the treatment confirm/cancel buttons are missing (see screenshots below, before and after PR).

<img width="350" src="https://user-images.githubusercontent.com/1370732/175785481-d39dfd54-dcd6-48ff-9735-4adca4411ff4.png" /> <img width="350" src="https://user-images.githubusercontent.com/1370732/175785959-64d2348a-619a-4891-8a55-f581c8c739c4.png" />


This PR half-rounds the decimal digits to two (i. e. 0.007 to 0.01) but does not print trailing zeros.

It fixes #1878.