### PR TITLE
Remove the fallback setting

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -145,6 +145,7 @@ public class IdempotentMigrations {
     // Force legacy settings to be at their recommended values
     private static void legacySettingsFix() {
         Pref.setBoolean("use_ob1_g5_collector_service", true);
+        Pref.setBoolean("ob1_g5_fallback_to_xdrip", false);
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -2456,6 +2456,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
        private void removeLegacyPreferences() {
            //  removePreferenceFromCategory("use_ob1_g5_collector_service", "ob1_options");
+           //  removePreferenceFromCategory("ob1_g5_fallback_to_xdrip", "ob1_options");
        }
 
        private void removePreferenceFromCategory(final String preference, final String category) {

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -346,12 +346,6 @@
                     android:title="@string/title_ob1_g5_use_insufficiently_calibrated" />
                 <CheckBoxPreference
                     android:defaultValue="false"
-                    android:dependency="ob1_g5_use_transmitter_alg"
-                    android:key="ob1_g5_fallback_to_xdrip"
-                    android:summary="@string/summary_ob1_g5_fallback_to_xdrip"
-                    android:title="@string/title_ob1_g5_fallback_to_xdrip" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
                     android:key="ob1_minimize_scanning"
                     android:summary="@string/summary_ob1_minimize_scanning"
                     android:title="@string/title_ob1_minimize_scanning" />


### PR DESCRIPTION
This PR retires a setting.
The setting is Fallback to xDrip.  The setting is permanently set to false.

I am running this now in a G6 in native mode as a test.
Unfortunately, I don't have a G5 transmitter to test.

This setting, as is, can be dangerous.  Someone who uses this setting enabled could get a sudden change in readings because their glucose changes suddenly, or because there is a fallback.  How would they know the cause of the sudden change?

We should either use native mode or not.  There should be no switching back and forth on the fly.  Therefore, there should be no need to this setting.