### PR TITLE
Medtronic CareLink Follower: add pump status data to integration

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkDataProcessor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkDataProcessor.java
@@ -9,6 +9,7 @@ import com.eveningoutpost.dexdrip.Models.Treatments;
 import com.eveningoutpost.dexdrip.Models.UserError;
 import com.eveningoutpost.dexdrip.UtilityModels.Inevitable;
 import com.eveningoutpost.dexdrip.UtilityModels.Pref;
+import com.eveningoutpost.dexdrip.UtilityModels.PumpStatus;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.ActiveNotification;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.Alarm;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.ClearedNotification;
@@ -218,7 +219,15 @@ public class CareLinkDataProcessor {
             }
         }
 
-
+        //PUMP INFO (Pump Status)
+        if (recentData.isNGP()) {
+            PumpStatus.setReservoir(recentData.reservoirRemainingUnits);
+            PumpStatus.setBattery(recentData.medicalDeviceBatteryLevelPercent);
+            if (recentData.activeInsulin != null)
+                PumpStatus.setBolusIoB(recentData.activeInsulin.amount);
+            PumpStatus.syncUpdate();
+        }
+		
         // LAST ALARM -> NOTE (only for GC)
         if (Pref.getBooleanDefaultFalse("clfollow_download_notifications")) {
 


### PR DESCRIPTION
The current medtronic carelink integration works pretty good, but I am still missing the data of the pump.
The change in this PR was implemented by @benceszasz but it wasn't part of the Medtronic CareLink Follower (MMConnect for xDrip) #1649 PR.
I am using this code since quite a while and I did not face any problem yet. 
Are there any concerns or could this be taken over? 
