### PR TITLE
Minor repositioning. No functional changes.

### DIFF
--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -717,19 +717,6 @@
                 </intent>
             </Preference>
         </PreferenceCategory>
-        <PreferenceCategory
-            android:key="title_I_understandb"
-            android:title="@string/eula">
-            <Preference
-                android:key="I_understandb"
-                android:summary="@string/not_for_medical_use"
-                android:title="@string/end_user_license_agreement">
-                <intent
-                    android:action="android.intent.action.MAIN"
-                    android:targetClass="com.eveningoutpost.dexdrip.LicenseAgreementActivity"
-                    android:targetPackage="@string/local_target_package" />
-            </Preference>
-        </PreferenceCategory>
 
         <PreferenceScreen
             android:dependency="I_understand"
@@ -768,6 +755,19 @@
             </PreferenceCategory>
         </PreferenceScreen>
 
+        <PreferenceCategory
+            android:key="title_I_understandb"
+            android:title="@string/eula">
+            <Preference
+                android:key="I_understandb"
+                android:summary="@string/not_for_medical_use"
+                android:title="@string/end_user_license_agreement">
+                <intent
+                    android:action="android.intent.action.MAIN"
+                    android:targetClass="com.eveningoutpost.dexdrip.LicenseAgreementActivity"
+                    android:targetPackage="@string/local_target_package" />
+            </Preference>
+        </PreferenceCategory>
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
I'm essentially putting this here to try and split it off from a separate PR.
All this does is reorder two preferences, so that "low level prediction values" doesn't look like it's part of the EULA category.

### BEFORE
<image width="300" src="https://user-images.githubusercontent.com/52087143/185745304-be11c440-332e-47a4-ac61-bf05eaa03309.png">

### AFTER

<image width="300" src="https://user-images.githubusercontent.com/52087143/185745194-1ae1c782-2bde-45f1-8f10-f093e30f3169.png">
