### PR TITLE
CareLink Follower  Updates: Multi follow, correct device type, TZ correction

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkDataProcessor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkDataProcessor.java
@@ -234,8 +234,8 @@ public class CareLinkDataProcessor {
             // Only Guardian Connect, NGP has all in notifications
             if (recentData.isGM() && recentData.lastAlarm != null) {
                 //Add notification from alarm
-                if (recentData.lastAlarm.datetime != null && recentData.lastAlarm.kind != null)
-                    addNotification(recentData.lastAlarm.datetime, recentData.getDeviceFamily(), recentData.lastAlarm);
+                if (recentData.lastAlarm.datetimeAsDate != null && recentData.lastAlarm.kind != null)
+                    addNotification(recentData.lastAlarm.datetimeAsDate, recentData.getDeviceFamily(), recentData.lastAlarm);
             }
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkDataProcessor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkDataProcessor.java
@@ -234,8 +234,8 @@ public class CareLinkDataProcessor {
             // Only Guardian Connect, NGP has all in notifications
             if (recentData.isGM() && recentData.lastAlarm != null) {
                 //Add notification from alarm
-                if (recentData.lastAlarm.datetimeAsDate != null && recentData.lastAlarm.kind != null)
-                    addNotification(recentData.lastAlarm.datetimeAsDate, recentData.getDeviceFamily(), recentData.lastAlarm);
+                if (recentData.lastAlarm.datetime != null && recentData.lastAlarm.kind != null)
+                    addNotification(recentData.lastAlarm.datetime, recentData.getDeviceFamily(), recentData.lastAlarm);
             }
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkFollowDownloader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkFollowDownloader.java
@@ -25,6 +25,7 @@ public class CareLinkFollowDownloader {
     private String carelinkUsername;
     private String carelinkPassword;
     private String carelinkCountry;
+    private String carelinkPatient;
 
     private CareLinkClient careLinkClient;
 
@@ -40,10 +41,11 @@ public class CareLinkFollowDownloader {
         return status;
     }
 
-    CareLinkFollowDownloader(String carelinkUsername, String carelinkPassword, String carelinkCountry) {
+    CareLinkFollowDownloader(String carelinkUsername, String carelinkPassword, String carelinkCountry, String carelinkPatient) {
         this.carelinkUsername = carelinkUsername;
         this.carelinkPassword = carelinkPassword;
         this.carelinkCountry = carelinkCountry;
+        this.carelinkPatient = carelinkPatient;
         loginDataLooksOkay = !emptyString(carelinkUsername) && !emptyString(carelinkPassword) && carelinkCountry != null && !emptyString(carelinkCountry);
     }
 
@@ -122,7 +124,10 @@ public class CareLinkFollowDownloader {
 
                 //Get data
                 try {
-                    recentData = getCareLinkClient().getRecentData();
+                    if (JoH.emptyString(this.carelinkPatient))
+                        recentData = getCareLinkClient().getRecentData();
+                    else
+                        recentData = getCareLinkClient().getRecentData(this.carelinkPatient);
                     lastResponseCode = carelinkClient.getLastResponseCode();
                 } catch (Exception e) {
                     UserError.Log.e(TAG, "Exception in CareLink data download: " + e);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkFollowService.java
@@ -171,7 +171,8 @@ public class CareLinkFollowService extends ForegroundService {
                     downloader = new CareLinkFollowDownloader(
                             Pref.getString("clfollow_user", ""),
                             Pref.getString("clfollow_pass", ""),
-                            Pref.getString("clfollow_country", "").toLowerCase()
+                            Pref.getString("clfollow_country", "").toLowerCase(),
+                            Pref.getString("clfollow_patient", "")
                     );
                 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -645,15 +645,9 @@ public class CareLinkClient {
 
                 timezoneMissing = true;
 
-                //Try get TZ offset string: lastSG or lastAlarm
-                if(recentData.lastSG != null && recentData.lastSG.datetime != null)
-                    offsetString = this.getZoneOffset(recentData.lastSG.datetime);
-                else
-                    offsetString = this.getZoneOffset(recentData.lastAlarm.datetime);
+                //offset = this.getZonedDate(recentData.lastSG.datetime).getOffset();
+                offsetString = this.getZoneOffset(recentData.lastSG.datetime);
 
-                //Set last alarm datetime as date
-                if(recentData.lastAlarm != null && recentData.lastAlarm.datetime != null)
-                    recentData.lastAlarm.datetimeAsDate = parseDateString(recentData.lastAlarm.datetime);
                 //Build correct dates with timezone
                 recentData.sMedicalDeviceTime = recentData.sMedicalDeviceTime + offsetString;
                 recentData.medicalDeviceTimeAsString = recentData.medicalDeviceTimeAsString + offsetString;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -645,9 +645,15 @@ public class CareLinkClient {
 
                 timezoneMissing = true;
 
-                //offset = this.getZonedDate(recentData.lastSG.datetime).getOffset();
-                offsetString = this.getZoneOffset(recentData.lastSG.datetime);
+                //Try get TZ offset string: lastSG or lastAlarm
+                if(recentData.lastSG != null && recentData.lastSG.datetime != null)
+                    offsetString = this.getZoneOffset(recentData.lastSG.datetime);
+                else
+                    offsetString = this.getZoneOffset(recentData.lastAlarm.datetime);
 
+                //Set last alarm datetimeAsDate
+                if(recentData.lastAlarm != null && recentData.lastAlarm.datetime != null)
+                    recentData.lastAlarm.datetimeAsDate = parseDateString(recentData.lastAlarm.datetime);
                 //Build correct dates with timezone
                 recentData.sMedicalDeviceTime = recentData.sMedicalDeviceTime + offsetString;
                 recentData.medicalDeviceTimeAsString = recentData.medicalDeviceTimeAsString + offsetString;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -515,8 +515,8 @@ public class CareLinkClient {
         //Add common browser headers
         requestBuilder
                 .addHeader("Accept-Language", "en;q=0.9, *;q=0.8")
-                .addHeader("sec-ch-ua", "\"Google Chrome\";v=\"87\", \" Not;A Brand\";v=\"99\", \"Chromium\";v=\"87\"")
-                .addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36");
+                .addHeader("sec-ch-ua", "\"Chromium\";v=\"112\", \"Google Chrome\";v=\"112\", \"Not:A-Brand\";v=\"99\"")
+                .addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36");
 
         //Set media type based on request type
         switch (type) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -645,9 +645,15 @@ public class CareLinkClient {
 
                 timezoneMissing = true;
 
-                //offset = this.getZonedDate(recentData.lastSG.datetime).getOffset();
-                offsetString = this.getZoneOffset(recentData.lastSG.datetime);
+                //Try get TZ offset string: lastSG or lastAlarm
+                if(recentData.lastSG != null && recentData.lastSG.datetime != null)
+                    offsetString = this.getZoneOffset(recentData.lastSG.datetime);
+                else
+                    offsetString = this.getZoneOffset(recentData.lastAlarm.datetime);
 
+                //Set last alarm datetime as date
+                if(recentData.lastAlarm != null && recentData.lastAlarm.datetime != null)
+                    recentData.lastAlarm.datetimeAsDate = parseDateString(recentData.lastAlarm.datetime);
                 //Build correct dates with timezone
                 recentData.sMedicalDeviceTime = recentData.sMedicalDeviceTime + offsetString;
                 recentData.medicalDeviceTimeAsString = recentData.medicalDeviceTimeAsString + offsetString;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Alarm.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Alarm.java
@@ -12,7 +12,8 @@ public class Alarm {
     }
 
     public int code;
-    public Date datetime;
+    public String datetime;
+    public Date datetimeAsDate;
     public String type;
     public boolean flash;
     public String kind;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Alarm.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Alarm.java
@@ -12,8 +12,7 @@ public class Alarm {
     }
 
     public int code;
-    public String datetime;
-    public Date datetimeAsDate;
+    public Date datetime;
     public String type;
     public boolean flash;
     public String kind;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/DataUpload.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/DataUpload.java
@@ -4,6 +4,7 @@ public class DataUpload {
 
     public long date;
     public boolean mobileUploaded;
+    public String status;
     public String device;
     public String serialNumber;
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/M2MEnabled.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/M2MEnabled.java
@@ -1,0 +1,7 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
+
+public class M2MEnabled {
+
+    public boolean value;
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Patient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Patient.java
@@ -1,0 +1,18 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
+
+public class Patient {
+
+    public String firstName;
+    public String lastName;
+    public String status;
+    public String username;
+    public boolean notificationsAllowed;
+    public String nickname;
+    public String lastDeviceFamily;
+    public boolean patientUsesConnect;
+
+    public boolean isBle() {
+        return lastDeviceFamily.contains("BLE");
+    }
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/RecentUploads.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/RecentUploads.java
@@ -1,0 +1,9 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
+
+import java.util.List;
+
+public class RecentUploads {
+
+    public List<DataUpload> recentUploads;
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionHelper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionHelper.java
@@ -159,9 +159,18 @@ public class DexCollectionHelper {
                                                         new Runnable() {
                                                             @Override
                                                             public void run() {
-                                                                Home.staticRefreshBGCharts();
-                                                                CareLinkFollowService.resetInstanceAndInvalidateSession();
-                                                                CollectionServiceStarter.restartCollectionServiceBackground();
+                                                                textSettingDialog(activity,
+                                                                        "clfollow_patient", "CareLink Patient",
+                                                                        "Enter CareLink Patient (optional)",
+                                                                        InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD,
+                                                                        new Runnable() {
+                                                                            @Override
+                                                                            public void run() {
+                                                                                Home.staticRefreshBGCharts();
+                                                                                CareLinkFollowService.resetInstanceAndInvalidateSession();
+                                                                                CollectionServiceStarter.restartCollectionServiceBackground();
+                                                                            }
+                                                                        });
                                                             }
                                                         });
                                             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1326,6 +1326,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             final Preference carelinkFollowUser = findPreference("clfollow_user");
             final Preference carelinkFollowPass = findPreference("clfollow_pass");
             final Preference carelinkFollowCountry = findPreference("clfollow_country");
+            final Preference carelinkFollowPatient = findPreference("clfollow_patient");
             final Preference carelinkFollowGracePeriod = findPreference("clfollow_grace_period");
             final Preference carelinkFollowMissedPollInterval = findPreference("clfollow_missed_poll_interval");
             final Preference carelinkFollowDownloadFingerBGs = findPreference("clfollow_download_finger_bgs");
@@ -1338,6 +1339,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 collectionCategory.addPreference(carelinkFollowUser);
                 collectionCategory.addPreference(carelinkFollowPass);
                 collectionCategory.addPreference(carelinkFollowCountry);
+                collectionCategory.addPreference(carelinkFollowPatient);
                 collectionCategory.addPreference(carelinkFollowGracePeriod);
                 collectionCategory.addPreference(carelinkFollowMissedPollInterval);
                 collectionCategory.addPreference(carelinkFollowDownloadFingerBGs);
@@ -1358,6 +1360,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     carelinkFollowUser.setOnPreferenceChangeListener(carelinkFollowListener);
                     carelinkFollowPass.setOnPreferenceChangeListener(carelinkFollowListener);
                     carelinkFollowCountry.setOnPreferenceChangeListener(carelinkFollowListener);
+                    carelinkFollowPatient.setOnPreferenceChangeListener(carelinkFollowListener);
                     carelinkFollowGracePeriod.setOnPreferenceChangeListener(carelinkFollowListener);
                     carelinkFollowMissedPollInterval.setOnPreferenceChangeListener(carelinkFollowListener);
                 } catch (Exception e) {
@@ -1369,6 +1372,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     collectionCategory.removePreference(carelinkFollowUser);
                     collectionCategory.removePreference(carelinkFollowPass);
                     collectionCategory.removePreference(carelinkFollowCountry);
+                    collectionCategory.removePreference(carelinkFollowPatient);
                     collectionCategory.removePreference(carelinkFollowGracePeriod);
                     collectionCategory.removePreference(carelinkFollowMissedPollInterval);
                     collectionCategory.removePreference(carelinkFollowDownloadFingerBGs);
@@ -1709,6 +1713,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             if (collectionType != DexCollectionType.CLFollow) {
                 try {
                     collectionCategory.removePreference(carelinkFollowCountry);
+                    collectionCategory.removePreference(carelinkFollowPatient);
                     collectionCategory.removePreference(carelinkFollowPass);
                     collectionCategory.removePreference(carelinkFollowUser);
                     collectionCategory.removePreference(carelinkFollowGracePeriod);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1336,6 +1336,8 @@
     <string name="summary_clfollow_pass">CareLink login password</string>
     <string name="title_clfollow_country">CareLink Country</string>
     <string name="summary_clfollow_country">Select your CareLink country.</string>
+    <string name="title_clfollow_patient">CareLink Patient Username</string>
+    <string name="summary_clfollow_patient">CareLink patient username (optional)</string>
     <string name="title_clfollow_lang">CareLink Language</string>
     <string name="summary_clfollow_lang">CareLink language code</string>
     <string name="title_clfollow_grace_period">Grace Period</string>

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -231,6 +231,14 @@
             android:summary="@string/summary_clfollow_pass"
             android:title="@string/title_clfollow_pass" />
         <EditTextPreference
+            android:defaultValue=""
+            android:inputType="textNoSuggestions|textVisiblePassword"
+            android:key="clfollow_patient"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:summary="@string/summary_clfollow_patient"
+            android:title="@string/title_clfollow_patient" />
+        <EditTextPreference
             android:defaultValue="30"
             android:inputType="textNoSuggestions|textVisiblePassword"
             android:key="clfollow_grace_period"


### PR DESCRIPTION
Multi follow
Implement new CareLink multiple follow APIs, integrate new APIs. New CareLink Follow parameter: CareLink Patient user, which must be provided only if care partner with multiple patients are used. For care partner with single patient the patient is automatically determined using the patient list API.

Correct device type
Device type may be wrong in CareLink after moving from standalone CGM to 7xxG pumps. This causes an error in data retrieval since standalone CGM and 7xxG pumps use different API for data retrieval. To address this issue the recent CareLink data upload infos for patient accounts are checked and the actual device type is extracted from data upload infos (device used for uploading data).

Timezone determination correction
In CareLink data TZ may be missing, which was previously extracted from Last SG's datetime. However Last SG is sometimes empty and TZ cannot be determined. If Last SG is not provided in CareLink data, then Last Alarm's datetime is used to get correct TZ.