### PR TITLE
Configurable text color for high-, in-range- and low-clucose values

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
@@ -113,11 +113,11 @@ public class BestGlucose {
             if (isStale()) wholeSpan(ret, new StrikethroughSpan());
             if (color) {
                 if (isLow()) {
-                    wholeSpan(ret, new ForegroundColorSpan(getCol(ColorCache.X.textcolor_low_values)));  //TESTING
+                    wholeSpan(ret, new ForegroundColorSpan(getCol(ColorCache.X.color_low_bg_values)));
                 } else if (isHigh()) {
-                    wholeSpan(ret, new ForegroundColorSpan(getCol(ColorCache.X.textcolor_high_values))); //TESTING
+                    wholeSpan(ret, new ForegroundColorSpan(getCol(ColorCache.X.color_high_bg_values)));
                 } else {
-                    wholeSpan(ret, new ForegroundColorSpan(getCol(ColorCache.X.textcolor_inrange_values)));
+                    wholeSpan(ret, new ForegroundColorSpan(getCol(ColorCache.X.color_inrange_bg_values)));
                 }
             }
             return ret;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
@@ -13,12 +13,14 @@ import com.eveningoutpost.dexdrip.Models.JoH;
 import com.eveningoutpost.dexdrip.Models.SensorSanity;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.UtilityModels.BgGraphBuilder;
+import com.eveningoutpost.dexdrip.UtilityModels.ColorCache;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.calibrations.CalibrationAbstract;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 
 import java.util.List;
 
+import static com.eveningoutpost.dexdrip.UtilityModels.ColorCache.getCol;
 import static com.eveningoutpost.dexdrip.calibrations.PluggableCalibration.getCalibrationPluginFromPreferences;
 
 /**
@@ -111,11 +113,12 @@ public class BestGlucose {
             if (isStale()) wholeSpan(ret, new StrikethroughSpan());
             if (color) {
                 if (isLow()) {
-                    // TODO should colors be configurable?
-                    wholeSpan(ret, new ForegroundColorSpan(Color.parseColor("#C30909")));
+                    wholeSpan(ret, new ForegroundColorSpan(getCol(ColorCache.X.textcolor_low_values)));  //TESTING
                 } else if (isHigh()) {
-                    wholeSpan(ret, new ForegroundColorSpan(Color.parseColor("#FFBB33")));
-                } // else default to whatever default is?
+                    wholeSpan(ret, new ForegroundColorSpan(getCol(ColorCache.X.textcolor_high_values))); //TESTING
+                } else {
+                    wholeSpan(ret, new ForegroundColorSpan(getCol(ColorCache.X.textcolor_inrange_values)));
+                }
             }
             return ret;
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -3001,11 +3001,11 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             }
         }
         if (bgGraphBuilder.unitized(estimate) <= bgGraphBuilder.lowMark) {
-            currentBgValueText.setTextColor(getCol(ColorCache.X.textcolor_low_values));
+            currentBgValueText.setTextColor(getCol(ColorCache.X.color_low_bg_values));
         } else if (bgGraphBuilder.unitized(estimate) >= bgGraphBuilder.highMark) {
-            currentBgValueText.setTextColor(getCol(ColorCache.X.textcolor_high_values));
+            currentBgValueText.setTextColor(getCol(ColorCache.X.color_high_bg_values));
         } else {
-            currentBgValueText.setTextColor(getCol(ColorCache.X.textcolor_inrange_values));
+            currentBgValueText.setTextColor(getCol(ColorCache.X.color_inrange_bg_values));
         }
 
         // TODO this should be made more efficient probably

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -90,6 +90,7 @@ import com.eveningoutpost.dexdrip.Services.WixelReader;
 import com.eveningoutpost.dexdrip.UtilityModels.AlertPlayer;
 import com.eveningoutpost.dexdrip.UtilityModels.BgGraphBuilder;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
+import com.eveningoutpost.dexdrip.UtilityModels.ColorCache;
 import com.eveningoutpost.dexdrip.UtilityModels.CompatibleApps;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.UtilityModels.Experience;
@@ -3000,11 +3001,11 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             }
         }
         if (bgGraphBuilder.unitized(estimate) <= bgGraphBuilder.lowMark) {
-            currentBgValueText.setTextColor(Color.parseColor("#C30909"));
+            currentBgValueText.setTextColor(getCol(ColorCache.X.textcolor_low_values));
         } else if (bgGraphBuilder.unitized(estimate) >= bgGraphBuilder.highMark) {
-            currentBgValueText.setTextColor(Color.parseColor("#FFBB33"));
+            currentBgValueText.setTextColor(getCol(ColorCache.X.textcolor_high_values));
         } else {
-            currentBgValueText.setTextColor(Color.WHITE);
+            currentBgValueText.setTextColor(getCol(ColorCache.X.textcolor_inrange_values));
         }
 
         // TODO this should be made more efficient probably

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ColorCache.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ColorCache.java
@@ -70,7 +70,10 @@ public class ColorCache {
         color_smb_line("color_smb_line"),
         color_number_wall("color_number_wall"),
         color_number_wall_shadow("color_number_wall_shadow"),
-        color_basal_tbr("color_basal_tbr");
+        color_basal_tbr("color_basal_tbr"),
+        textcolor_high_values("textcolor_high_values"),
+        textcolor_inrange_values("textcolor_inrange_values"),
+        textcolor_low_values("textcolor_low_values"),;
 
         @Getter
         String internalName;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ColorCache.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ColorCache.java
@@ -71,9 +71,10 @@ public class ColorCache {
         color_number_wall("color_number_wall"),
         color_number_wall_shadow("color_number_wall_shadow"),
         color_basal_tbr("color_basal_tbr"),
-        textcolor_high_values("textcolor_high_values"),
-        textcolor_inrange_values("textcolor_inrange_values"),
-        textcolor_low_values("textcolor_low_values"),;
+        color_high_bg_values("color_high_bg_values"),
+        color_inrange_bg_values("color_inrange_bg_values"),
+        color_low_bg_values("color_low_bg_values"),
+        ;
 
         @Getter
         String internalName;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
@@ -235,17 +235,17 @@ public class xDripWidget extends AppWidgetProvider {
                     views.setViewVisibility(R.id.widgetStatusLine, View.GONE);
                 }
                 if (bgGraphBuilder.unitized(estimate) <= bgGraphBuilder.lowMark) {
-                    views.setTextColor(R.id.widgetBg, getCol(ColorCache.X.textcolor_low_values));
-                    views.setTextColor(R.id.widgetDelta, getCol(ColorCache.X.textcolor_low_values));
-                    views.setTextColor(R.id.widgetArrow, getCol(ColorCache.X.textcolor_low_values));
+                    views.setTextColor(R.id.widgetBg, getCol(ColorCache.X.color_low_bg_values));
+                    views.setTextColor(R.id.widgetDelta, getCol(ColorCache.X.color_low_bg_values));
+                    views.setTextColor(R.id.widgetArrow, getCol(ColorCache.X.color_low_bg_values));
                 } else if (bgGraphBuilder.unitized(estimate) >= bgGraphBuilder.highMark) {
-                    views.setTextColor(R.id.widgetBg, getCol(ColorCache.X.textcolor_high_values));
-                    views.setTextColor(R.id.widgetDelta, getCol(ColorCache.X.textcolor_high_values));
-                    views.setTextColor(R.id.widgetArrow, getCol(ColorCache.X.textcolor_high_values));
+                    views.setTextColor(R.id.widgetBg, getCol(ColorCache.X.color_high_bg_values));
+                    views.setTextColor(R.id.widgetDelta, getCol(ColorCache.X.color_high_bg_values));
+                    views.setTextColor(R.id.widgetArrow, getCol(ColorCache.X.color_high_bg_values));
                 } else {
-                    views.setTextColor(R.id.widgetBg, getCol(ColorCache.X.textcolor_inrange_values));
-                    views.setTextColor(R.id.widgetDelta, getCol(ColorCache.X.textcolor_inrange_values));
-                    views.setTextColor(R.id.widgetArrow, getCol(ColorCache.X.textcolor_inrange_values));
+                    views.setTextColor(R.id.widgetBg, getCol(ColorCache.X.color_inrange_bg_values));
+                    views.setTextColor(R.id.widgetDelta, getCol(ColorCache.X.color_inrange_bg_values));
+                    views.setTextColor(R.id.widgetArrow, getCol(ColorCache.X.color_inrange_bg_values));
                 }
             } catch (RuntimeException e) {
                 Log.e(TAG, "Got exception in displaycurrentinfo: " + e);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xDripWidget.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip;
 
+import static com.eveningoutpost.dexdrip.UtilityModels.ColorCache.getCol;
+
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
@@ -233,17 +235,17 @@ public class xDripWidget extends AppWidgetProvider {
                     views.setViewVisibility(R.id.widgetStatusLine, View.GONE);
                 }
                 if (bgGraphBuilder.unitized(estimate) <= bgGraphBuilder.lowMark) {
-                    views.setTextColor(R.id.widgetBg, Color.parseColor("#C30909"));
-                    views.setTextColor(R.id.widgetDelta, Color.parseColor("#C30909"));
-                    views.setTextColor(R.id.widgetArrow, Color.parseColor("#C30909"));
+                    views.setTextColor(R.id.widgetBg, getCol(ColorCache.X.textcolor_low_values));
+                    views.setTextColor(R.id.widgetDelta, getCol(ColorCache.X.textcolor_low_values));
+                    views.setTextColor(R.id.widgetArrow, getCol(ColorCache.X.textcolor_low_values));
                 } else if (bgGraphBuilder.unitized(estimate) >= bgGraphBuilder.highMark) {
-                    views.setTextColor(R.id.widgetBg, Color.parseColor("#FFBB33"));
-                    views.setTextColor(R.id.widgetDelta, Color.parseColor("#FFBB33"));
-                    views.setTextColor(R.id.widgetArrow, Color.parseColor("#FFBB33"));
+                    views.setTextColor(R.id.widgetBg, getCol(ColorCache.X.textcolor_high_values));
+                    views.setTextColor(R.id.widgetDelta, getCol(ColorCache.X.textcolor_high_values));
+                    views.setTextColor(R.id.widgetArrow, getCol(ColorCache.X.textcolor_high_values));
                 } else {
-                    views.setTextColor(R.id.widgetBg, Color.WHITE);
-                    views.setTextColor(R.id.widgetDelta, Color.WHITE);
-                    views.setTextColor(R.id.widgetArrow, Color.WHITE);
+                    views.setTextColor(R.id.widgetBg, getCol(ColorCache.X.textcolor_inrange_values));
+                    views.setTextColor(R.id.widgetDelta, getCol(ColorCache.X.textcolor_inrange_values));
+                    views.setTextColor(R.id.widgetArrow, getCol(ColorCache.X.textcolor_inrange_values));
                 }
             } catch (RuntimeException e) {
                 Log.e(TAG, "Got exception in displaycurrentinfo: " + e);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,7 +325,7 @@
     <string name="high_glucose_values">High Glucose Values</string>
     <string name="in_range_glucose_values">In-range Glucose Values</string>
     <string name="default_color_selected">Default Color Selected</string>
-    <string name="glucose_values_textcolor">Text Colors for Glucose Values</string>
+    <string name="color_bg_values">Colors of BG Reading and Trend Arrow</string>
     <string name="xdrip_plus_extra_settings">xDrip+ extra settings</string>
     <string name="example_chart">Example Chart</string>
     <string name="treatments_prediction_curves">Treatments / Prediction Curves</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,6 +325,7 @@
     <string name="high_glucose_values">High Glucose Values</string>
     <string name="in_range_glucose_values">In-range Glucose Values</string>
     <string name="default_color_selected">Default Color Selected</string>
+    <string name="glucose_values_textcolor">Text Colors for Glucose Values</string>
     <string name="xdrip_plus_extra_settings">xDrip+ extra settings</string>
     <string name="example_chart">Example Chart</string>
     <string name="treatments_prediction_curves">Treatments / Prediction Curves</string>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -70,17 +70,17 @@
 
                 <PreferenceCategory
                     android:key="xdrip_plus_display_textcolorset1"
-                    android:title="@string/glucose_values_textcolor">
+                    android:title="@string/color_bg_values">
                     <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
                         android:defaultValue="#FFBB33"
-                        android:key="textcolor_high_values"
+                        android:key="color_high_bg_values"
                         android:title="@string/high_glucose_values"
                         app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
                         app:colorpicker_selectNoneButtonText="@string/revert_to_default"
                         app:colorpicker_showHex="false" />
                     <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
                         android:defaultValue="#FFFFFF"
-                        android:key="textcolor_inrange_values"
+                        android:key="color_inrange_bg_values"
                         android:title="@string/in_range_glucose_values"
                         app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
                         app:colorpicker_selectNoneButtonText="@string/revert_to_default"
@@ -88,7 +88,7 @@
 
                     <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
                         android:defaultValue="#C30909"
-                        android:key="textcolor_low_values"
+                        android:key="color_low_bg_values"
                         android:title="@string/low_glucose_values"
                         app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
                         app:colorpicker_selectNoneButtonText="@string/revert_to_default"

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -50,6 +50,7 @@
                         app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
                         app:colorpicker_selectNoneButtonText="@string/revert_to_default"
                         app:colorpicker_showHex="false" />
+
                     <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
                         android:defaultValue="#ffffff"
                         android:key="color_bad_values"
@@ -62,6 +63,33 @@
                         android:defaultValue="#a0a0a0"
                         android:key="color_filtered"
                         android:title="@string/filtered_values"
+                        app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
+                        app:colorpicker_selectNoneButtonText="@string/revert_to_default"
+                        app:colorpicker_showHex="false" />
+                </PreferenceCategory>
+
+                <PreferenceCategory
+                    android:key="xdrip_plus_display_textcolorset1"
+                    android:title="@string/glucose_values_textcolor">
+                    <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
+                        android:defaultValue="#FFBB33"
+                        android:key="textcolor_high_values"
+                        android:title="@string/high_glucose_values"
+                        app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
+                        app:colorpicker_selectNoneButtonText="@string/revert_to_default"
+                        app:colorpicker_showHex="false" />
+                    <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
+                        android:defaultValue="#FFFFFF"
+                        android:key="textcolor_inrange_values"
+                        android:title="@string/in_range_glucose_values"
+                        app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
+                        app:colorpicker_selectNoneButtonText="@string/revert_to_default"
+                        app:colorpicker_showHex="false" />
+
+                    <com.eveningoutpost.dexdrip.UtilityModels.ColorPicker
+                        android:defaultValue="#C30909"
+                        android:key="textcolor_low_values"
+                        android:title="@string/low_glucose_values"
                         app:colorpicker_noneSelectedSummaryText="@string/default_color_selected"
                         app:colorpicker_selectNoneButtonText="@string/revert_to_default"
                         app:colorpicker_showHex="false" />


### PR DESCRIPTION
There are three new color pickers for changing text and trend arrow colors of high-, in-range and low-glucose values on main-screen, widget and also AOD widget. The default colors are set to the previous colors.

Screenshot of the colorpickers with default colors:
<img width="350" src="https://user-images.githubusercontent.com/2668238/178733873-d8d71e73-a9c9-450a-9cc1-736dbef63797.png" />

Screenshot of main screen with changed color setting for in-range values:
<img width="350" src="https://user-images.githubusercontent.com/2668238/178734045-b654fe26-b2b9-4493-bbf0-9547d1e0a444.png" />

Screenshot of widget with changed color setting for in-range values:
<img width="350" src="https://user-images.githubusercontent.com/2668238/178734342-5e52b70c-840b-47c1-9650-2a57337ad842.png" />