### PR TITLE
Allow to start even if the number of days is -1 for a mod TX

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
@@ -104,7 +104,7 @@ public class StartNewSensor extends ActivityWithMenu {
 
         ucalendar = Calendar.getInstance();
         if (Ob1G5CollectionService.usingNativeMode()) {
-            if (!DexSyncKeeper.isReady(Pref.getString("dex_txid", "NULL")) || transmitterAgeInDays() == -1) {
+            if (!DexSyncKeeper.isReady(Pref.getString("dex_txid", "NULL")) || (transmitterAgeInDays() == -1 && !FirmwareCapability.isTransmitterModified(getTransmitterID()))) {
                 JoH.static_toast_long("Need to connect to transmitter before we can start sensor");
                 UserError.Log.e(TAG, "Need to connect to transmitter before we can start sensor");
                 MegaStatus.startStatus(MegaStatus.G5_STATUS);


### PR DESCRIPTION
This will bypass the check for transmitter days for starting a sensor for mod transmitters.