### PR TITLE
BgGraphBuilder: expand data limit maximum if source exceeds expected rate

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/pebble/PebbleDisplayAbstract.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/pebble/PebbleDisplayAbstract.java
@@ -53,7 +53,7 @@ public abstract class PebbleDisplayAbstract implements PebbleDisplayInterface {
     protected static final int VERSION_KEY = 1002;
 
 
-    protected static final int NUM_VALUES =(60/5)*24;
+    protected static final int MAX_VALUES =60*24;
 
     protected Context context;
     protected BgGraphBuilder bgGraphBuilder;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/pebble/PebbleDisplayTrend.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/pebble/PebbleDisplayTrend.java
@@ -339,7 +339,7 @@ public class PebbleDisplayTrend extends PebbleDisplayAbstract {
                 {
                     long end = System.currentTimeMillis() + (60000 * 5);
                     long start = end - (60000 * 60 * trendPeriod) - (60000 * 10);
-                    this.bgGraphBuilder = new BgGraphBuilder(context, start, end, NUM_VALUES, true);
+                    this.bgGraphBuilder = new BgGraphBuilder(context, start, end, MAX_VALUES, true);
                     lastTrendPeriod = trendPeriod;
                 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/pebble/PebbleDisplayTrendOld.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/pebble/PebbleDisplayTrendOld.java
@@ -326,7 +326,7 @@ public class PebbleDisplayTrendOld extends PebbleDisplayAbstract {
                 {
                     long end = System.currentTimeMillis() + (60000 * 5);
                     long start = end - (60000 * 60*trendPeriod) -  (60000 * 10);
-                    this.bgGraphBuilder = new BgGraphBuilder(context, start, end, NUM_VALUES, true);
+                    this.bgGraphBuilder = new BgGraphBuilder(context, start, end, MAX_VALUES, true);
                     lastTrendPeriod=trendPeriod;
                 }
 

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -83,7 +83,7 @@ public class BgGraphBuilder {
     final int previewAxisTextSize;
     final int hoursPreviewStep;
     private final static double timeshift = 500000;
-    private static final int NUM_VALUES =(60/5)*24;
+    private static final int MAX_VALUES =60*24;
     private final List<BgReading> bgReadings;
     private final List<Calibration> calibrations;
     private List<PointValue> inRangeValues = new ArrayList<PointValue>();
@@ -110,7 +110,7 @@ public class BgGraphBuilder {
     }
 
     public BgGraphBuilder(Context context, long start, long end){
-        this(context, start, end, NUM_VALUES);
+        this(context, start, end, MAX_VALUES);
     }
 
     public BgGraphBuilder(Context context, long start, long end, int numValues, boolean show_prediction) {//KS TODO implement show_prediction


### PR DESCRIPTION
This is a copy of the following for wear and pebble.
https://github.com/NightscoutFoundation/xDrip/commit/05668fffe2cf0da7f1a4f3f4a360d224da848300

I have not tested this because I have no Android wear device.

The intent is to fix this: https://github.com/NightscoutFoundation/xDrip/issues/1518#issuecomment-1192239714