### PR TITLE
Add predicted iob data to broadcastservice

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/broadcastservice/BroadcastService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/broadcastservice/BroadcastService.java
@@ -527,6 +527,9 @@ public class BroadcastService extends Service {
                 bundle.putLong("treatment.timeStamp", treatment.timestamp);
             }
 
+            predictedIOB = "";
+            predictedBWP = "";
+
             if (settings.isDisplayGraph()) {
                 long graphStartOffset = settings.getGraphStart();
                 long graphEndOffset = settings.getGraphEnd();


### PR DESCRIPTION
Some people would like to see predicted(simulated) iob data on the watch. So this PR extends the broadcast data with a  predicted IOB and BWP info.
Also it enables **not** simple mode in _defaultLines_  function in order to receive simulated data including predicted lgraph lines.