### PR TITLE
Remove setting: Unbond G5 before each read

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -146,6 +146,7 @@ public class IdempotentMigrations {
     private static void legacySettingsFix() {
         Pref.setBoolean("use_ob1_g5_collector_service", true);
         Pref.setBoolean("ob1_g5_fallback_to_xdrip", false);
+        Pref.setBoolean("always_unbond_G5", false);
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -2457,6 +2457,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
        private void removeLegacyPreferences() {
            //  removePreferenceFromCategory("use_ob1_g5_collector_service", "ob1_options");
            //  removePreferenceFromCategory("ob1_g5_fallback_to_xdrip", "ob1_options");
+           //  removePreferenceFromCategory("always_unbond_G5", "ob1_options");
        }
 
        private void removePreferenceFromCategory(final String preference, final String category) {

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -404,11 +404,6 @@
                     android:key="always_get_new_keys"
                     android:summary="@string/g5_full_authentification"
                     android:title="@string/authentificate_before_reading" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="always_unbond_G5"
-                    android:summary="@string/g5_remove_before_read"
-                    android:title="@string/unbond_g5_before_read" />
             </PreferenceCategory>
             <PreferenceCategory
                 android:key="dex_battery_category"


### PR DESCRIPTION
Is there any scenario that requires this setting to be enabled?
If not, please let's retire it.

![Screenshot_20230917-101348](https://github.com/NightscoutFoundation/xDrip/assets/51497406/d7609dcf-cfe5-4a2d-98a6-c9edf3e98ff4)

![Screenshot_20230917-101223](https://github.com/NightscoutFoundation/xDrip/assets/51497406/b9965e69-6413-4783-84cb-cd7d38fb8d24)
