### PR TITLE
This change changes the behavior when one is scanning a sensor that is not the current sensor.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -458,10 +458,6 @@ public class NFCReaderX {
                     long now = JoH.tsl();
                     String SensorSn = LibreUtils.decodeSerialNumberKey(tag.getId());
 
-                    if (SensorSanity.checkLibreSensorChangeIfEnabled(SensorSn)) {
-                        Log.e(TAG, "Problem with Libre Serial Number - not processing");
-                        return;
-                    }
                     // Set the time of the current reading
                     PersistentStore.setLong("libre-reading-timestamp", JoH.tsl());
 
@@ -664,6 +660,15 @@ public class NFCReaderX {
 
                         SensorType sensorType = LibreOOPAlgorithm.getSensorType(patchInfo);
                         Log.uel(TAG, "Libre sensor of type " + sensorType.name() + " detected.");
+
+                        String SensorSn = LibreUtils.decodeSerialNumberKey(patchUid);
+                        // In the case that the wrong sensor was scanned we don't continue processing the data, but we also
+                        // don't stop the sensor. This is a manual case, and the user can scan the correct sensor.
+                        if (SensorSanity.checkLibreSensorChangeIfEnabled(SensorSn, false)) {
+                            Log.e(TAG, "Problem with Libre Serial Number - not processing");
+                            return null;
+                        }
+
                         if (addressed && sensorType != SensorType.Libre1 && sensorType != SensorType.Libre1New) {
                             Log.d(TAG, "Not using addressed mode since not a libre 1 sensor");
                             addressed = false;

--- a/app/src/test/java/com/eveningoutpost/dexdrip/Models/SensorSanityTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/Models/SensorSanityTest.java
@@ -83,7 +83,7 @@ public class SensorSanityTest extends RobolectricTestWithConfig {
     }
 
     private void sensorCheck(final String checkName, final String sn, boolean shouldBeTrue, boolean shouldBeNull) {
-        final boolean result = SensorSanity.checkLibreSensorChange(sn);
+        final boolean result = SensorSanity.checkLibreSensorChange(sn,true);
         final Sensor sensor = Sensor.currentSensor();
 
         //System.out.println("Test: " + checkName + " " + sn + " " + shouldBeTrue + " " + shouldBeNull + " -> " + result + " " + sensor);
@@ -109,35 +109,35 @@ public class SensorSanityTest extends RobolectricTestWithConfig {
         // Start testing: create a sensor, call checkLibreSensorChange twice with same sensor, and once with a new
         // sn, and verify it is closed.
         Sensor.create(JoH.tsl());
-        SensorSanity.checkLibreSensorChange("SN111");
-        SensorSanity.checkLibreSensorChange("SN111");
-        SensorSanity.checkLibreSensorChange("SN222");
+        SensorSanity.checkLibreSensorChange("SN111", true);
+        SensorSanity.checkLibreSensorChange("SN111", true);
+        SensorSanity.checkLibreSensorChange("SN222", true);
         this_sensor = Sensor.currentSensor();
 
         assertWithMessage("Expecting this_sensor to be null after serial change").that(this_sensor).isNull();
 
         // Continue testing: create new one, call with the second sn twice. now call with third sn, sensor should be stopped.
         Sensor.create(JoH.tsl());
-        SensorSanity.checkLibreSensorChange("SN222");
-        SensorSanity.checkLibreSensorChange("SN222");
-        boolean retVal = SensorSanity.checkLibreSensorChange("SN333");
+        SensorSanity.checkLibreSensorChange("SN222", true);
+        SensorSanity.checkLibreSensorChange("SN222", true);
+        boolean retVal = SensorSanity.checkLibreSensorChange("SN333", true);
         assertWithMessage("Expecting true after serial change").that(retVal).isEqualTo(true);
         this_sensor = Sensor.currentSensor();
         assertWithMessage("Expecting this_sensor to be null after serial change").that(this_sensor).isNull();
 
         // Create a new sensor, call check, then stop it and start another, all should be well.
         Sensor.create(JoH.tsl());
-        SensorSanity.checkLibreSensorChange("SN333");
-        SensorSanity.checkLibreSensorChange("SN333");
-        SensorSanity.checkLibreSensorChange("SN333");
+        SensorSanity.checkLibreSensorChange("SN333", true);
+        SensorSanity.checkLibreSensorChange("SN333", true);
+        SensorSanity.checkLibreSensorChange("SN333", true);
         this_sensor = Sensor.currentSensor();
         assertWithMessage("Expecting this_sensor not to be null without serial change").that(this_sensor).isNotNull();
         if (this_sensor != null) {
             Sensor.stopSensor();
         }
         Sensor.create(JoH.tsl());
-        SensorSanity.checkLibreSensorChange("SN333");
-        SensorSanity.checkLibreSensorChange("SN333");
+        SensorSanity.checkLibreSensorChange("SN333", true);
+        SensorSanity.checkLibreSensorChange("SN333", true);
         this_sensor = Sensor.currentSensor();
         assertWithMessage("Expecting this_sensor not to be null without serial change").that(this_sensor).isNotNull();
 
@@ -145,8 +145,8 @@ public class SensorSanityTest extends RobolectricTestWithConfig {
         // Stop the sensor. Start a new one. call checkLibreSensorChange with the new sensor_sn twice. Sensor should be alive.
         Sensor.stopSensor();
         Sensor.create(JoH.tsl());
-        SensorSanity.checkLibreSensorChange("SN444");
-        SensorSanity.checkLibreSensorChange("SN444");
+        SensorSanity.checkLibreSensorChange("SN444", true);
+        SensorSanity.checkLibreSensorChange("SN444", true);
         this_sensor = Sensor.currentSensor();
         assertWithMessage("Expecting this_sensor not to be null without serial change").that(this_sensor).isNotNull();
     }


### PR DESCRIPTION
The old behavior was to close the old sensor in the case that a new sensor was scanned. The new behavior is this:
If the scan was a manual scan, we ignore the scan and return (this is the reason that the check has moved to the first possible position). 
If this is a reading from a device like miaomiao the old behavior is preserved (close the sensor). The reason for the difference is that if one is using a device, than he has already sticked the device to the sensor, and there is no going back.
But manual scan can be done on a new/old sensor in a mistake, and next the correct sensor will be read.