### PR TITLE
Custom Sound File

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -589,12 +589,12 @@ public class EditAlertActivity extends ActivityWithMenu {
         buttonalertMp3.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(mContext);
-                builder.setTitle("What type of Alert?")
+                builder.setTitle(getString(R.string.select_new_sound))
                         .setItems(R.array.alertType, new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
                                 if (which == 0) {
                                     Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
-                                    intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, "Select tone for Alerts:");
+                                    intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, getString(R.string.choose_alert_sound_file));
                                     intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, true);
                                     intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true);
                                     intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_ALL);
@@ -604,7 +604,7 @@ public class EditAlertActivity extends ActivityWithMenu {
                                       chooseFile();
                                     }
                                 } else {
-                                    // Xdrip default was chossen, we live the file name as empty.
+                                    // Xdrip default was chosen, we leave the file name empty.
                                     audioPath = "";
                                     alertMp3File.setText(shortPath(audioPath));
                                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
@@ -595,10 +595,6 @@ public class Reminders extends ActivityWithRecycler implements SensorEventListen
                         intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true);
                         intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_ALL);
                         startActivityForResult(intent, REQUEST_CODE_CHOOSE_RINGTONE);
-                    } else if (which == 1) {
-                        if (checkPermissions()) {
-                            chooseFile();
-                        }
                     } else {
                         JoH.static_toast_long(xdrip.getAppContext().getString(R.string.using_default_sound));
                         selectedSound = null;

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -180,14 +180,12 @@
     </string-array>
 
     <string-array name="alertType">
-        <item>System Sound/Alarm</item>
-        <item>Custom Sound/Alarm</item>
-        <item>Default xDrip sound</item>
+        <item>@string/choose_sound_file</item>
+        <item>@string/default_xdrip_sound</item>
     </string-array>
 
     <string-array name="reminderAlertType">
         <item>Android Ringtone/Alarm</item>
-        <item>Custom Audio file</item>
         <item>Default xDrip+ reminder sound</item>
     </string-array>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,7 +226,7 @@
     <string name="show_settings_qr_codes">Show Settings QR codes</string>
     <string name="load_save_settings_to_sdcard">Load / Save settings</string>
     <string name="alarms_and_alerts">Alarms and Alerts</string>
-    <string name="alerts_and_notifications">Place custom sound files in the \"Notifications\" folder</string>
+    <string name="alerts_and_notifications">Alerts and Notifications</string>
     <string name="glucose_level_alerts_list">Glucose Level Alerts List</string>
     <string name="glucose_alerts_settings">Glucose Alerts Settings</string>
     <string name="smart_snoozing">Smart Snoozing</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,7 +226,7 @@
     <string name="show_settings_qr_codes">Show Settings QR codes</string>
     <string name="load_save_settings_to_sdcard">Load / Save settings</string>
     <string name="alarms_and_alerts">Alarms and Alerts</string>
-    <string name="alerts_and_notifications">Alerts and Notifications</string>
+    <string name="alerts_and_notifications">Place custom sound files in the \"Notifications\" folder</string>
     <string name="glucose_level_alerts_list">Glucose Level Alerts List</string>
     <string name="glucose_alerts_settings">Glucose Alerts Settings</string>
     <string name="smart_snoozing">Smart Snoozing</string>
@@ -1715,4 +1715,9 @@
     <string name="simplify_graphs_by_smoothing_out_irregularities">Simplify graphs by smoothing out irregularities</string>
     <string name="graph_smoothing">Graph Smoothing</string>
     <string name="last_reading">Last Reading</string>
+    <string name="select_new_sound">Select new sound source</string>
+    <string name="choose_alert_sound_file">BG Level Sound</string>
+    <string name="choose_sound_file">Choose File</string>
+    <string name="default_xdrip_sound">Default xDrip sound</string>
+    <string name="Custom_Sound_Note_summary">Place custom sound files in the \"Notifications\" folder at the root of the internal storage.</string>
 </resources>

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -6,8 +6,7 @@
         android:summary="@string/glucose_calibration_and_other_alerts"
         android:title="@string/alarms_and_alerts">
         <PreferenceCategory
-            android:key="alerts_category"
-            android:title="@string/alerts_and_notifications">
+            android:key="alerts_category">
             <Preference
                 android:key="bg_level_alerts"
                 android:title="@string/glucose_level_alerts_list">
@@ -356,6 +355,9 @@
                         android:title="@string/follower_chime_new" />
                 </PreferenceCategory>
             </PreferenceScreen>
+            <Preference
+                android:summary="@string/Custom_Sound_Note_summary">
+            </Preference>
         </PreferenceCategory>
     </PreferenceScreen>
 </PreferenceScreen>


### PR DESCRIPTION
This is a second attempt at an older PR (https://github.com/NightscoutFoundation/xDrip/pull/1827).  

**Why we need this**
If you tap on "Choose File" on the edit alert page in order to change the sound file for one of your main glucose level alerts, you will see this:
![Screenshot_20210915-140641](https://user-images.githubusercontent.com/51497406/133486873-07020616-4994-4a60-9305-f091a8c3984a.png)

If you then tap on custom sound and navigate to an mp3 file, you will see that it is grayed out.  So, you cannot choose a custom sound file.
The solution is to add the custom sound file to your Notifications folder (as explained here: https://navid200.github.io/xDrip/docs/Custom-sound-grayed-out.html) and use the "System Sound/Alarm" option to choose it.

The custom sound option on the form is not functional on many phones and confusing to the users.
You can see an example here:  https://github.com/NightscoutFoundation/xDrip/discussions/2282

In case you don't experience this problem on your phone, you can recreate it using virtual device as explained here:  https://github.com/NightscoutFoundation/xDrip/discussions/1983 

There is an identical problem if you go to xDrip reminders and attempt to change the sound file for one of the reminders.

If you experience this problem on your phone, you will have the same problem if you choose to use a custom sound file for any other alert like the Forecast Low alert or the Persistent High Alert.

This PR removes the "Custom sound/alarm" option and makes tapping on the choose file behave as shown below.  
![Screenshot_20211117-225530](https://user-images.githubusercontent.com/51497406/142349066-4031fe95-9c03-43f3-b689-c53877571069.png)

And for reminders:
![Screenshot_20211117-230119](https://user-images.githubusercontent.com/51497406/142349812-1034615c-45d4-4f65-9376-8998ab82157e.png)

This PR also removes the all caps category title of Alerts and notifications from the Alarms and Alerts page, which is redundant with respect to the existing title of "Alarms and Alerts".  
And adds a note on the same page explaining where custom files should be placed, as shown below:
![Screenshot_20220821-181119](https://user-images.githubusercontent.com/51497406/185813161-52069823-2eb1-4589-975c-a359f81e788e.jpg)



**Is there a workaround?**
The only workaround is to avoid using the custom sound option.  

**Are there any side effects?**
No

**Tests**
Tested with Android 8 and 11 and virtual Android 11