### PR TITLE
Rename Samsung Workarounds

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -449,7 +449,7 @@ public class JoH {
         if (!buggy_samsung) {
            if (JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4) {
                buggy_samsung = true;
-               UserError.Log.d(TAG,"Enabling buggy handset mode due to historical pattern");
+               UserError.Log.d(TAG,"Enabling wake workaround mode due to historical pattern");
            }
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -449,7 +449,7 @@ public class JoH {
         if (!buggy_samsung) {
            if (JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4) {
                buggy_samsung = true;
-               UserError.Log.d(TAG,"Enabling buggy samsung mode due to historical pattern");
+               UserError.Log.d(TAG,"Enabling buggy handset mode due to historical pattern");
            }
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkFollowService.java
@@ -244,7 +244,7 @@ public class CareLinkFollowService extends ForegroundService {
         megaStatus.add(new StatusItem("Last poll time", lastPoll > 0 ? JoH.dateTimeText(lastPoll) : "n/a"));
         megaStatus.add(new StatusItem("Next poll time", JoH.dateTimeText(wakeup_time)));
         megaStatus.add(new StatusItem());
-        megaStatus.add(new StatusItem("Buggy Samsung", JoH.buggy_samsung ? "Yes" : "No"));
+        megaStatus.add(new StatusItem("Buggy handset", JoH.buggy_samsung ? "Yes" : "No"));
 
         return megaStatus;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrum/MedtrumCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrum/MedtrumCollectionService.java
@@ -881,7 +881,7 @@ public class MedtrumCollectionService extends JamBaseBluetoothService implements
                         if (wakeup_jitter > 1000) {
                             UserError.Log.d(TAG, "Wake up, time jitter: " + JoH.niceTimeScalar(wakeup_jitter));
                             if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && JoH.isSamsung()) {
-                                UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
+                                UserError.Log.wtf(TAG, "Enabled wake workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
                                 JoH.buggy_samsung = true;
                                 PersistentStore.incrementLong(BUGGY_SAMSUNG_ENABLED);
                                 max_wakeup_jitter = 0;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -207,7 +207,7 @@ public class NightscoutFollowService extends ForegroundService {
         }
         statuses.add(new StatusItem("Next poll time", JoH.dateTimeText(wakeup_time)));
         statuses.add(new StatusItem());
-        statuses.add(new StatusItem("Buggy Samsung", JoH.buggy_samsung ? gs(R.string.yes) : gs(R.string.no)));
+        statuses.add(new StatusItem("Buggy handset", JoH.buggy_samsung ? gs(R.string.yes) : gs(R.string.no)));
         statuses.add(new StatusItem("Download treatments", NightscoutFollow.treatmentDownloadEnabled() ? gs(R.string.yes) : gs(R.string.no)));
 
         if (StringUtils.isNotBlank(lastState)) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareFollowService.java
@@ -215,7 +215,7 @@ public class ShareFollowService extends ForegroundService {
             megaStatus.add(new StatusItem("Last BG time", JoH.dateTimeText(lastBg.timestamp)));
         }
         megaStatus.add(new StatusItem("Next poll time", JoH.dateTimeText(wakeup_time)));
-        megaStatus.add(new StatusItem("Buggy Samsung", JoH.buggy_samsung ? gs(R.string.yes) : gs(R.string.no)));
+        megaStatus.add(new StatusItem("Buggy handset", JoH.buggy_samsung ? gs(R.string.yes) : gs(R.string.no)));
 
         return megaStatus;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/webfollow/WebFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/webfollow/WebFollowService.java
@@ -232,7 +232,7 @@ public class WebFollowService extends ForegroundService {
         megaStatus.add(new StatusItem("Next poll time", JoH.dateTimeText(wakeup_time)));
 
         if (JoH.buggy_samsung) {
-            megaStatus.add(new StatusItem("Buggy Samsung", JoH.buggy_samsung ? gs(R.string.yes) : gs(R.string.no)));
+            megaStatus.add(new StatusItem("Buggy handset", JoH.buggy_samsung ? gs(R.string.yes) : gs(R.string.no)));
         }
 
         if (lastErrorTime != 0L && (msSince(lastErrorTime) < Constants.HOUR_IN_MS)) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/DexCollectionService.java
@@ -1044,7 +1044,7 @@ public class DexCollectionService extends Service implements BtCallBack {
             l.add(new StatusItem("Slowest wake up", JoH.niceTimeScalar(max_wakeup_jitter) + " late", max_wakeup_jitter > 61000 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
         }
         if (JoH.buggy_samsung) {
-            l.add(new StatusItem("Buggy Samsung", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : StatusItem.Highlight.BAD));
+            l.add(new StatusItem("Buggy handset", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : StatusItem.Highlight.BAD));
         }
         if (retry_time > 0)
             l.add(new StatusItem("Next Retry", JoH.niceTimeTill(retry_time), JoH.msTill(retry_time) < -2 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
@@ -1190,7 +1190,7 @@ public class DexCollectionService extends Service implements BtCallBack {
             }
             JoH.persistentBuggySamsungCheck();
             if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && (JoH.isSamsung())) {
-                UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
+                UserError.Log.wtf(TAG, "Enabled wake workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
                 JoH.setBuggySamsungEnabled();
                 max_wakeup_jitter = 0;
             } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/DoNothingService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/DoNothingService.java
@@ -105,7 +105,7 @@ public class DoNothingService extends Service {
                 max_wake_time_difference = Math.max(max_wake_time_difference, wake_time_difference);
 
                 if (!JoH.buggy_samsung && JoH.isSamsung()) {
-                    UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + JoH.niceTimeScalar(wake_time_difference));
+                    UserError.Log.wtf(TAG, "Enabled wake workaround due to jitter of: " + JoH.niceTimeScalar(wake_time_difference));
                     JoH.setBuggySamsungEnabled();
                 }
 
@@ -211,7 +211,7 @@ public class DoNothingService extends Service {
             }
 
             if (JoH.buggy_samsung) {
-                l.add(new StatusItem("Buggy Samsung", "Using workaround", max_wake_time_difference < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : BAD));
+                l.add(new StatusItem("Buggy handset", "Using workaround", max_wake_time_difference < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : BAD));
             }
 
             if (nextWakeUpTime != -1) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/JamBaseBluetoothService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/JamBaseBluetoothService.java
@@ -178,7 +178,7 @@ public abstract class JamBaseBluetoothService extends Service {
 
     protected static void enableBuggySamsungIfNeeded(final String TAG) {
         if ((JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4)) {
-            UserError.Log.d(TAG, "Enabling buggy samsung due to persistent metric");
+            UserError.Log.d(TAG, "Enabling buggy handset due to persistent metric");
             JoH.buggy_samsung = true;
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/JamBaseBluetoothService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/JamBaseBluetoothService.java
@@ -178,7 +178,7 @@ public abstract class JamBaseBluetoothService extends Service {
 
     protected static void enableBuggySamsungIfNeeded(final String TAG) {
         if ((JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4)) {
-            UserError.Log.d(TAG, "Enabling buggy handset due to persistent metric");
+            UserError.Log.d(TAG, "Enabling wake workaround due to persistent metric");
             JoH.buggy_samsung = true;
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -943,7 +943,7 @@ public class Ob1G5CollectionService extends G5BaseService {
         UserError.Log.d(TAG, "Checking model: " + this_model);
 
         if ((JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4)) {
-            UserError.Log.d(TAG, "Enabling buggy samsung due to persistent metric");
+            UserError.Log.d(TAG, "Enabling buggy handset due to persistent metric");
             JoH.buggy_samsung = true;
         }
 
@@ -1026,7 +1026,7 @@ public class Ob1G5CollectionService extends G5BaseService {
                     if (wakeup_jitter > 1000) {
                         UserError.Log.d(TAG, "Wake up, time jitter: " + niceTimeScalar(wakeup_jitter));
                         if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && JoH.isSamsung()) {
-                            UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + niceTimeScalar(wakeup_jitter));
+                            UserError.Log.wtf(TAG, "Enabled wake workaround due to jitter of: " + niceTimeScalar(wakeup_jitter));
                             JoH.buggy_samsung = true;
                             PersistentStore.incrementLong(BUGGY_SAMSUNG_ENABLED);
                             max_wakeup_jitter = 0;
@@ -2043,7 +2043,7 @@ public class Ob1G5CollectionService extends G5BaseService {
         }
 
         if (JoH.buggy_samsung) {
-            l.add(new StatusItem("Buggy Samsung", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? Highlight.GOOD : BAD));
+            l.add(new StatusItem("Buggy handset", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? Highlight.GOOD : BAD));
         }
 
         final String tx_id = getTransmitterID();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -943,7 +943,7 @@ public class Ob1G5CollectionService extends G5BaseService {
         UserError.Log.d(TAG, "Checking model: " + this_model);
 
         if ((JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4)) {
-            UserError.Log.d(TAG, "Enabling buggy handset due to persistent metric");
+            UserError.Log.d(TAG, "Enabling wake workaround due to persistent metric");
             JoH.buggy_samsung = true;
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/WifiCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/WifiCollectionService.java
@@ -74,7 +74,7 @@ public class WifiCollectionService extends Service {
             l.add(new StatusItem("Wakeup jitter", JoH.niceTimeScalar(max_wakeup_jitter), max_wakeup_jitter > TOLERABLE_JITTER ? StatusItem.Highlight.BAD : StatusItem.Highlight.NORMAL));
         }
         if (JoH.buggy_samsung) {
-            l.add(new StatusItem("Buggy Samsung", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : StatusItem.Highlight.BAD));
+            l.add(new StatusItem("Buggy handset", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : StatusItem.Highlight.BAD));
         }
         if(DexCollectionType.hasLibre()) {
             l.addAll(LibreWifiReader.megaStatus());
@@ -119,7 +119,7 @@ public class WifiCollectionService extends Service {
                 Log.d(TAG, "Wake up jitter: " + JoH.niceTimeScalar(wakeup_jitter));
             }
             if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && (JoH.isSamsung())) {
-                UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
+                UserError.Log.wtf(TAG, "Enabled wake workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
                 JoH.setBuggySamsungEnabled();
                 max_wakeup_jitter = 0;
             } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/BuggySamsung.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/BuggySamsung.java
@@ -42,7 +42,7 @@ public class BuggySamsung {
                 if (wakeup_jitter > 1000) {
                     UserError.Log.d(TAG, "Wake up, time jitter: " + JoH.niceTimeScalar(wakeup_jitter));
                     if ((wakeup_jitter > TOLERABLE_JITTER) && (!buggy_samsung) && isSamsung()) {
-                        UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
+                        UserError.Log.wtf(TAG, "Enabled wake workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
                         buggy_samsung = true;
                         PersistentStore.incrementLong(BUGGY_SAMSUNG_ENABLED);
                         max_wakeup_jitter = 0;
@@ -61,7 +61,7 @@ public class BuggySamsung {
     // enable if we have historic markers showing previous enabling
     public void checkWasBuggy() {
         if (!buggy_samsung && isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4) {
-            UserError.Log.e(TAG, "Enabling buggy samsung due to persistent metric");
+            UserError.Log.e(TAG, "Enabling buggy handset due to persistent metric");
             buggy_samsung = true;
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/BuggySamsung.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/BuggySamsung.java
@@ -61,7 +61,7 @@ public class BuggySamsung {
     // enable if we have historic markers showing previous enabling
     public void checkWasBuggy() {
         if (!buggy_samsung && isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4) {
-            UserError.Log.e(TAG, "Enabling buggy handset due to persistent metric");
+            UserError.Log.e(TAG, "Enabling wake workaround due to persistent metric");
             buggy_samsung = true;
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1319,8 +1319,8 @@
     <string name="title_lefun_screen_heart_pressure">Show Heart Pressure</string>
     <string name="title_lefun_screen_find_phone">Show Find Phone / Snooze</string>
     <string name="title_lefun_screen_mac_address">Show MAC Address</string>
-    <string name="summary_allow_samsung_workaround">Use workarounds to avoid non-standard Android behavior of Samsung handsets. Without this, collectors usually fail to get data.</string>
-    <string name="title_allow_samsung_workaround">Samsung Workarounds</string>
+    <string name="summary_allow_samsung_workaround">Use workarounds to avoid non-standard Android behavior of some handsets. Without this, collectors usually fail to get data.</string>
+    <string name="title_allow_samsung_workaround">Wake Workarounds</string>
     <string name="summary_medtrum_use_native">Use transmitter calibration instead of xDrip for primary</string>
     <string name="title_medtrum_use_native">Medtrum Native</string>
     <string name="summary_medtrum_a_hex">Hex diagnostic test value</string>

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -350,7 +350,7 @@ public class JoH {
         if (!buggy_samsung) {
             if (JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4) {
                 buggy_samsung = true;
-                UserError.Log.d(TAG,"Enabling buggy handset mode due to historical pattern");
+                UserError.Log.d(TAG,"Enabling wake workaround mode due to historical pattern");
             }
         }
     }

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -350,7 +350,7 @@ public class JoH {
         if (!buggy_samsung) {
             if (JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4) {
                 buggy_samsung = true;
-                UserError.Log.d(TAG,"Enabling buggy samsung mode due to historical pattern");
+                UserError.Log.d(TAG,"Enabling buggy handset mode due to historical pattern");
             }
         }
     }

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/services/DexCollectionService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/services/DexCollectionService.java
@@ -998,7 +998,7 @@ public class DexCollectionService extends Service implements BtCallBack {
             l.add(new StatusItem("Slowest wake up", JoH.niceTimeScalar(max_wakeup_jitter) + " late", max_wakeup_jitter > 61000 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
         }
         if (JoH.buggy_samsung) {
-            l.add(new StatusItem("Buggy Samsung", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : StatusItem.Highlight.BAD));
+            l.add(new StatusItem("Buggy handset", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? StatusItem.Highlight.GOOD : StatusItem.Highlight.BAD));
         }
         if (retry_time > 0)
             l.add(new StatusItem("Next Retry", JoH.niceTimeTill(retry_time), JoH.msTill(retry_time) < -2 ? StatusItem.Highlight.CRITICAL : StatusItem.Highlight.NORMAL));
@@ -1141,7 +1141,7 @@ public class DexCollectionService extends Service implements BtCallBack {
             }
             JoH.persistentBuggySamsungCheck();
             if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && (JoH.isSamsung())) {
-                UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
+                UserError.Log.wtf(TAG, "Enabled Buggy handset workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
                 JoH.setBuggySamsungEnabled();
                 max_wakeup_jitter = 0;
             } else {

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/services/DexCollectionService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/services/DexCollectionService.java
@@ -1141,7 +1141,7 @@ public class DexCollectionService extends Service implements BtCallBack {
             }
             JoH.persistentBuggySamsungCheck();
             if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && (JoH.isSamsung())) {
-                UserError.Log.wtf(TAG, "Enabled Buggy handset workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
+                UserError.Log.wtf(TAG, "Enabled wake workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
                 JoH.setBuggySamsungEnabled();
                 max_wakeup_jitter = 0;
             } else {

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -855,7 +855,7 @@ public class Ob1G5CollectionService extends G5BaseService {
         UserError.Log.d(TAG, "Checking model: " + this_model);
 
         if ((JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4)) {
-            UserError.Log.d(TAG, "Enabling buggy handset due to persistent metric");
+            UserError.Log.d(TAG, "Enabling wake workaround due to persistent metric");
             JoH.buggy_samsung = true;
         }
 
@@ -934,7 +934,7 @@ public class Ob1G5CollectionService extends G5BaseService {
                     if (wakeup_jitter > 1000) {
                         UserError.Log.d(TAG, "Wake up, time jitter: " + JoH.niceTimeScalar(wakeup_jitter));
                         if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && JoH.isSamsung()) {
-                            UserError.Log.wtf(TAG, "Enabled Buggy handset workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
+                            UserError.Log.wtf(TAG, "Enabled wake workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
                             JoH.buggy_samsung = true;
                             PersistentStore.incrementLong(BUGGY_SAMSUNG_ENABLED);
                             max_wakeup_jitter = 0;

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -855,7 +855,7 @@ public class Ob1G5CollectionService extends G5BaseService {
         UserError.Log.d(TAG, "Checking model: " + this_model);
 
         if ((JoH.isSamsung() && PersistentStore.getLong(BUGGY_SAMSUNG_ENABLED) > 4)) {
-            UserError.Log.d(TAG, "Enabling buggy samsung due to persistent metric");
+            UserError.Log.d(TAG, "Enabling buggy handset due to persistent metric");
             JoH.buggy_samsung = true;
         }
 
@@ -934,7 +934,7 @@ public class Ob1G5CollectionService extends G5BaseService {
                     if (wakeup_jitter > 1000) {
                         UserError.Log.d(TAG, "Wake up, time jitter: " + JoH.niceTimeScalar(wakeup_jitter));
                         if ((wakeup_jitter > TOLERABLE_JITTER) && (!JoH.buggy_samsung) && JoH.isSamsung()) {
-                            UserError.Log.wtf(TAG, "Enabled Buggy Samsung workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
+                            UserError.Log.wtf(TAG, "Enabled Buggy handset workaround due to jitter of: " + JoH.niceTimeScalar(wakeup_jitter));
                             JoH.buggy_samsung = true;
                             PersistentStore.incrementLong(BUGGY_SAMSUNG_ENABLED);
                             max_wakeup_jitter = 0;
@@ -1805,7 +1805,7 @@ public class Ob1G5CollectionService extends G5BaseService {
         }
 
         if (JoH.buggy_samsung) {
-            l.add(new StatusItem("Buggy Samsung", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? Highlight.GOOD : BAD));
+            l.add(new StatusItem("Buggy handset", "Using workaround", max_wakeup_jitter < TOLERABLE_JITTER ? Highlight.GOOD : BAD));
         }
 
         final String tx_id = getTransmitterID();


### PR DESCRIPTION
We are now using this for phones other than Samsung.  For example, Xiaomi.

People disable the setting thinking that it should only be enabled if they have a Samsung phone.

The question comes up why buggy Samsung is shown on the status page, or in a log, when they are not using a Samsung.  
  
![2](https://user-images.githubusercontent.com/51497406/219825178-d97caf72-1b19-4dd9-be29-268b28b601e9.png)
<br/>  


This PR will remove "Samsung" from the title and summary of the setting and from the logs to avoid the confusion.

This is compiled and I am running it right now.
![Screenshot_20230217-195913](https://user-images.githubusercontent.com/51497406/219823086-47a964a7-5b5d-4d70-b3fa-4a19739dd556.png)
