### PR TITLE
fix ISO 8601 date string parsing if it contains milliseconds

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/DateUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/DateUtil.java
@@ -25,7 +25,7 @@ public class DateUtil {
 
     /**
      * Takes in an ISO date string of the following format:
-     * yyyy-MM-dd'T'HH:mm:ss.SSS(Z|+/-HH:mm)
+     * yyyy-MM-dd'T'HH:mm:ss.SSS(Z|+/-HH:mm) and parses it to a Java Date object.
      *
      * The milliseconds and time zone/offset values are optional.
      *
@@ -40,6 +40,21 @@ public class DateUtil {
             OffsetDateTime odt = OffsetDateTime.parse(pOffsetFix.matcher(strDateTime).replaceFirst("$1:$2"));
             return Date.from(odt.toInstant());
         }
+    }
+
+    /**
+     * Takes in an ISO date string of the following format:
+     * yyyy-MM-dd'T'HH:mm:ss.SSS(Z|+/-HH:mm) and parses it to a Java Date object.
+     *
+     * The milliseconds and time zone/offset values are optional.
+     *
+     * @param isoDateString the iso date string to parse
+     * @param omitMilliseconds whether milliseconds should be returned or ignored
+     * @return the date object
+     */
+    public static Date tolerantFromISODateString(String isoDateString, boolean omitMilliseconds) {
+        Date date = tolerantFromISODateString(isoDateString);
+        return new Date(date.getTime() - date.getTime() % 1000);
     }
 
     /**

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/DateUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/DateUtil.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 public class DateUtil {
 
     private static final String FORMAT_DATE_ISO = "yyyy-MM-dd'T'HH:mm:ss'Z'"; // eg 2017-03-24T22:03:27Z
-    private static final Pattern pDateFix = Pattern.compile("^(\\d{4}-\\d{2}-\\d{2})[ T](\\d{2}:\\d{2}:\\d{2})(?:.\\d+Z)*[^Z]?$");
+    private static final Pattern pDateFix = Pattern.compile("^(\\d{4}-\\d{2}-\\d{2})[ T](\\d{2}:\\d{2}:\\d{2})(?:\\.\\d+Z?)*[^Z]?$");
     private static final Pattern pOffsetFix = Pattern.compile("([+-]\\d{2})(\\d{2})$");
 
     /**

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/DateUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/DateUtil.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 public class DateUtil {
 
     private static final String FORMAT_DATE_ISO = "yyyy-MM-dd'T'HH:mm:ss'Z'"; // eg 2017-03-24T22:03:27Z
-    private static final Pattern pDateFix = Pattern.compile("^(\\d{4}-\\d{2}-\\d{2})[ T](\\d{2}:\\d{2}:\\d{2})(?:\\.\\d+Z?)*[^Z]?$");
+    private static final Pattern pDateFix = Pattern.compile("^(\\d{4}-\\d{2}-\\d{2})[ T](\\d{2}:\\d{2}:\\d{2})(\\.\\d+)*[^Z]?$");
     private static final Pattern pOffsetFix = Pattern.compile("([+-]\\d{2})(\\d{2})$");
 
     /**
@@ -33,7 +33,7 @@ public class DateUtil {
      * @return the date object
      */
     public static Date tolerantFromISODateString(String isoDateString) {
-        String strDateTime = pDateFix.matcher(isoDateString).replaceFirst("$1T$2Z");
+        String strDateTime = pDateFix.matcher(isoDateString).replaceFirst("$1T$2$3Z");
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) { // use Joda Time classes
             return DateTime.parse(strDateTime).toDate();
         } else {  // use built-in java.time classes

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/Entry.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/Entry.java
@@ -44,7 +44,7 @@ public class Entry extends BaseMessage {
         }
         if (sysTime != null) {
             try {
-                final Date date = DateUtil.tolerantFromISODateString(sysTime);
+                final Date date = DateUtil.tolerantFromISODateString(sysTime, true);
                 return date.getTime();
             } catch (Exception e) {
                 //
@@ -52,7 +52,7 @@ public class Entry extends BaseMessage {
         }
         if (dateString != null) {
             try {
-                final Date date = DateUtil.tolerantFromISODateString(dateString);
+                final Date date = DateUtil.tolerantFromISODateString(dateString, true);
                 return date.getTime();
             } catch (Exception e) {
                 //

--- a/app/src/test/java/com/eveningoutpost/dexdrip/Models/DateUtilTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/Models/DateUtilTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class DateUtilTest {
 
     public static Collection<String> testISODateStrings = Arrays.asList("2018-03-03 11:22:48", "2018-03-03T11:22:48", "2018-03-03T11:22:48Z",
-            "2018-03-03T11:22:48.384Z", "2018-03-03T12:22:48+01:00", "2018-03-03T05:22:48-06:00", "2018-03-03T14:22:48+0300");
+            "2018-03-03T11:22:48.384Z", "2018-03-03T11:22:48.348", "2018-03-03T12:22:48+01:00", "2018-03-03T05:22:48-06:00", "2018-03-03T14:22:48+0300");
     public static Date dtExpected = Date.from(Instant.parse("2018-03-03T11:22:48.000Z"));
 
     static void setFinalStatic(Field field, Object newValue) throws Exception {

--- a/app/src/test/java/com/eveningoutpost/dexdrip/Models/DateUtilTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/Models/DateUtilTest.java
@@ -25,8 +25,10 @@ import static org.junit.Assert.assertEquals;
 public class DateUtilTest {
 
     public static Collection<String> testISODateStrings = Arrays.asList("2018-03-03 11:22:48", "2018-03-03T11:22:48", "2018-03-03T11:22:48Z",
-            "2018-03-03T11:22:48.384Z", "2018-03-03T11:22:48.348", "2018-03-03T12:22:48+01:00", "2018-03-03T05:22:48-06:00", "2018-03-03T14:22:48+0300");
-    public static Date dtExpected = Date.from(Instant.parse("2018-03-03T11:22:48.000Z"));
+            "2018-03-03T12:22:48+01:00", "2018-03-03T05:22:48-06:00", "2018-03-03T14:22:48+0300",
+            "2018-03-03T11:22:48.384Z", "2018-03-03T11:22:48.384", "2018-03-03T12:22:48.384+0100");
+    public static Date dtExpected = Date.from(Instant.parse("2018-03-03T11:22:48.384Z"));
+    public static Date dtExpectedNoMilliseconds = Date.from(dtExpected.toInstant().truncatedTo(ChronoUnit.SECONDS));
 
     static void setFinalStatic(Field field, Object newValue) throws Exception {
         field.setAccessible(true);
@@ -42,7 +44,7 @@ public class DateUtilTest {
         @Parameterized.Parameter
         public String strInput;
 
-        @Parameterized.Parameters(name = "{index}: fromISODate({0})={1}")
+        @Parameterized.Parameters(name = "{index}: {0}")
         public static Collection<String> data() {
             return testISODateStrings;
         }
@@ -50,7 +52,12 @@ public class DateUtilTest {
         @Test
         public void tolerantFromISODateString() {
             try {
-                assertEquals(dtExpected, DateUtil.tolerantFromISODateString(strInput));
+                final Date parsed = DateUtil.tolerantFromISODateString(strInput);
+                if (parsed.getTime() % 1000 > 0) {
+                    assertEquals(dtExpected, parsed);
+                } else {
+                    assertEquals(dtExpectedNoMilliseconds, parsed);
+                }
             } catch (Exception e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
This PR enhances #1879 and fixes the exception reported with comment https://github.com/NightscoutFoundation/xDrip/pull/1649/#discussion_r983252108. The exception is caused if the date string contains milliseconds but no trailing 'Z'.

With the second commit milliseconds are retained, if any.