### PR TITLE
No update available toast message

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/UpdateActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/UpdateActivity.java
@@ -173,8 +173,8 @@ public class UpdateActivity extends BaseAppCompatActivity {
                                     }
                                 } else {
                                     Log.i(TAG, "Our current version is the most recent: " + versionnumber + " vs " + newversion);
-                                    if ((callingMethodName).equals("checkForUpdate")) {
-                                        JoH.static_toast_long(xdrip.gs(R.string.current_version_is_up_to_date)); // Only for manual update check
+                                    if (fromUi) { // Only for manual update check
+                                        JoH.static_toast_long(xdrip.gs(R.string.current_version_is_up_to_date));
                                     }
                                 }
                             } catch (Exception e) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/UpdateActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/UpdateActivity.java
@@ -80,6 +80,9 @@ public class UpdateActivity extends BaseAppCompatActivity {
     private static String CHECKSUM = "";
 
     public static void checkForAnUpdate(final Context context) {
+        StackTraceElement[] stacktrace = Thread.currentThread().getStackTrace();
+        StackTraceElement stack = stacktrace[3];
+        String callingMethodName = stack.getMethodName(); // Name of the method that has called this one
         if (prefs == null) prefs = PreferenceManager.getDefaultSharedPreferences(context);
         if ((last_check_time != -1) && (!prefs.getBoolean(AUTO_UPDATE_PREFS_NAME, true))) return;
         if (last_check_time == 0)
@@ -169,6 +172,9 @@ public class UpdateActivity extends BaseAppCompatActivity {
                                     }
                                 } else {
                                     Log.i(TAG, "Our current version is the most recent: " + versionnumber + " vs " + newversion);
+                                    if ((callingMethodName).equals("checkForUpdate")) {
+                                        JoH.static_toast_long(xdrip.gs(R.string.current_version_is_up_to_date)); // Only for manual update check
+                                    }
                                 }
                             } catch (Exception e) {
                                 Log.e(TAG, "Got exception parsing update version: " + e.toString());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,7 @@
     <string name="libre_last_x_minutes_graph">Libre last %d minutes graph</string>
     <string name="share_config_via_qr_code">Share config via QR code</string>
     <string name="check_for_updated_version">Check for updated version</string>
+    <string name="current_version_is_up_to_date">No update in the selected channel</string>
     <string name="send_feedback_to_developer">Send Feedback to developers</string>
     <string name="home_screen">Home Screen</string>
     <string name="event_logs">Event Logs</string>


### PR DESCRIPTION
If you check for updates when there is no update available, xDrip provides no information.
The following question occasionally comes up.
Does "Check for updated version" work?

This PR shows a toast message clarifying that there is no update.
![Screenshot_20230921-121759](https://github.com/NightscoutFoundation/xDrip/assets/51497406/b703d9a6-9bab-4cb1-9c6b-9e15e8cf2040)



It only does that when checking manually.
If you have enabled automatic update check, there will be no toast message everyday.