### PR TITLE
Clarify Silent mode vs Do not disturb

### DIFF
--- a/app/src/main/res/values-de/strings-de.xml
+++ b/app/src/main/res/values-de/strings-de.xml
@@ -775,7 +775,8 @@
     <string name="rising_threshold">Steigungswarngrenze</string>
     <string name="set_sound_for_bg_alerts">Setze den Ton, der für Glukosealarme benutzt wird.</string>
     <string name="alert_sound">Alarmton</string>
-    <string name="override_silent_mode_these">Lautlos-Modus bei diesen Alarmen überschreiben</string>
+    <string name="override_silent_mode_these">"Nicht stören" ignorieren</string>
+    <string name="no_effect_when_using_notification_channels">Diese Einstellung hat keinen Effekt, wenn die Benachrichtigungskanal-Funktion aktiviert ist. Das Verhalten kann dann in den Android-Benachrichtigungseinstellungen geändert werden.</string>
     <string name="persistent_repeat_max">Maximal alle x Minuten wiederholen</string>
     <string name="momentum_indicates_low">Wenn der Trend anzeigt, dass eine Unterzuckerung bevorsteht</string>
     <string name="notify_on_low_battery_level">Benachrichtigen, wenn der Ladezustand niedrig wird.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -805,7 +805,8 @@
     <string name="rising_threshold">rising threshold</string>
     <string name="set_sound_for_bg_alerts">Set sound used for BG Alerts.</string>
     <string name="alert_sound">Alert Sound</string>
-    <string name="override_silent_mode_these">Override Silent mode on these alerts</string>
+    <string name="override_silent_mode_these">Ignore Do not disturb</string>
+    <string name="no_effect_when_using_notification_channels">This setting has no effect when using Notification Channels. You can configure the behavior in the Android notification settings, then.</string>
     <string name="persistent_repeat_max">Repeating max every (minutes)</string>
     <string name="momentum_indicates_low">When momentum trend indicates a Low would be predicted</string>
     <string name="notify_on_low_battery_level">Notify when battery level goes below</string>

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -272,7 +272,8 @@
                     <CheckBoxPreference
                         android:defaultValue="false"
                         android:key="other_alerts_override_silent"
-                        android:title="@string/override_silent_mode_these" />
+                        android:title="@string/override_silent_mode_these"
+                        android:summary="@string/no_effect_when_using_notification_channels" />
                 </PreferenceCategory>
             </PreferenceScreen>
             <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
I had a deep dive why Other alerts/"Override Silent mode on these alerts" isn't working on my phone. Turns out the setting is only referring to the Do not disturb function.

This PR changes the text from "Override Silent mode on these alerts" to "Ignore Do not disturb" for the following reasons:

- The option has no effect when the phone's volume is 0 (I'd call that silent). Alarms won't come through if you set the tristate sound/vibrate/no sound button in the pull down menu to no sound. This is a different behavior to the glucose alerts. They do override the no sound setting. The renaming helps the user to differentiate between the behaviors and prevents confusion like here https://github.com/NightscoutFoundation/xDrip/issues/193#issuecomment-1098418384
- The suggested wording is compatible with the Android settings. See screenshot below.
- The current text doesn't fit onto the screen of a Galaxy S8+. See screenshot below.

It also adds a summary to the setting, explaining that it has no effect when using Notification Channels.

I tested the behavior with and without Notification Channels.

Old:
![grafik](https://user-images.githubusercontent.com/1894841/233851885-500b391e-0c1e-46c8-a615-cba233c24df2.png)

New:
![grafik](https://user-images.githubusercontent.com/1894841/233851892-687968e8-086f-43dd-94e5-65069f0454df.png)

Android wording:
![grafik](https://user-images.githubusercontent.com/1894841/233851928-96c6a03c-82c5-46d6-bfc7-aaa7790f3a92.png)
