### PR TITLE
Alerts: fix custom sound handling

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/AlertList.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/AlertList.java
@@ -253,23 +253,9 @@ public class AlertList extends ActivityWithMenu {
         listViewHigh.setAdapter(simpleAdapterHigh);
     }
 
-    private String shortPath(String path) {
+    private String shortPath(final String path) {
         try {
-            if (path != null) {
-                if (path.length() == 0) {
-                    return "xDrip Default";
-                }
-                Ringtone ringtone = RingtoneManager.getRingtone(mContext, Uri.parse(path));
-                if (ringtone != null) {
-                    return ringtone.getTitle(mContext);
-                } else {
-                    String[] segments = path.split("/");
-                    if (segments.length > 1) {
-                        return segments[segments.length - 1];
-                    }
-                }
-            }
-            return "";
+            return EditAlertActivity.shortPath(path);
         } catch (SecurityException e) {
             // need external storage permission?
             checkStoragePermissions(gs(R.string.need_permission_to_access_audio_files));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -21,6 +21,7 @@ import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.content.CursorLoader;
 import android.text.InputType;
 import android.text.format.DateFormat;
 import android.text.method.DigitsKeyListener;
@@ -58,6 +59,8 @@ import java.util.List;
 
 import static com.eveningoutpost.dexdrip.Home.startWatchUpdaterService;
 import static com.eveningoutpost.dexdrip.xdrip.gs;
+
+import lombok.val;
 
 public class EditAlertActivity extends ActivityWithMenu {
     //public static String menu_name = "Edit Alert";
@@ -594,7 +597,7 @@ public class EditAlertActivity extends ActivityWithMenu {
                             public void onClick(DialogInterface dialog, int which) {
                                 if (which == 0) {
                                     Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
-                                    intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, "Select tone for Alerts:");
+                                    intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, getString(R.string.select_tone_for_alerts));
                                     intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, true);
                                     intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true);
                                     intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_ALL);
@@ -651,7 +654,7 @@ public class EditAlertActivity extends ActivityWithMenu {
                         setTimeRanges();
                     }
                 }, startHour, startMinute, DateFormat.is24HourFormat(mContext));
-                mTimePicker.setTitle("Select Time");
+                mTimePicker.setTitle(getString(R.string.select_time));
                 mTimePicker.show();
 
             }
@@ -669,7 +672,7 @@ public class EditAlertActivity extends ActivityWithMenu {
                         setTimeRanges();
                     }
                 }, endHour, endMinute, DateFormat.is24HourFormat(mContext));
-                mTimePicker.setTitle("Select Time");
+                mTimePicker.setTitle(getString(R.string.select_time));
                 mTimePicker.show();
 
             }
