### PR TITLE
Don't show larger values then chosen max when marked as bad

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -1267,7 +1267,9 @@ public class BgGraphBuilder {
                     pluginValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(Math.min(plugin.getGlucoseFromBgReading(bgReading, cd), BgReading.BG_READING_MAXIMUM_VALUE))));
                 }
                 if (bgReading.ignoreForStats) {
-                    badValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
+                    if (unitized(bgReading.calculated_value) <= defaultMaxY) { // Don't display value marked as bad if greater than the default Max (defaultMaxY)
+                        badValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
+                    }
                 } else if (bgReading.calculated_value >= BgReading.BG_READING_MAXIMUM_VALUE) {
                     highValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(BgReading.BG_READING_MAXIMUM_VALUE)));
                 } else if (unitized(bgReading.calculated_value) >= highMark) {


### PR DESCRIPTION
We have an open issue about the 24-hour penalty here: https://github.com/NightscoutFoundation/xDrip/issues/2173

This PR partly addresses that.
There are times the user may have a single error showing a very large value.  This PR allows the user to mark that reading bad.  Then, the vertical axis limit will not increase to include the large reading.

On the other hand, there are times someone may have correct readings that re very high.  In that case, the user should not mark those as bad readings.  But, they will still have to deal with their vertical axis being modified for 24 hours.  This is the part of the problem that this PR does not address.
There will be a different PR for that later.
 
I have tested this.