### PR TITLE
Allow test if ascending is not delayed

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -941,8 +941,8 @@ public class EditAlertActivity extends ActivityWithMenu {
 
             if (Pref.getBooleanDefaultFalse("start_snoozed"))  {
                 JoH.static_toast_long("Start Snoozed setting means alert would normally start silent");
-            } else if (Pref.getStringDefaultBlank("bg_alert_profile").equals("ascending")) {
-                JoH.static_toast_long("Ascending Volume Profile means it will start silent");
+            } else if (Pref.getStringDefaultBlank("bg_alert_profile").equals("ascending") && Pref.getBoolean("delay_ascending_3min", true)) {
+                JoH.static_toast_long("Ascending Volume Profile + delayed ascending means it will start silent");
             } else if (Pref.getStringDefaultBlank("bg_alert_profile").equals("Silent")) {
                 JoH.static_toast_long("Volume Profile is set to silent!");
             }


### PR DESCRIPTION
Currently, if you have the ascending volume profile chosen and test one of your glucose level alerts, it will be silent and you will see the following message:
*Ascending Volume Profile means it will start silent*

However, we now have the following setting available:
Delay Ascending Volume

If you disable that setting, the alert does not start silent.

This PR corrects this discrepancy.
If the setting is disabled, testing the alert will let you hear it.
Only if you have enabled the delay ascending volume (default setting), will you hear no sound and see the following message:
*Ascending Volume Profile + delayed ascending means it will start silent*

This has been tested.