### PR TITLE
Transmitter ID

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/Ob1G5CollectionService.java
@@ -1972,7 +1972,7 @@ public class Ob1G5CollectionService extends G5BaseService {
         }
 
         if (transmitterID != null) {
-            l.add(new StatusItem("Sensor Device", transmitterID + ((transmitterMAC != null && Home.get_engineering_mode()) ? "\n" + transmitterMAC : "")));
+            l.add(new StatusItem("Transmitter ID", transmitterID + ((transmitterMAC != null && Home.get_engineering_mode()) ? "\n" + transmitterMAC : "")));
         }
 
         if (static_connection_state != null) {


### PR DESCRIPTION
When I ask people to post a screenshot of their system status page, I add "You can blackout the transmitter ID if you like".
But, not everyone knows what transmitter ID means looking at the system status page as it is currently listed as "Sensor Device".
This PR changes it to Transmitter ID as shown below.
![Screenshot_20220625-174151](https://user-images.githubusercontent.com/51497406/175791307-1a636599-c305-454f-8ba2-1ccf44bb8f0d.png)
