### PR TITLE
Don't start G6 if transmitter age is not known

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
@@ -54,6 +54,7 @@ public class StartNewSensor extends ActivityWithMenu {
     // private TimePicker tp;
     final Activity activity = this;
     Calendar ucalendar = Calendar.getInstance();
+    private int transmitterAgeInDays = DexTimeKeeper.getTransmitterAgeInDays(getTransmitterID());
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -101,8 +102,9 @@ public class StartNewSensor extends ActivityWithMenu {
 
         ucalendar = Calendar.getInstance();
         if (Ob1G5CollectionService.usingNativeMode()) {
-            if (!DexSyncKeeper.isReady(Pref.getString("dex_txid", "NULL"))) {
-                JoH.static_toast_long("Need to connect to transmitter once before we can start sensor");
+            if (!DexSyncKeeper.isReady(Pref.getString("dex_txid", "NULL")) || !(transmitterAgeInDays > -1)) {
+                JoH.static_toast_long("Need to connect to transmitter before we can start sensor");
+                UserError.Log.e(TAG, "Need to connect to transmitter before we can start sensor");
                 MegaStatus.startStatus(MegaStatus.G5_STATUS);
             } else {
                 startSensorOrAskForG6Code();   // If we're using native mode, don't bother asking about insertion time
@@ -179,7 +181,6 @@ public class StartNewSensor extends ActivityWithMenu {
         if (Ob1G5CollectionService.usingCollector() && Ob1G5StateMachine.usingG6()) {
             if (JoH.pratelimit("dex-stop-start", cap)) {
                 JoH.clearRatelimit("dex-stop-start");
-                val transmitterAgeInDays = DexTimeKeeper.getTransmitterAgeInDays(getTransmitterID());
                 val modified = FirmwareCapability.isTransmitterModified(getTransmitterID());
                 val endOfLife = transmitterAgeInDays >= ABSOLUTE_MAX_AGE_DAYS || (!modified && transmitterAgeInDays >= MAX_AGE_DAYS);
                 if (transmitterAgeInDays < MAX_AGE_DAYS - MONTH_WARNING_DAYS


### PR DESCRIPTION
If the transmitter age is not know, currently, a sensor can still be started.
A start will not be allowed if there has been no contact.  But, with a new transmitter, even after a first contact, the transmitter age may still not be known

This PR will not allow the sensor to be started as long as the transmitter age is not a valid integer.
It also adds a log if a start is not allowed in addition to a toast message.