### PR TITLE
Wake workaround for all brands

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/JoH.java
@@ -438,10 +438,8 @@ public class JoH {
         return null; // too big
     }
 
-    public static boolean isSamsung() {     // same workaround for xiaomi, so include that but may want name refactoring later
-        return Build.MANUFACTURER.toLowerCase().contains("samsung")
-            || Build.MANUFACTURER.toLowerCase().contains("xiaomi")
-            || Build.MANUFACTURER.toLowerCase().contains("oneplus");    // experimental test
+    public static boolean isSamsung() {  // Workaround for all brands
+        return true;
     }
 
     private static final String BUGGY_SAMSUNG_ENABLED = "buggy-samsung-enabled";


### PR DESCRIPTION
Tested on Android 11 Motorola.

Does not trigger on this phone.  But, there may be other phones and other brands that would benefit.

If the artifact is experienced by anyone after this PR, they can disable the "Wake workarounds" setting. 