### PR TITLE
Remove slot number from engineering mode

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -306,7 +306,7 @@ public class Ob1G5StateMachine {
 
     @SuppressLint("CheckResult")
     private static void handleAuthenticationWrite(final Ob1G5CollectionService parent, final RxBleConnection connection) {
-        final int specifiedSlot = Pref.getBooleanDefaultFalse("engineering_mode") ? Pref.getStringToInt("dex_specified_slot", -1) : -1;
+        final int specifiedSlot = Pref.getStringToInt("dex_specified_slot", -1);
         final AuthRequestTxMessage authRequest = (specifiedSlot == -1) ? new AuthRequestTxMessage(getTokenSize(), usingAlt())
         : new AuthRequestTxMessage(getTokenSize(), specifiedSlot);
         lastAuthPacket = authRequest;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -2084,6 +2084,11 @@ public class Ob1G5CollectionService extends G5BaseService {
             }
         }
 
+        val g6slot_marker = Pref.getStringToInt("dex_specified_slot", -1);
+        if (Pref.getBooleanDefaultFalse("using_g6") && g6slot_marker != 2 && g6slot_marker != -1) { // If G6 is selected and the slot number is not default
+            l.add(new StatusItem("Slot", g6slot_marker, Highlight.NOTICE));
+        }
+
         final int queueSize = Ob1G5StateMachine.queueSize();
         if (queueSize > 0) {
             l.add(new StatusItem("Queue Items", "(" + queueSize + ") " + Ob1G5StateMachine.getFirstQueueItemName()));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/watch/thinjam/BlueJayAdapter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/watch/thinjam/BlueJayAdapter.java
@@ -90,7 +90,7 @@ public class BlueJayAdapter {
     };
 
     private static boolean alwaysAllowPhoneSlot() {
-        final int specifiedSlot = Pref.getBooleanDefaultFalse("engineering_mode") ? Pref.getStringToInt("dex_specified_slot", -1) : -1;
+        final int specifiedSlot = Pref.getStringToInt("dex_specified_slot", -1);
         return specifiedSlot == 3;
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1698,7 +1698,7 @@
     </plurals>
     <string name="external_status_strings_eg_tbr">External status strings, eg TBR from AAPS</string>
     <string name="accept_external_status">Accept External Status</string>
-    <string name="summary_dex_specified_slot" translatable="false">Specify transmitter slot manually, setting this incorrectly will prevent any readings being received.</string>
+    <string name="summary_dex_specified_slot" translatable="false">Specify transmitter slot manually, setting this incorrectly will prevent any readings being received.  Leave blank for default.</string>
     <string name="title_dex_specified_slot" translatable="false">Manual Slot Number</string>
     <string name="cancel_by_default">Cancel by default</string>
     <string name="old">Old</string>

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -380,7 +380,6 @@
                     android:defaultValue=""
                     android:inputType="number"
                     android:maxLength="1"
-                    android:dependency="engineering_mode"
                     android:key="dex_specified_slot"
                     android:summary="@string/summary_dex_specified_slot"
                     android:title="@string/title_dex_specified_slot" />


### PR DESCRIPTION
There are individuals who use this (Dex slot number change).
I wish that we won't encourage users to enable engineering mode for normal use.
Please let's remove it from engineering mode.

There would be a problem if we just remove it from engineering mode:
We will end up with connectivity failure reports and we will have no way of knowing why.
To remedy that, the status page now shows a new item identifying the chosen slot number only if G6 is selected and only if the selected value is not default.
![Screenshot_20230428-090156](https://user-images.githubusercontent.com/51497406/235156470-0d9d8350-8a04-42b3-9c1f-bb1e00d60cc0.jpg)
