### PR TITLE
normalize 'relative' PointValue in BroadcastService

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/broadcastservice/models/GraphLine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/broadcastservice/models/GraphLine.java
@@ -3,6 +3,8 @@ package com.eveningoutpost.dexdrip.Services.broadcastservice.models;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import com.eveningoutpost.dexdrip.UtilityModels.HPointValue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +42,11 @@ public class GraphLine implements Parcelable {
         values = new ArrayList<>();
         line.update(0);
         for (PointValue pointValue : line.getValues()) {
-            values.add(new GraphPoint(pointValue.getX(), pointValue.getY()));
+            float real_timestamp = pointValue.getX();
+            if (pointValue instanceof HPointValue) {
+                real_timestamp = (float) HPointValue.unconvert(real_timestamp);
+            }
+            values.add(new GraphPoint(real_timestamp, pointValue.getY()));
         }
         color = line.getColor();
     }


### PR DESCRIPTION
After the changes in  this PR [NightscoutFoundation/xDrip#2254] the graph doesnt display anymore via watchdrip.  (https://github.com/NightscoutFoundation/xDrip/pull/2254) . In order to fix this problem l Use unconvert() method to restore the values to the same range as it was before.