### PR TITLE
Remove "unable to do upload" as soon as uploads resume

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/UploaderQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/UploaderQueue.java
@@ -530,8 +530,8 @@ public class UploaderQueue extends Model {
 
         ///
 
-        if (NightscoutUploader.last_exception_time > 0) {
-            l.add(new StatusItem("REST-API problem\n" + JoH.dateTimeText(NightscoutUploader.last_exception_time) + " (" + NightscoutUploader.last_exception_count + ")", NightscoutUploader.last_exception, JoH.msSince(NightscoutUploader.last_exception_time) < (Constants.MINUTE_IN_MS * 6) ? StatusItem.Highlight.BAD : StatusItem.Highlight.NORMAL));
+        if (NightscoutUploader.last_exception_count > 0) {
+            l.add(new StatusItem("REST-API problem\n" + JoH.dateTimeText(NightscoutUploader.last_exception_time) + " (" + NightscoutUploader.last_exception_count + ")", NightscoutUploader.last_exception, StatusItem.Highlight.BAD));
         }
 
 


### PR DESCRIPTION
This is a typical question that is often posted in facebook groups:  
  
![Screenshot 2023-05-29 164357](https://github.com/NightscoutFoundation/xDrip/assets/51497406/f7d51ec5-e9e8-406b-8c29-6a421eb5dde1)


The rest api problem remains on the status page even after uploads resume.  That brings up questions.
This PR removes that note from the Uploaders status page when uploads resume.