### PR TITLE
Fix carelink login error 504

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -688,8 +688,8 @@ public class CareLinkClient {
         //Add common browser headers
         requestBuilder
                 .addHeader("Accept-Language", "en;q=0.9, *;q=0.8")
-                .addHeader("sec-ch-ua", "\"Chromium\";v=\"112\", \"Google Chrome\";v=\"112\", \"Not:A-Brand\";v=\"99\"")
-                .addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36");
+                .addHeader("sec-ch-ua", "\"Chromium\";v=\"115\", \"Google Chrome\";v=\"115\", \"Not:A-Brand\";v=\"99\"")
+                .addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36");
 
         //Set media type based on request type
         switch (type) {


### PR DESCRIPTION
xDrip carelink follow gets 504 error whereas Medtronic Carelink app and WebUI is working properly.
```
08-17 19:23:31.096 32209  5353 D OkHttp  : --> GET https://carelink.minimed.eu/patient/sso/login?country=tw&lang=en
08-17 19:23:31.097 32209  5353 D OkHttp  : Accept-Language: en;q=0.9, *;q=0.8
08-17 19:23:31.097 32209  5353 D OkHttp  : sec-ch-ua: "Chromium";v="112", "Google Chrome";v="112", "Not:A-Brand";v="99"
08-17 19:23:31.097 32209  5353 D OkHttp  : User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36
08-17 19:23:31.097 32209  5353 D OkHttp  : Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
08-17 19:23:31.097 32209  5353 D OkHttp  : Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
08-17 19:23:31.097 32209  5353 D OkHttp  : --> END GET
08-17 19:23:31.144 32209  5353 D OkHttp  : <-- 504 Gateway Time-out https://carelink.minimed.eu/patient/sso/login?country=tw&lang=en (47ms)
```