### PR TITLE
Remove old log access

### DIFF
--- a/app/src/main/res/menu/menu_eventlog_activity.xml
+++ b/app/src/main/res/menu/menu_eventlog_activity.xml
@@ -7,13 +7,6 @@
         android:icon="@android:drawable/ic_menu_search"
         app:actionViewClass="android.support.v7.widget.SearchView"
         app:showAsAction="always|collapseActionView"/>
-    <item android:id="@+id/userEvents"
-        android:title="@string/view_old_error_log"
-        android:checkable="false"
-        android:orderInCategory="2"
-        android:onClick="viewErrorLog"
-        android:visible="true"
-        android:showAsAction="never"/>
     <item android:id="@+id/returnHome"
         android:title="@string/return_to_home_screen"
         android:checkable="false"

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1034,14 +1034,6 @@
             android:key="xdrip_less_common_settings"
             android:summary="@string/debug_and_other_misc_options"
             android:title="@string/less_common_settings">
-            <Preference
-                android:key="recent_errors"
-                android:title="@string/view_recent_errors_warnings">
-                <intent
-                    android:action="android.intent.action.MAIN"
-                    android:targetClass="com.eveningoutpost.dexdrip.ErrorsActivity"
-                    android:targetPackage="@string/local_target_package" />
-            </Preference>
 
             <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
                 android:key="xdrip_extra_status_line"


### PR DESCRIPTION
This PR removes the option to access the old logs.

There are individuals who still post these logs.  We have to tell them to post the new logs.  Can we please get rid of the old ones so that everyone would use the same set of logs?  
This PR does that.