### PR TITLE
Remove debug smoothing from engineering mode

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -1077,7 +1077,7 @@ public class BgGraphBuilder {
             smbValues.clear();
 
             if (Pref.getBooleanDefaultFalse("graph_smoothing")) {
-                if (Home.get_engineering_mode() && Pref.getBooleanDefaultFalse("show-unsmoothed-values-as-plugin")) {
+                if (Pref.getBooleanDefaultFalse("show-unsmoothed-values-as-plugin")) {
                     showUnSmoothedValues(bgReadings);
                 }
                 SmootherFactory.get(Pref.getString("main-chart-smoothing-alg","")).smoothBgReadings(bgReadings);

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1479,8 +1479,7 @@
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="show-unsmoothed-values-as-plugin"
-                    android:dependency="engineering_mode"
-                    android:summary="Show unsmoothed data in place of plugin (engineering mode only)"
+                    android:summary="Show unsmoothed data as well"
                     android:title="Debug smoothing" />
                 <CheckBoxPreference
                     android:defaultValue="true"


### PR DESCRIPTION
Please let's remove this setting from engineering mode, or please tell me why it can be confusing and should remain there.

Thanks