### PR TITLE
Change default setting for accept follower actions to false

### DIFF
--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -817,7 +817,7 @@
                 android:summary="@string/this_device_will_send_data_to_followers"
                 android:title="@string/be_master_for_followers" />
             <CheckBoxPreference
-                android:defaultValue="true"
+                android:defaultValue="false"
                 android:dependency="plus_follow_master"
                 android:key="plus_accept_follower_actions"
                 android:summary="@string/summary_plus_accept_follower_actions"


### PR DESCRIPTION
There are cases where an individual just wants to have someone follow their readings.  But, they want to be in charge of everything themselves.

There are also cases where someone wants the follower to be able to enter treatments.

How do we know which group is larger than the other so that we can choose the right default?

Allowing someone to stop your sensor without your knowledge is a very dangerous situation.  There are times you may want that to be the case for example if the master is a child who has not mastered using the CGM yet.

1- If you want to stop sensor on your child's phone and cannot, all you need to do is to ask him to enable this setting.

2- If you don't want your follower to be able to accidentally stop your sensor and they do, it will be too late to do anything about it as the sensor will have been stopped already and you cannot undo that.

Comparing those two scenarios, I see the safest default to be false.