### PR TITLE
Linear ascending volume

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -127,6 +127,10 @@ public class AlertPlayer {
     final static int MAX_VIBRATING_MINUTES = 2;
     final static int MAX_ASCENDING_MINUTES = 5;
 
+    // Ascending without delay profile
+    final static float NODELAY_ASCENDING_INTERCEPT = 0.3333f; // Lower volumes are silent on some phones.
+    final static float NODELAY_ASCENDING_SLOPE = 0.166675f; // So that the volume reaches 1 (max) in 4 steps (1-2-3-4-5) since in most cases, we have a new reading once every 5 minutes.
+
     public int streamType = AudioManager.STREAM_MUSIC;
 
     private final AudioManager.OnAudioFocusChangeListener focusChangeListener =
@@ -543,11 +547,11 @@ public class AlertPlayer {
         if (profile != ALERT_PROFILE_VIBRATE_ONLY && profile != ALERT_PROFILE_SILENT) {
             float volumeFrac = (float) (minsFromStartPlaying - MAX_VIBRATING_MINUTES) / (MAX_ASCENDING_MINUTES - MAX_VIBRATING_MINUTES);
             // While minsFromStartPlaying <= MAX_VIBRATING_MINUTES, we only vibrate ...
+            if (!Pref.getBoolean("delay_ascending_3min", true)) { // If delay_ascending_3min is disabled, linearly increase volume from start.
+                volumeFrac = (minsFromStartPlaying * NODELAY_ASCENDING_SLOPE + NODELAY_ASCENDING_INTERCEPT);
+            }
             volumeFrac = Math.max(volumeFrac, 0); // Limit volumeFrac to values greater than and equal to 0
             volumeFrac = Math.min(volumeFrac, 1); // Limit volumeFrac to values less than and equal to 1
-            if (!Pref.getBoolean("delay_ascending_3min", true) && volumeFrac < 0.3) {
-                volumeFrac = (float) 0.3; // If delay_ascending_3min is disabled, we never only vibrate.
-            }
             if (profile == ALERT_PROFILE_MEDIUM) {
                 volumeFrac = (float) 0.7;
             }


### PR DESCRIPTION
This PR modifies the behavior of the ascending volume profile only when the "Delay Ascending Volume" setting is disabled.  By default, this setting is enabled.

The following shows the profile using extra logs enabled after this PR.
![Screenshot_20230320-111637](https://user-images.githubusercontent.com/51497406/226385622-9b495612-968a-440f-a61b-8c20762c1c9e.png)

Currently, before this PR, the volume is increased this way:
0.666
0.333
0.3
0.3
0.3

That means, the volume, currently, does not reach 100% (High) in a single 5-minute cycle.  It only reaches 70% (Medium) in a single 5-minute cycle.  
Only if you don't snooze the alert and it keeps going, on the next reading, will it reach 100%.

Also, for the first 3 minutes, currently, the volume is set to 0.3.  On some phones, any volume setting below 0.3333 (like 0.3) is silent.

This change will make the volume increase linearly from start and reach the high level (100%) in one 5-minute cycle.

I am currently using this and it is perfect.