@@ -685,9 +688,9 @@ public class EditAlertActivity extends ActivityWithMenu {
     private void chooseFile()
     {
         final Intent fileIntent = new Intent();
-        fileIntent.setType("audio/mpeg3");
-        fileIntent.setAction(Intent.ACTION_GET_CONTENT);
-        startActivityForResult(Intent.createChooser(fileIntent, "Select File for Alert"), REQUEST_CODE_CHOOSE_FILE);
+        fileIntent.setType("audio/*");
+        fileIntent.setAction(Intent.ACTION_OPEN_DOCUMENT);
+        startActivityForResult(Intent.createChooser(fileIntent, getString(R.string.select_file_for_alert)), REQUEST_CODE_CHOOSE_FILE);
     }
 
     @Override
@@ -698,7 +701,7 @@ public class EditAlertActivity extends ActivityWithMenu {
             if ((grantResults.length > 0) && (grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
                 chooseFile(); // must be the only functionality which calls for permission
             } else {
-                JoH.static_toast_long(this, "Cannot choose file without storage permission");
+                JoH.static_toast_long(this, getString(R.string.cannot_choose_file_without_permission));
             }
         }
     }
@@ -708,45 +711,47 @@ public class EditAlertActivity extends ActivityWithMenu {
             Uri uri = data.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
             if (uri != null) {
                 audioPath = uri.toString();
+                Log.d(TAG, "Selected ringtone audio path: " + audioPath);
                 alertMp3File.setText(shortPath(audioPath));
             } else {
                 if (requestCode == REQUEST_CODE_CHOOSE_FILE) {
-                    Uri selectedImageUri = data.getData();
+                    try {
+                        val selectedAudioUri = data.getData();
+                        getContentResolver().takePersistableUriPermission(selectedAudioUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
-                    // Todo this code is very flacky. Probably need a much better understanding of how the different programs
-                    // select the file names. We might also have to
-                    // - See more at: http://blog.kerul.net/2011/12/pick-file-using-intentactiongetcontent.html#sthash.c8xtIr1Y.cx7s9nxH.dpuf
+                        // Todo this code is very flacky. Probably need a much better understanding of how the different programs
+                        // select the file names. We might also have to
+                        // - See more at: http://blog.kerul.net/2011/12/pick-file-using-intentactiongetcontent.html#sthash.c8xtIr1Y.cx7s9nxH.dpuf
 
-                    //MEDIA GALLERY
-                    String selectedAudioPath = getPath(selectedImageUri);
-                    if (selectedAudioPath == null) {
-                        //OI FILE Manager
-                        selectedAudioPath = selectedImageUri.getPath();
+                        //MEDIA GALLERY
+                        String selectedAudioPath = getRealPathFromURI(selectedAudioUri);
+                        if (selectedAudioPath == null) {
+                            //OI FILE Manager
+                            selectedAudioPath = selectedAudioUri.getPath();
+                        }
+                        Log.d(TAG, "Selected audio path: " + selectedAudioPath + " " + selectedAudioUri);
+                        audioPath = selectedAudioUri.toString();
+                        alertMp3File.setText(shortPath(selectedAudioPath));
+                    } catch (Exception e) {
+                        JoH.static_toast_long(getString(R.string.problem_with_sound) + " " + e.getMessage());
                     }
-                    audioPath = selectedAudioPath;
-                    alertMp3File.setText(shortPath(audioPath));
                 }
             }
         }
     }
 
-    public String getPath(Uri uri) {
-        String[] projection = { MediaStore.Images.Media.DATA };
-        Cursor cursor = managedQuery(uri, projection, null, null, null);
-        if(cursor!=null)
-        {
-            //HERE YOU WILL GET A NULLPOINTER IF CURSOR IS NULL
-            //THIS CAN BE, IF YOU USED OI FILE MANAGER FOR PICKING THE MEDIA
-            int column_index;
-            try {
-                column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
-            } catch ( IllegalArgumentException e) {
-                Log.e(TAG, "cursor.getColumnIndexOrThrow failed", e);
-                return null;
-            }
+    private String getRealPathFromURI(final Uri contentUri) {
+        try {
+            String[] projection = {MediaStore.Images.Media.DATA};
+            val loader = new CursorLoader(mContext, contentUri, projection, null, null, null);
+            val cursor = loader.loadInBackground();
+            val column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
             cursor.moveToFirst();
-            return cursor.getString(column_index);
-        }   else {
+            val result = cursor.getString(column_index);
+            cursor.close();
+            return result;
+        } catch (Exception e) {
+            Log.d(TAG, "Got exception parsing uri " + e);
             return null;
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
+import android.content.res.AssetFileDescriptor;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -1134,6 +1135,20 @@ public class JoH {
         } catch (IOException | NullPointerException | IllegalArgumentException | SecurityException ex) {
             UserError.Log.e(TAG, "setMediaDataSource from uri failed: uri = " + uri.toString(), ex);
             // fall through
+        }
+        return false;
+    }
+
+    // from resource id
+    public static boolean setMediaDataSource(final Context context, final MediaPlayer mp, final int resid) {
+        try {
+            AssetFileDescriptor afd = context.getResources().openRawResourceFd(resid);
+            if (afd == null) return false;
+            mp.setDataSource(afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
+            afd.close();
+            return true;
+        } catch (IOException | NullPointerException | IllegalArgumentException | SecurityException ex) {
+            UserError.Log.e(TAG, "setMediaDataSource from resource id failed:", ex);
         }
         return false;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -2,6 +2,7 @@ package com.eveningoutpost.dexdrip.UtilityModels;
 
 import static com.eveningoutpost.dexdrip.Home.startWatchUpdaterService;
 import static com.eveningoutpost.dexdrip.Models.JoH.delayedMediaPlayerRelease;
+import static com.eveningoutpost.dexdrip.Models.JoH.setMediaDataSource;
 import static com.eveningoutpost.dexdrip.Models.JoH.stopAndReleasePlayer;
 
 import android.app.Notification;
@@ -312,34 +313,6 @@ public class AlertPlayer {
 
     }
 
-
-    // from file uri
-    private boolean setMediaDataSource(Context context, MediaPlayer mp, Uri uri) {
-        try {
-            mp.setDataSource(context, uri);
-            return true;
-        } catch (IOException | NullPointerException | IllegalArgumentException | SecurityException ex) {
-            Log.e(TAG, "setMediaDataSource from uri failed: uri = " + uri.toString(), ex);
-            // fall through
-        }
-        return false;
-    }
-
-    // from resource id
-    private boolean setMediaDataSource(Context context, MediaPlayer mp, int resid) {
-        try {
-            AssetFileDescriptor afd = context.getResources().openRawResourceFd(resid);
-            if (afd == null) return false;
-
-            mp.setDataSource(afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
-            afd.close();
-
-            return true;
-        } catch (IOException | NullPointerException | IllegalArgumentException | SecurityException ex) {
-            Log.e(TAG, "setMediaDataSource from resource id failed:", ex);
-        }
-        return false;
-    }
 
     protected synchronized void playFile(final Context ctx, final String fileName, final float volumeFrac, final boolean forceSpeaker, final boolean overrideSilentMode) {
         Log.i(TAG, "playFile: called fileName = " + fileName);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1715,4 +1715,8 @@
     <string name="simplify_graphs_by_smoothing_out_irregularities">Simplify graphs by smoothing out irregularities</string>
     <string name="graph_smoothing">Graph Smoothing</string>
     <string name="last_reading">Last Reading</string>
+    <string name="select_file_for_alert">Select File for Alert</string>
+    <string name="cannot_choose_file_without_permission">Cannot choose file without storage permission</string>
+    <string name="select_time">Select Time</string>
+    <string name="select_tone_for_alerts">Select tone for Alerts</string>
 </resources>


### PR DESCRIPTION
This PR is designed to fix the problem with custom sound selection for Alerts

Previously these were unselectable and would not function even if they could have been selected.

This PR is designed to supersede https://github.com/NightscoutFoundation/xDrip/pull/1986 and https://github.com/NightscoutFoundation/xDrip/pull/2285 and resolve issues as described here: https://github.com/NightscoutFoundation/xDrip/discussions/1983 and https://github.com/NightscoutFoundation/xDrip/discussions/2282

It gives basically the same treatment as was prototyped for custom sounds for `Reminders` which was done in this commit: https://github.com/NightscoutFoundation/xDrip/commit/9f3ebd1b2c7981a5dde3e56ca77bff4a0c4feced

The changes are:

- Selection to use wildcard mime type `audio/*`
- URI is stored instead of absolute path
- `takePersistableUriPermission()` is used to grant permission past reboot
- Utility version of `setMediaDataSource()` is used to handle different file opening mechanisms
- Strings are extracted from some prompts to enable localization

Because this touches `AlertPlayer` I have raised a PR so that additional testing can be done before merging with the nightly. 

The utility method should be able to handle old and new style uris/paths and will fallback to a default sound if, for example, the custom sound file is deleted or moved.

I have tested this on Android 11 and 12 but not on previous models. Android documentation implies that this should work down to Android 4 and overall this should be more the "official" way that these files should be handled and so should have a good chance to succeed. 

I think this is a cleaner way to handle things overall with fewer changes and making life easier for the user and fixing the original feature which was broken rather than removing it.

Testing on Android 6 and 8 would be helpful. Comments welcomed. Ideally I would like to merge this 1st Sept.