### PR TITLE
Report current IoB value in the /pebble endpoint.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
@@ -978,7 +978,7 @@ public class Treatments extends Model {
     }
 
     // NEW NEW NEW
-    public static List<Iob> ioBForGraph_new(int number, long startTime) {
+    public static List<Iob> ioBForGraph_new(long startTime) {
 
        // Log.d(TAG, "Processing iobforgraph2: main  ");
         JoH.benchmark_method_start();
@@ -1290,6 +1290,23 @@ public class Treatments extends Model {
         JoH.benchmark_method_end();
         return responses;
     }*/
+
+    public static Double getCurrentIoB() {
+        long now = System.currentTimeMillis();
+
+        final List<Iob> iobInfo = Treatments.ioBForGraph_new(now - 1 * Constants.DAY_IN_MS);
+
+        if (iobInfo != null) {
+            for (Iob iob : iobInfo) {
+                // Find IoB sample close to the current timestamp.
+                if (iob.timestamp > now - 5 * MINUTE_IN_MS && iob.timestamp < now + 5 * MINUTE_IN_MS) {
+                    return iob.iob;
+                }
+            }
+        }
+
+        return null;
+    }
 
     public String getBestShortText() {
         if (!eventType.equals(DEFAULT_EVENT_TYPE)) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -1686,7 +1686,7 @@ public class BgGraphBuilder {
                     final double relaxed_predicted_bg_limit = initial_predicted_bg * 1.20;
                     final double cob_insulin_max_draw_value = highMark * 1.20;
                     // final List<Iob> iobinfo_old = Treatments.ioBForGraph(numValues, (start_time * FUZZER));
-                    final List<Iob> iobinfo = (simulation_enabled) ? Treatments.ioBForGraph_new(MAX_VALUES, (start_time * FUZZER)) : null; // for test
+                    final List<Iob> iobinfo = (simulation_enabled) ? Treatments.ioBForGraph_new(start_time * FUZZER) : null; // for test
 
                     long fuzzed_timestamp = (long) end_time; // initial value in case there are no iob records
                     if (d)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebServicePebble.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebServicePebble.java
@@ -7,6 +7,7 @@ import com.eveningoutpost.dexdrip.models.BgReading;
 import com.eveningoutpost.dexdrip.models.Calibration;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError;
+import com.eveningoutpost.dexdrip.models.Treatments;
 import com.eveningoutpost.dexdrip.dagger.Injectors;
 import com.eveningoutpost.dexdrip.ui.MicroStatus;
 
@@ -82,7 +83,8 @@ public class WebServicePebble extends BaseWebService {
             }
 
             bgs.put("battery", microStatus.gs("bestBridgeBattery"));
-            bgs.put("iob", 0); // TODO get iob
+            Double iob = Treatments.getCurrentIoB();
+            bgs.put("iob", (iob == null) ? "unknown" : String.format("%.02f", iob));
             // TODO output bwp and bwpo
 
             status_array.put(status);


### PR DESCRIPTION
This PR implements IoB value reporting in the /pebble endpoint. It is using existing `ioBForGraph_new` method to get a series of IoB values and then finds one close to the current timestamp.

I've also removed `number` parameter from `ioBForGraph_new`, as it was unused.

With this change watchface developers will be able to display IoB values reported by xDrip+.

Emulator based testing:

When IoB data is not available, `iob` field reports "unknown":
![Screenshot_20230618_212827_unknown_iob](https://github.com/NightscoutFoundation/xDrip/assets/14372325/550a0a83-9acd-4daf-9e3b-0b8931e7f1d4)
When IoB data is available, current value is reported:
![Screenshot_20230618_213038_iob_reported](https://github.com/NightscoutFoundation/xDrip/assets/14372325/f70fee55-417c-47f7-b10d-b4be39fd6200)

