### PR TITLE
Fix Bluetooth connectivity problems

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -307,7 +307,7 @@ dependencies {
     }
     implementation 'com.github.jamorham:amazfitcommunication:master-SNAPSHOT'
     implementation 'io.reactivex:rxjava:1.3.3'
-    implementation "com.polidea.rxandroidble2:rxandroidble:1.12.1"
+    implementation "com.polidea.rxandroidble2:rxandroidble:1.17.2"
     implementation 'com.google.guava:guava:24.1-android'
     implementation 'com.embarkmobile:zxing-android-minimal:2.0.0@aar'
     implementation 'com.embarkmobile:zxing-android-integration:2.0.0@aar'

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -631,6 +631,8 @@
     <string name="bluetooth_watchdog">Bluetooth Watchdog</string>
     <string name="reset_bluetooth_g5">Reset Bluetooth by turning it off and on as a way to keep the G5 data source working. Without this the G5 collector may fail.</string>
     <string name="g5_bluetooth_watchdog">Dex Bluetooth Watchdog</string>
+    <string name="aggressive_bluetooth_restart">Aggressive Bluetooth restart</string>
+    <string name="aggressive_bluetooth_restart_description">Restart Bluetooth once certain connection errors occur. Enable only if you experience recurring Bluetooth connectivity problems.</string>
     <string name="close_gatt">If the Bluetooth watchdog activates often then you can try unchecking this option to see if it helps</string>
     <string name="older_bluetooth_wakelocks">Older Bluetooth wakelocks which can drain extra battery but might be needed for Bluetooth reception</string>
     <string name="reset_bluetooth_on_off">Reset Bluetooth by turning it off and on every few minutes! Only select if you are testing. It may disrupt anything else using Bluetooth.</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1289,6 +1289,12 @@
                     android:summary="@string/bluetooth_watchdog_timer_sums"
                     android:title="@string/bluetooth_watchdog_timers" />
                 <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:dependency="bluetooth_watchdog"
+                    android:key="aggressive_bluetooth_restart"
+                    android:summary="@string/aggressive_bluetooth_restart_description"
+                    android:title="@string/aggressive_bluetooth_restart" />
+                <CheckBoxPreference
                     android:defaultValue="true"
                     android:key="g5_bluetooth_watchdog"
                     android:summary="@string/reset_bluetooth_g5"


### PR DESCRIPTION
Remove use_auto_connect as it's value never changes.
Reset always_scan after successful connection or manual collector restart.
Restart bluetooth once BleDisconnectedException with status 133 is caught.
Restart bluetooth more frequently on CONNECT_NOW failures.
Add aggressive_bluetooth_restart advanced setting.

Related discussion here: https://github.com/NightscoutFoundation/xDrip/discussions/3165