### PR TITLE
Add LISPRO insulin

### DIFF
--- a/app/src/main/res/raw/insulin_profiles.txt
+++ b/app/src/main/res/raw/insulin_profiles.txt
@@ -59,6 +59,28 @@
       }
     },
     {
+      "name": "Lispro",
+      "displayName": "Lispro (rapid acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "111291061285",
+        "111291059828",
+        "111291064107",
+        "111291063541"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "15",
+          "peak": "90",
+          "duration": "210"
+        }
+      }
+    },
+    {
       "name": "Actrapid",
       "displayName": "Actrapid (short acting)",
       "concentration": "U100",


### PR DESCRIPTION
This PR adds the insulin type "lispro Sanofi®".

Depends on #2773.

The curve data was gathered from the diagram and text in the european product information ANNEX I SUMMARY OF PRODUCT CHARACTERISTICS. https://www.ema.europa.eu/en/documents/product-information/insulin-lispro-sanofi-epar-product-information_en.pdf

This is a screenshot from the document:
![grafik](https://user-images.githubusercontent.com/1894841/230670260-cf1982d5-55df-4f5d-943a-f3571f4400e5.png)

The PNNs were converted from the PZN from the manufacturer page: https://mein.sanofi.de/produkte/insulin-lispro-sanofi This converter was used: https://www.ifaffm.de/de/ifa-codingsystem/von-pzn-zu-ppn/ppn-generator.html