### PR TITLE
Falling rate, rising rate and units

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -172,9 +172,9 @@
     </string-array>
 
     <string-array name="risingEntries">
-        <item>1 mg/dl/m (0.06 mmol/l/m)</item>
-        <item>2 mg/dl/m (0.11 mmol/l/m)</item>
-        <item>3 mg/dl/m (0.17 mmol/l/m)</item>
+        <item>1 mg/dl/min (0.06 mmol/l/min)</item>
+        <item>2 mg/dl/min (0.11 mmol/l/min)</item>
+        <item>3 mg/dl/min (0.17 mmol/l/min)</item>
     </string-array>
 
     <string-array name="risingValues">

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -172,9 +172,9 @@
     </string-array>
 
     <string-array name="risingEntries">
-        <item>1 mg/dl (0.06 mmol/l)</item>
-        <item>2 mg/dl (0.11 mmol/l)</item>
-        <item>3 mg/dl (0.17 mmol/l)</item>
+        <item>1 mg/dl/m (0.06 mmol/l/m)</item>
+        <item>2 mg/dl/m (0.11 mmol/l/m)</item>
+        <item>3 mg/dl/m (0.17 mmol/l/m)</item>
     </string-array>
 
     <string-array name="risingValues">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -801,8 +801,8 @@
     <string name="alert_seconds_reraise">Number of SECONDS to pass before raising the same alert.</string>
     <string name="bg_falling_fast">BG falling fast</string>
     <string name="bg_rising_fast">BG rising fast</string>
-    <string name="falling_threshold">falling threshold</string>
-    <string name="rising_threshold">rising threshold</string>
+    <string name="falling_threshold">falling rate threshold</string>
+    <string name="rising_threshold">rising rate threshold</string>
     <string name="set_sound_for_bg_alerts">Set sound used for BG Alerts.</string>
     <string name="alert_sound">Alert Sound</string>
     <string name="override_silent_mode_these">Override Silent mode on these alerts</string>


### PR DESCRIPTION
This is what we have now:
![Screenshot_20230115-205435](https://user-images.githubusercontent.com/51497406/212583166-9826f6c3-962c-421c-8f1c-d6311d5f4cdd.jpg)

The PR changes "rising" to "rising rate", and "falling" to "falling rate".
And it appends /min to the units.  

These are what we will have after this PR:
![Screenshot_20230115-204714](https://user-images.githubusercontent.com/51497406/212583711-dbfb1ffb-9789-418a-a62e-4db966636ab1.png)
  
![Screenshot_20230117-170942](https://user-images.githubusercontent.com/51497406/213024502-4fc09900-b5b9-4caa-8dfc-f0d5b8452d5d.png)

On a small screen, the units wrap.  The following image shows an example tested with a virtual device.
![Screenshot 2023-01-17 161122](https://user-images.githubusercontent.com/51497406/213024827-d2990ee5-7e67-4d50-8f24-6fa9fd028b0a.png)