### PR TITLE
Block incorrect raw timestamp

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -130,6 +130,7 @@ public class Ob1G5StateMachine {
     private static volatile BgReading lastGlucoseBgReading;
     private static volatile AuthRequestTxMessage lastAuthPacket;
     private static volatile boolean backup_loaded = false;
+    private static final int OLDEST_RAW = 300 * 24 * 60 * 60; // 300 days
 
     // Auth Check + Request
     @SuppressLint("CheckResult")
@@ -1609,7 +1610,11 @@ public class Ob1G5StateMachine {
         }
 
         UserError.Log.d(TAG, "SUCCESS!! unfiltered: " + sensorRx.unfiltered + " filtered: " + sensorRx.filtered + " timestamp: " + sensorRx.timestamp + " " + JoH.qs((double) sensorRx.timestamp / 86400, 1) + " days :: (" + sensorRx.status + ")");
-        DexTimeKeeper.updateAge(getTransmitterID(), sensorRx.timestamp);
+        if (FirmwareCapability.isTransmitterModified(getTransmitterID()) && sensorRx.timestamp > OLDEST_RAW) { // Raw timestamp reported by a mod TX is incorrect until after sensor start.
+            UserError.Log.d(TAG, "Will not update age since raw timestamp is incorrect.");
+        } else { // Update age, based on the raw timestamp, only if the raw timestamp is correct.
+            DexTimeKeeper.updateAge(getTransmitterID(), sensorRx.timestamp);
+        }
         Ob1G5CollectionService.setLast_transmitter_timestamp(sensorRx.timestamp);
         if (sensorRx.unfiltered == 0) {
             UserError.Log.e(TAG, "Transmitter sent raw sensor value of 0 !! This isn't good. " + JoH.hourMinuteString());


### PR DESCRIPTION
After a hard reset, the raw timestamp is incorrect until after sensor start.
With the incorrect timestamp, the corresponding activation time is incorrect resulting in the transmitter days parameter to be reported as -1.
As long as transmitter days is -1, xDrip refuses to start sensor.
This creates a catch-22 situation.

This PR does not allow an incorrect raw timestamp to be used to update the transmitter age.
Tests show that the catch-22 situation is avoided after this PR.