### PR TITLE
Add option to disable colored BG Reading text on widget / AOD

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -2422,6 +2422,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             findPreference("widget_range_lines").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("extra_status_line").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("widget_status_line").setOnPreferenceChangeListener(new WidgetListener());
+            findPreference("widget_disable_colored_text").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("status_line_calibration_long").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("status_line_calibration_short").setOnPreferenceChangeListener(new WidgetListener());
             findPreference("status_line_avg").setOnPreferenceChangeListener(new WidgetListener());

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
@@ -111,6 +111,7 @@ public class xDripWidget extends AppWidgetProvider {
 
         final boolean showLines = Pref.getBoolean("widget_range_lines", false);
         final boolean showExstraStatus = Pref.getBoolean("extra_status_line", false) && Pref.getBoolean("widget_status_line", false);
+        final boolean disableColoredText = Pref.getBoolean("widget_disable_colored_text", false);
 
         if (lastBgreading != null) {
             double estimate = 0;
@@ -232,11 +233,11 @@ public class xDripWidget extends AppWidgetProvider {
                     views.setTextViewText(R.id.widgetStatusLine, "");
                     views.setViewVisibility(R.id.widgetStatusLine, View.GONE);
                 }
-                if (bgGraphBuilder.unitized(estimate) <= bgGraphBuilder.lowMark) {
+                if (!disableColoredText && bgGraphBuilder.unitized(estimate) <= bgGraphBuilder.lowMark) {
                     views.setTextColor(R.id.widgetBg, Color.parseColor("#C30909"));
                     views.setTextColor(R.id.widgetDelta, Color.parseColor("#C30909"));
                     views.setTextColor(R.id.widgetArrow, Color.parseColor("#C30909"));
-                } else if (bgGraphBuilder.unitized(estimate) >= bgGraphBuilder.highMark) {
+                } else if (!disableColoredText && bgGraphBuilder.unitized(estimate) >= bgGraphBuilder.highMark) {
                     views.setTextColor(R.id.widgetBg, Color.parseColor("#FFBB33"));
                     views.setTextColor(R.id.widgetDelta, Color.parseColor("#FFBB33"));
                     views.setTextColor(R.id.widgetArrow, Color.parseColor("#FFBB33"));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -830,6 +830,8 @@
     <string name="chosse_language">Choose a specific language</string>
     <string name="widget_range_lines">Widget Range Lines</string>
     <string name="show_range_on_widget">Show a high and low line on the widget.</string>
+    <string name="disable_colored_widget_text">Disables coloring of the BG reading text on high / low BG on the widget.</string>
+    <string name="disable_colored_bg">Disable colored BG Reading</string>
     <string name="delayed_but_more_stable">Delayed but more stable when noisy (not recommended)</string>
     <string name="show_bolus_wizard_preview">Show Bolus Wizard Preview</string>
     <string name="display_calculations">Display Insulin/Carb calculations</string>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -345,6 +345,11 @@
                     android:summary="@string/grid_glucose_lines_visible"
                     android:title="@string/show_graph_glucose_lines" />
                 <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="widget_disable_colored_text"
+                    android:summary="@string/disable_colored_widget_text"
+                    android:title="@string/disable_colored_bg" />
+                <CheckBoxPreference
                     android:defaultValue="true"
                     android:key="show_filtered_curve"
                     android:summary="@string/useful_for_noise_and_missed_readings"


### PR DESCRIPTION
The red BG Reading of the widget is very hard to read on a dim screen, e.g. on the Always On Display Widget.
This was discussed here: https://github.com/NightscoutFoundation/xDrip/discussions/2208
Maybe the strings of the option could be a bit better. Any suggestions?