### PR TITLE
Update client common browser headers

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -515,8 +515,8 @@ public class CareLinkClient {
         //Add common browser headers
         requestBuilder
                 .addHeader("Accept-Language", "en;q=0.9, *;q=0.8")
-                .addHeader("sec-ch-ua", "\"Google Chrome\";v=\"87\", \" Not;A Brand\";v=\"99\", \"Chromium\";v=\"87\"")
-                .addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36");
+                .addHeader("sec-ch-ua", "\"Chromium\";v=\"112\", \" Google Chrome\";v=\"112\", \"Not:A-Brand\";v=\"99\"")
+                .addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36");
 
         //Set media type based on request type
         switch (type) {


### PR DESCRIPTION
Should fix login issues.

This is a reproduction of https://github.com/benceszasz/xDripCareLinkFollower/pull/22/files and should solve the current login issues with the current version of CareLink.

See https://github.com/NightscoutFoundation/xDrip/discussions/2821 for more context.