### PR TITLE
Use decimal value separator depending on locale ("." or ",") on EditTextActivity

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -49,6 +49,7 @@ import com.eveningoutpost.dexdrip.watch.thinjam.BlueJayEntry;
 import com.eveningoutpost.dexdrip.wearintegration.WatchUpdaterService;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -214,9 +215,8 @@ public class EditAlertActivity extends ActivityWithMenu {
         doMgdl = (prefs.getString("units", "mgdl").compareTo("mgdl") == 0);
 
         if(!doMgdl) {
-            alertThreshold.setInputType(InputType.TYPE_CLASS_NUMBER);
-            alertThreshold.setInputType(InputType.TYPE_NUMBER_FLAG_DECIMAL);
-            alertThreshold.setKeyListener(DigitsKeyListener.getInstance(false,true));
+            char decimalValueSeparator = DecimalFormatSymbols.getInstance().getDecimalSeparator();
+            alertThreshold.setKeyListener(DigitsKeyListener.getInstance("0123456789" + decimalValueSeparator));
         }
 
         uuid = getExtra(savedInstanceState, "uuid", null);


### PR DESCRIPTION
When creating a new alarm and entering a decimal threshold value some European languages (Ukrainian, for example) languages use `,` for fractions. However, the xDrip keypad does not allow you to use `,`. In this case, if you enter 4.3 it'll be parsed as 4,0. To avoid that we have to use a decimal line separator depending on the current locale.

Additionally, when `alertThreshold.setKeyListener(DigitsKeyListener.getInstance("0123456789" + decimalValueSeparator)); `is applied there is no need to set input type because DigitsKeyListener.getInstance modifies that anyway.

Part of the documentation for `setKeyListener`

> Note that this method has significant and subtle interactions with soft keyboards and other input method: see KeyListener.getInputType() for important details. Calling this method will replace the current content type of the text view with the content type returned by the key listener