### PR TITLE
Limit REST API upload failure alert and log to once a day

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
@@ -99,6 +99,7 @@ public class NightscoutUploader {
         public static long last_success_time = -1;
         public static long last_exception_time = -1;
         public static int last_exception_count = 0;
+        public static int last_exception_log_count = 0;
         public static String last_exception;
         public static final String VIA_NIGHTSCOUT_TAG = "via Nightscout";
 
@@ -110,8 +111,10 @@ public class NightscoutUploader {
 
         private static int failurecount = 0;
 
-        public static int upload_fail_notification_period = 86400; // Failed upload notification will be shown only if there is no upload for 24 hours.
-        public static int exception_count_trigger = upload_fail_notification_period / 60 / 5 -1;
+        public static final int FAIL_NOTIFICATION_PERIOD = 86400; // Failed upload notification will be shown if there is no upload for 24 hours.
+        public static final int FAIl_COUNT_NOTIFICATION = FAIL_NOTIFICATION_PERIOD / 60 / 5 -1; // Number of 5-minute read cycles corresponding to notification period
+        public static final int FAIL_LOG_PERIOD = 6 * 60 * 60; // FAILED upload/download log will be shown if there is no upload/download for 6 hours.
+        public static final int FAIL_COUNT_LOG = FAIL_LOG_PERIOD / 60 / 5 -1; // Number of 5-minute read cycles corresponding to 6 hours
 
         private Context mContext;
         private Boolean enableRESTUpload;
@@ -497,6 +500,7 @@ public class NightscoutUploader {
                     any_successes = true;
                     last_success_time = JoH.tsl();
                     last_exception_count = 0;
+                    last_exception_log_count = 0;
                 } catch (Exception e) {
                     String msg = "Unable to do REST API Upload: " + e.getMessage() + " marking record: " + (any_successes ? "succeeded" : "failed");
                     handleRestFailure(msg);
@@ -577,32 +581,38 @@ public class NightscoutUploader {
                   }
                 }
             }
+
         }
 
     private static synchronized void handleRestFailure(String msg) {
         last_exception = msg;
         last_exception_time = JoH.tsl();
         last_exception_count++;
-        if (last_exception_count > exception_count_trigger) {
-            if (JoH.ratelimit("nightscout-error-notification", upload_fail_notification_period)) {
+        last_exception_log_count++;
+        if (last_exception_log_count > FAIL_COUNT_LOG) { // If the number of failed uploads/downloads crosses the logging target
+            if (JoH.pratelimit("nightscout-error-log", FAIL_LOG_PERIOD)) { // If there has been more than 6 hours since the last log
                 Log.e(TAG, msg);
-                if (Pref.getBooleanDefaultFalse("warn_nightscout_failures")) {
-                    notification_shown = true;
-                    JoH.showNotification("Nightscout Failure", "REST-API upload to Nightscout has failed " + last_exception_count
-                                    + " times. With message: " + last_exception + " " + ((last_success_time > 0) ? "Last succeeded: " + JoH.dateTimeText(last_success_time) : ""),
+                last_exception_log_count = 0; // Reset the fail count for logging.
+            }
+            if (last_exception_count > FAIl_COUNT_NOTIFICATION) { // If the number of failed uploads crosses the notification target
+                if (JoH.pratelimit("nightscout-error-notification", FAIL_NOTIFICATION_PERIOD)) { // If there has been more than 24 hours since the last notification
+                    if (Pref.getBooleanDefaultFalse("warn_nightscout_failures")) {
+                        notification_shown = true;
+                        JoH.showNotification("Nightscout Failure", "REST-API upload to Nightscout has failed " + last_exception_count
+                                        + " times. With message: " + last_exception + " " + ((last_success_time > 0) ? "Last succeeded: " + JoH.dateTimeText(last_success_time) : ""),
 
-                            MegaStatus.getStatusPendingIntent("Uploaders"), Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID, NotificationChannels.NIGHTSCOUT_UPLOADER_CHANNEL, true, true, null, null, msg);
-                } else {
-                    Log.e(TAG, "Cannot alert for nightscout failures as preference setting is disabled");
+                                MegaStatus.getStatusPendingIntent("Uploaders"), Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID, NotificationChannels.NIGHTSCOUT_UPLOADER_CHANNEL, true, true, null, null, msg);
+                    } else {
+                        Log.e(TAG, "Cannot alert for nightscout failures as preference setting is disabled");
+                    }
+                }
+            } else {
+                if (notification_shown) {
+                    JoH.cancelNotification(Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID);
+                    notification_shown = false;
                 }
             }
-        } else {
-            if (notification_shown) {
-                JoH.cancelNotification(Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID);
-                notification_shown = false;
-            }
         }
-        // Log.e(TAG, msg); // This spams the logs once every 5 minutes.  Let's do it differently.
     }
 
     private String getDeviceString(BgReading record) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
@@ -111,10 +111,10 @@ public class NightscoutUploader {
 
         private static int failurecount = 0;
 
-        public static final int FAIL_NOTIFICATION_PERIOD = 86400; // Failed upload notification will be shown if there is no upload for 24 hours.
+        public static final int FAIL_NOTIFICATION_PERIOD = 24 * 60 * 60; // Failed upload notification will be shown if there is no upload for 24 hours.
         public static final int FAIl_COUNT_NOTIFICATION = FAIL_NOTIFICATION_PERIOD / 60 / 5 -1; // Number of 5-minute read cycles corresponding to notification period
         public static final int FAIL_LOG_PERIOD = 6 * 60 * 60; // FAILED upload/download log will be shown if there is no upload/download for 6 hours.
-        public static final int FAIL_COUNT_LOG = FAIL_LOG_PERIOD / 60 / 5 -1; // Number of 5-minute read cycles corresponding to 6 hours
+        public static final int FAIL_COUNT_LOG = FAIL_LOG_PERIOD / 60 / 5 -1; // Number of 5-minute read cycles corresponding to log period
 
         private Context mContext;
         private Boolean enableRESTUpload;
@@ -601,7 +601,7 @@ public class NightscoutUploader {
                         JoH.showNotification("Nightscout Failure", "REST-API upload to Nightscout has failed " + last_exception_count
                                         + " times. With message: " + last_exception + " " + ((last_success_time > 0) ? "Last succeeded: " + JoH.dateTimeText(last_success_time) : ""),
 
-                                MegaStatus.getStatusPendingIntent("Uploaders"), Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID, NotificationChannels.NIGHTSCOUT_UPLOADER_CHANNEL, true, true, null, null, msg);
+                                MegaStatus.getStatusPendingIntent("Uploaders"), Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID, NotificationChannels.NIGHTSCOUT_UPLOADER_CHANNEL, false, false, null, null, msg);
                     } else {
                         Log.e(TAG, "Cannot alert for nightscout failures as preference setting is disabled");
                     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
@@ -110,7 +110,7 @@ public class NightscoutUploader {
 
         private static int failurecount = 0;
 
-        public static int upload_fail_notification_period = 86400; // Failed upload notification will be shown only if there is no upload for this long (seconds).
+        public static int upload_fail_notification_period = 86400; // Failed upload notification will be shown only if there is no upload for 24 hours.
         public static int exception_count_trigger = upload_fail_notification_period / 60 / 5 -1;
 
         private Context mContext;
@@ -584,17 +584,17 @@ public class NightscoutUploader {
         last_exception_time = JoH.tsl();
         last_exception_count++;
         if (last_exception_count > exception_count_trigger) {
-            if (Pref.getBooleanDefaultFalse("warn_nightscout_failures")) {
-                if (JoH.ratelimit("nightscout-error-notification", upload_fail_notification_period)) {
+            if (JoH.ratelimit("nightscout-error-notification", upload_fail_notification_period)) {
+                Log.e(TAG, msg);
+                if (Pref.getBooleanDefaultFalse("warn_nightscout_failures")) {
                     notification_shown = true;
                     JoH.showNotification("Nightscout Failure", "REST-API upload to Nightscout has failed " + last_exception_count
                                     + " times. With message: " + last_exception + " " + ((last_success_time > 0) ? "Last succeeded: " + JoH.dateTimeText(last_success_time) : ""),
 
                             MegaStatus.getStatusPendingIntent("Uploaders"), Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID, NotificationChannels.NIGHTSCOUT_UPLOADER_CHANNEL, true, true, null, null, msg);
-                    Log.e(TAG, msg);
+                } else {
+                    Log.e(TAG, "Cannot alert for nightscout failures as preference setting is disabled");
                 }
-            } else {
-                Log.e(TAG, "Cannot alert for nightscout failures as preference setting is disabled");
             }
         } else {
             if (notification_shown) {


### PR DESCRIPTION
If you upload to Nightscout and have no internet access, you will get fail  log once every 5 minutes until you have access to the internet again.
You will also receive an alert once every 30 minutes.

Many users just disable the alert.

We have Google Cloud Nightscout users who have not logged into their FreeDNS account for 6 months.  As a result, their Nightscout has stopped working.  But, they have no idea.  The reason is that they have disabled this alert.

If this PR is merged, there will only be a single log once every 6 hours and a single alert only once a day if there is no internet access.  
However, the uploaders status page still shows the failure immediately as this PR makes no change to that.

If Nightscout upload is failing, it could just be because you have no access to the internet.  In that case, the alert has no value.
If your Nightscout server has gone down, you will need to fix it.  Receiving an alert after 24 hours of failure, is not going to take the chance of fixing it away.
So, there is no reason to receive so many alerts and logs.

Please let me know if I am overlooking a scenario when a 5-minute log interval and a 30-minute alert interval is necessary.