### PR TITLE
Close all active db connections before database import (resolves #1475, #1705)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/ImportDatabaseActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ImportDatabaseActivity.java
@@ -299,6 +299,7 @@ public class ImportDatabaseActivity extends ListActivityWithMenu {
                                     fout.write(buffer, 0, count);
                                 }
                                 fout.close();
+                                fout.flush();
                                 dbFile = new File(output_filename);
                                 delete_file = dbFile;
                                 Log.d(TAG, "New filename: " + output_filename);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
@@ -9,6 +9,7 @@ import android.os.Looper;
 import android.text.format.DateFormat;
 import android.widget.Toast;
 
+import com.activeandroid.ActiveAndroid;
 import com.activeandroid.Cache;
 import com.activeandroid.Configuration;
 import com.eveningoutpost.dexdrip.Models.JoH;
@@ -354,6 +355,10 @@ public class DatabaseUtil {
                 destStream = new FileOutputStream(currentDBtmp);
                 dst = destStream.getChannel();
                 dst.transferFrom(src, 0, src.size());
+                destStream.flush();
+                // Close all active db connections before database import.
+                ActiveAndroid.clearCache();
+                ActiveAndroid.dispose();
                 currentDB.renameTo(currentDBold);
                 currentDBtmp.renameTo(currentDB);
                 currentDBold.delete();


### PR DESCRIPTION
Since 2020, I have experienced a problem importing database backups in xDrip, where immediately after an import the database is wiped due to sqlite detecting database corruption:

```
10-15 00:33:09.366 30246 30348 W SQLiteLog: (28) file unlinked while open: /data/user/0/com.eveningoutpost.dexdrip/databases/DexDrip.db
10-15 00:33:09.367 30246 30348 W SQLiteLog: (28) file unlinked while open: /data/user/0/com.eveningoutpost.dexdrip/databases/DexDrip.db
10-15 00:33:09.399 30246 30348 E SQLiteLog: (11) database corruption at line 67539 of [bcd014c473]
10-15 00:33:09.399 30246 30348 E SQLiteLog: (11) database disk image is malformed in "PRAGMA journal_mode"
10-15 00:33:09.668 30246 30348 E SQLiteDatabase: Database corruption detected in open()
10-15 00:33:09.668 30246 30348 E SQLiteDatabase: android.database.sqlite.SQLiteDatabaseCorruptException: database disk image is malformed (code 11 SQLITE_CORRUPT): , while compiling: PRAGMA journal_mode
10-15 00:33:09.668 30246 30348 E DefaultDatabaseErrorHandler: Corruption reported by sqlite on database: /data/user/0/com.eveningoutpost.dexdrip/databases/DexDrip.db
10-15 00:33:09.672  1867  2747 E SQLiteDatabase: DB wipe detected: package=com.eveningoutpost.dexdrip reason=corruption file=/data/user/0/com.eveningoutpost.dexdrip/databases/DexDrip.db ctime=2022-10-15T04:33:09Z mtime=2022-10-15T04:33:09Z atime=2022-10-15T04:33:08Z checkfile [unable to obtain timestamp]
10-15 00:33:09.672  1867  2747 E SQLiteDatabase: DB wipe detected: package=com.eveningoutpost.dexdrip reason=corruption file=/data/user/0/com.eveningoutpost.dexdrip/databases/DexDrip.db ctime=2022-10-15T04:33:09Z mtime=2022-10-15T04:33:09Z atime=2022-10-15T04:33:08Z checkfile [unable to obtain timestamp]
```

Given the "file unlinked while open" messages, I investigated the code used when performing a database import and noticed that the database is closed _after_ renaming the imported backup to the sqlite database file. This causes a race condition where if there is currently a connection open to the sqlite database, it is closed after the file underneath it was renamed, resulting in the new database corrupting itself.

I presume this appears more frequently the larger the size of your database, due to the added time it takes for the system to copy the files between the old and new buffer. The assumption that this is a race condition is further validated by the fact that if you re-ran the import process many (often 5 or more) times, eventually it would succeed.

After applying this change, I was able to successfully import my database file (which is very large, with data back to when I started using xDrip in 2017) twice in a row with no DB corruption being reported. Previously I would have needed to import the database 5 or more times for it to succeed.

The only inadvertent result of this change I have noticed is that xDrip closes immediately after database import, requiring you to relaunch it, while before the app would stay open. I presume this is because forcefully closing the database right before importing is closing some process still using the database underneath it which breaks some assumption inside the code. I don't think this actually matters and, regardless, this fix allowing for database imports to occur overweighs the side effect of needing to re-open xDrip after a database import (which is probably necessary for all of the app's components to detect the new data from the backup anyway).