### PR TITLE
Support subpath in url for Nightscout follower

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
@@ -61,10 +61,10 @@ public class NightscoutFollow {
                 "User-Agent: xDrip+ " + BuildConfig.VERSION_NAME,
         })
 
-        @GET("/api/v1/entries.json")
+        @GET("api/v1/entries.json")
         Call<List<Entry>> getEntries(@Header("api-secret") String secret, @Query("count") int count, @Query("rr") String rr);
 
-        @GET("/api/v1/treatments")
+        @GET("api/v1/treatments")
         Call<ResponseBody> getTreatments(@Header("api-secret") String secret);
     }
 


### PR DESCRIPTION
This will add support for subpaths in the Nightscout follower url.

Currently when you have a Nightscout instance running at i.e. https://domain.com/subpath/ it will strip the /subpath/ from the url which is not correct. By using relative paths for the @GET methods subpaths are working.