### PR TITLE
Clarify notification

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SettingsValidation.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SettingsValidation.java
@@ -18,7 +18,7 @@ public class SettingsValidation {
         setting_name = "engineering_mode";
         if (Pref.getBooleanDefaultFalse("engineering_mode")) {
             if (JoH.pratelimit(setting_name + NOTIFY_MARKER, RENOTIFY_TIME)) {
-                id = notify("Engineering Mode", setting_name, "" + xdrip.getAppContext().getString(R.string.eng_mode_is_on), id);
+                id = notifyDis("Engineering Mode", setting_name, "" + xdrip.getAppContext().getString(R.string.eng_mode_is_on), id);
             }
         }
 
@@ -26,7 +26,7 @@ public class SettingsValidation {
 
         // OB1 is disabled
 
-        // Samsung workaround is disabled
+        // Wake workaround is disabled
 
         // Bluetooth watchdog is disabled
 
@@ -41,9 +41,15 @@ public class SettingsValidation {
         // Aggressive service restarts is disabled
     }
 
-    private static int notify(String short_name, String setting_string, String msg, int id) {
+    private static int notifyDis(String short_name, String setting_string, String msg, int id) {
 
-        JoH.showNotification("Inadvisable settings - " + short_name, "Please enable or disable " + setting_string, null, id, false, false, null, null, ((msg.length() > 0) ? msg : ""));
+        JoH.showNotification("Inadvisable setting ", "Please disable " + short_name, null, id, false, false, null, null, ((msg.length() > 0) ? msg : ""));
+        return id + 1;
+    }
+
+    private static int notifyEn(String short_name, String setting_string, String msg, int id) {
+
+        JoH.showNotification("Inadvisable setting ", "Please enable " + short_name, null, id, false, false, null, null, ((msg.length() > 0) ? msg : ""));
         return id + 1;
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SettingsValidation.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SettingsValidation.java
@@ -6,7 +6,7 @@ import com.eveningoutpost.dexdrip.xdrip;
 
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.SETTINGS_INADVISABLE_BASE_ID;
 
-// navid200
+// Navid200
 
 public class SettingsValidation {
     private static final String NOTIFY_MARKER = "-NOTIFY";
@@ -23,6 +23,7 @@ public class SettingsValidation {
         }
 
         // Todo Add the following items as well
+        // A different method than notifyDis should be created (perhaps notifyEn) for settings that are disabled and are advised to be enabled e.g. OB1.
 
         // OB1 is disabled
 
@@ -44,12 +45,6 @@ public class SettingsValidation {
     private static int notifyDis(String short_name, String setting_string, String msg, int id) {
 
         JoH.showNotification("Inadvisable setting ", "Please disable " + short_name, null, id, false, false, null, null, ((msg.length() > 0) ? msg : ""));
-        return id + 1;
-    }
-
-    private static int notifyEn(String short_name, String setting_string, String msg, int id) {
-
-        JoH.showNotification("Inadvisable setting ", "Please enable " + short_name, null, id, false, false, null, null, ((msg.length() > 0) ? msg : ""));
         return id + 1;
     }
 }


### PR DESCRIPTION
This is what the notification looks like before you expand it:
![Screenshot_20230515-142329](https://github.com/NightscoutFoundation/xDrip/assets/51497406/2560e7bc-2361-4399-9b0c-01416736d9b1)

It reads "Please enable or disable engineering_mode".
That can be misleading.

After the PR, it will read "Please disable Engineering Mode" as shown below.
![Screenshot_20230520-212152](https://github.com/NightscoutFoundation/xDrip/assets/51497406/2372280b-03ec-4694-9a5e-640eef4bf6ad)  

The price to pay is that we now need two different notification methods, one for advising to disable and the other for advising to enable.  