### PR TITLE
Remove Load/Save Settings from the 3-dot menu

### DIFF
--- a/app/src/main/res/menu/menu_home.xml
+++ b/app/src/main/res/menu/menu_home.xml
@@ -57,14 +57,6 @@
                 android:orderInCategory="1"
                 android:onClick="exportCSVasSiDiary"
                 android:showAsAction="never"/>
-
-            <item android:id="@+id/importsettings"
-                android:title="@string/load_save_settings_on_sdcard"
-                android:checkable="false"
-                android:onClick="settingsSDcardExport"
-                android:visible="true"
-                android:orderInCategory="1"
-                android:showAsAction="never"/>
         </menu>
     </item>
 


### PR DESCRIPTION
To save or load settings, it makes sense to do it by first going to settings.
If you do that, you will see a section titled "Copying settings".
Under it, you can copy or load settings using either the QR code or creating/loading the file.

What currently exists under the 3-dot menu is redundant.
Can we please remove it to help clean up?

This is what it will look like after this PR:
![Screenshot_20230906-175335](https://github.com/NightscoutFoundation/xDrip/assets/51497406/6858e0c9-8bef-46b9-911f-be86b8bc028b)

This has been tested.