### PR TITLE
Don't show G6 cal code for G7

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -2107,7 +2107,7 @@ public class Ob1G5CollectionService extends G5BaseService {
         }
         final String sensorCode = getCurrentSensorCode();
         if (sensorCode != null) {
-            if (usingG6()) {
+            if (usingG6() && FirmwareCapability.isTransmitterG6(getTransmitterID())) {
                 l.add(new StatusItem("Calibration Code", sensorCode));
             }
         }


### PR DESCRIPTION
I have tested this with G6 only as I don't have G7.