### PR TITLE
Selective activation time update

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexTimeKeeper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexTimeKeeper.java
@@ -52,8 +52,12 @@ public class DexTimeKeeper {
             return;
         }
 
-        UserError.Log.d(TAG, "Activation time updated to: " + JoH.dateTimeText(activation_time));
-        PersistentStore.setLong(DEX_XMIT_START + transmitterId, activation_time);
+        if (FirmwareCapability.isTransmitterModified(getTransmitterID()) && activation_time < OLDEST_ALLOWED) {
+            UserError.Log.d(TAG, "Activation time would have been updated to: " + JoH.dateTimeText(activation_time));
+        } else { // Update the activation time in the persistent store only if it is not years in the past or if we are not using a modified transmitter.
+            UserError.Log.d(TAG, "Activation time updated to: " + JoH.dateTimeText(activation_time));
+            PersistentStore.setLong(DEX_XMIT_START + transmitterId, activation_time);
+        }
 
     }
 


### PR DESCRIPTION
After a hard reset of a mod transmitter, the read time stamp becomes a very large value.  I am not sure.  But, this could be because of a format mismanagement of a negative number, turning a very small negative value into a very large positive value (6214 days or 17 years)!

The activation time calculated from that goes back to 2006.  When this is written into the persistent store, resulting transmitter days value becomes invalid (unknown).

This PR avoids writing into the persistent store an activation time that is so far back in the past.

Tests show that the lock situation reported by users (https://github.com/NightscoutFoundation/xDrip/discussions/3078) does not happen any longer after this PR.