### PR TITLE
Nightscout follower delay option

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -147,7 +147,7 @@ public class NightscoutFollowService extends ForegroundService {
      */
     public static List<StatusItem> megaStatus() {
         final BgReading lastBg = BgReading.lastNoSenssor();
-        final long lag = Constants.SECOND_IN_MS * Integer.valueOf(Pref.getString("nsfollow_lag", "0")); // Wake delay selected by user
+        final long lag = Constants.SECOND_IN_MS * Pref.getStringToInt("nsfollow_lag", 0); // Wake delay selected by user
 
         String lastPollText = "n/a";
         if (lastPoll > 0) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -13,6 +13,7 @@ import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.Inevitable;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utilitymodels.StatusItem;
 import com.eveningoutpost.dexdrip.utilitymodels.StatusItem.Highlight;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.utils.Anticipate;
@@ -146,6 +147,7 @@ public class NightscoutFollowService extends ForegroundService {
      */
     public static List<StatusItem> megaStatus() {
         final BgReading lastBg = BgReading.lastNoSenssor();
+        final long lag = Constants.SECOND_IN_MS * Integer.valueOf(Pref.getString("nsfollow_lag", "0")); // Wake delay selected by user
 
         String lastPollText = "n/a";
         if (lastPoll > 0) {
@@ -159,10 +161,10 @@ public class NightscoutFollowService extends ForegroundService {
         Highlight ageOfLastBgPollHighlight = Highlight.NORMAL;
         if (bgReceiveDelay > 0) {
             ageOfBgLastPoll = JoH.niceTimeScalar(bgReceiveDelay);
-            if (bgReceiveDelay > SAMPLE_PERIOD / 2) {
+            if (bgReceiveDelay - lag > SAMPLE_PERIOD / 2) {
                 ageOfLastBgPollHighlight = Highlight.BAD;
             }
-            if (bgReceiveDelay > SAMPLE_PERIOD * 2) {
+            if (bgReceiveDelay - lag > SAMPLE_PERIOD * 2) {
                 ageOfLastBgPollHighlight = Highlight.CRITICAL;
             }
         }
@@ -173,7 +175,7 @@ public class NightscoutFollowService extends ForegroundService {
         if (lastBg != null) {
             long age = JoH.msSince(lastBg.timestamp);
             ageLastBg = JoH.niceTimeScalar(age);
-            if (age > SAMPLE_PERIOD + hightlightGrace) {
+            if (age > SAMPLE_PERIOD + hightlightGrace + lag) {
                 bgAgeHighlight = Highlight.BAD;
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/utils/Anticipate.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/utils/Anticipate.java
@@ -21,7 +21,7 @@ public class Anticipate {
      */
 
     public static long next(long now, final long lastTimeStamp, final long period, final long grace) {
-        final long lag = Constants.SECOND_IN_MS * Integer.valueOf(Pref.getString("nsfollow_lag", "0")); // User can choose a wake delay with a 0 default.
+        final long lag = Constants.SECOND_IN_MS * Pref.getStringToInt("nsfollow_lag", 0); // User can choose a wake delay with a 0 default.
         final long last = lastTimeStamp + lag; // We delay the source timestamp and use it as the time we received the reading to account for any source delay.
 
         final long since = now - last;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/utils/Anticipate.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/utils/Anticipate.java
@@ -1,5 +1,8 @@
 package com.eveningoutpost.dexdrip.cgm.nsfollow.utils;
 
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+
 /**
  * Choose optimum anticipation times for re-attempting data collection to minimize
  * number of requests to nightscout but at the same time reduce latency from new
@@ -16,7 +19,10 @@ public class Anticipate {
      * If last + period and a bit < now, ask again after grace
      * If last + period and a bit >= now, ask again after last + period and grace
      */
-    public static long next(long now, final long last, final long period, final long grace) {
+
+    public static long next(long now, final long lastTimeStamp, final long period, final long grace) {
+        final long lag = Constants.SECOND_IN_MS * Integer.valueOf(Pref.getString("nsfollow_lag", "0")); // User can choose a wake delay with a 0 default.
+        final long last = lastTimeStamp + lag; // We delay the source timestamp and use it as the time we received the reading to account for any source delay.
 
         final long since = now - last;
         if (since <= (grace * 2)) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1257,6 +1257,8 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             final Preference nsFollowDownload = findPreference("nsfollow_download_treatments");
             final Preference nsFollowUrl = findPreference("nsfollow_url");
+            final Preference nsFollowLag = findPreference("nsfollow_lag"); // Show the Nightscout follow wake delay setting only when NS follow is the data source
+            bindPreferenceSummaryToValue(findPreference("nsfollow_lag")); // Show the selected value as summary
             try {
                 nsFollowUrl.setOnPreferenceChangeListener((preference, newValue) -> {
                     NightscoutFollow.resetInstance();
@@ -1721,6 +1723,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 try {
                     collectionCategory.removePreference(nsFollowUrl);
                     collectionCategory.removePreference(nsFollowDownload);
+                    collectionCategory.removePreference(nsFollowLag);
                 } catch (Exception e) {
                     //
                 }
@@ -2417,6 +2420,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     if (collectionType == DexCollectionType.NSFollow) {
                         collectionCategory.addPreference(nsFollowUrl);
                         collectionCategory.addPreference(nsFollowDownload);
+                        collectionCategory.addPreference(nsFollowLag);
                     }
 
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -531,15 +531,17 @@
             The default is no delay, and is marked with the single symbol >  -->
     <string-array name="nsfollowlag_entries">
         <item>0 ></item>
-        <item>30 s</item>
+        <item>40 s</item>
         <item>1 min</item>
+        <item>1.5 min</item>
         <item>2 min</item>
         <item>3 min</item>
     </string-array>
     <string-array name="nsfollowlag_values">
         <item>0</item>
-        <item>30</item>
+        <item>40</item>
         <item>60</item>
+        <item>90</item>
         <item>120</item>
         <item>180</item>
     </string-array>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -527,4 +527,21 @@
         <item>400</item>
     </string-array>
 
+    <!--    Nightscout follow wake delay, with respect to the source timestamp
+            The default is no delay, and is marked with the single symbol >  -->
+    <string-array name="nsfollowlag_entries">
+        <item>0 ></item>
+        <item>30 s</item>
+        <item>1 min</item>
+        <item>2 min</item>
+        <item>3 min</item>
+    </string-array>
+    <string-array name="nsfollowlag_values">
+        <item>0</item>
+        <item>30</item>
+        <item>60</item>
+        <item>120</item>
+        <item>180</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1337,6 +1337,7 @@
     <string name="title_nsfollow_url">Nightscout Follow URL</string>
     <string name="summary_nsfollow_download_treatments">Also download treatments from Nightscout as follower</string>
     <string name="title_nsfollow_download_treatments">Download Treatments</string>
+    <string name="title_nsfollow_lag">Nightscout Follow delay</string>
     <!-- Maybe we can use them later?
     <string name="title_clfollow_user">CareLink Username</string>
     <string name="summary_clfollow_user">CareLink login username</string>

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -196,7 +196,14 @@
             android:defaultValue="false"
             android:key="nsfollow_download_treatments"
             android:summary="@string/summary_nsfollow_download_treatments"
-            android:title="@string/title_nsfollow_download_treatments"
+            android:title="@string/title_nsfollow_download_treatments" />
+        <ListPreference
+            android:defaultValue="0"
+            android:key="nsfollow_lag"
+            android:summary=""
+            android:title="@string/title_nsfollow_lag"
+            android:entries="@array/nsfollowlag_entries"
+            android:entryValues="@array/nsfollowlag_values"
             />
 
         <EditTextPreference


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/929

**What is the problem?**  
xDrip, when set as Nightscout follower, looks at the timestamp of a reading to decide when to perform the next reading.  The problem is that the timestamp is created by the first element in the master path.  But, there may be other elements in the path before the reading is uploaded to Nightscout.  As a result, when Nightscout receives the reading may be after the reading's timestamp.

Now, consider what xDrip follower does.  It performs a reading 5 minutes after the timestamp of the previous reading.  If it fails to bring in a new reading, it performs one last attempt with a very short delay.  If the second attempt also fails, xDrip goes back to sleep and will not attempt to read for another cycle (5 minutes).  
There will be no problem if the delay in the master path is less than 20 seconds.  But, if it is more, xDrip brings in new readings with a 10-minute delay.

**What does this PR do?**
It does not reduce the delay (with respect to the master timestamp) from 10 minutes to 5 minutes.  But, it reduces it.  How much it can reduce it depends on the amount of delay in the master path.

**New setting**  
There is a new setting, titled Nightscout Follow delay, only visible when hardware data source is set to Nightsocut Follower.
![Screenshot_20231109-201147](https://github.com/NightscoutFoundation/xDrip/assets/51497406/55966163-4d08-402f-aef1-5ed2fe404c24)  
  
Tapping on the new setting, takes you to a page, where you can choose a wake delay.  
![Screenshot_20231114-212559](https://github.com/NightscoutFoundation/xDrip/assets/51497406/1da9ae25-50c0-486b-aeae-dd590e75c60c)

  
The default value of the wake delay is 0.  At default, the xDrip behavior remains as is.
But, if you choose any of the non-zero values, you will be delaying when xDrip attempts to read from Nightscout by the chosen value with respect to the reading time stamp.  
  
I have included delay values up to 3 minutes.  This is not because I think a delay on the source side greater than 3 minutes does not need a solution.  But, rather because I am not sure if such a delay would ever occur.  I mean what could cause such a long delay?
If such a long delay is a possibility, we should include larger delay options.


<br/>  

**What setting value should be chosen**  
The smallest setting value that solves the problem should be selected.   

<br/>  

**Test setup**  
I have a first Nightscout site that I upload to from a virtual machine with a fake data source.
In order to recreate the problem that this PR addresses and allow testing it, I use a phone with a custom version of xDrip on it as a follower of my first Nightscout.  The customized xDrip lets me delay when it reads from Nightscout.  This custom xDrip uploads to a second Nightscout site.
As I delay reading from the first Nightsocut, I effectively delay the upload to the second Nightscout.
I then use a second phone with xDrip as a follower of the second Nightscout.  
This allows me to see how xDrip behaves as a Nightcsosut follower with different master delays by just delaying the custom xDrip setting.
<br/>  
  

**Test1**
I have set up two phones as followers of the same test setup simultaneously, with the master delay set to 1 minute.  I have created a video of the two phones.
The phone shown on the left runs the Nightly release of xDrip (https://github.com/NightscoutFoundation/xDrip/releases/tag/2023.11.07).  
The phone on the right runs the same with the addition of this PR.  The Nightscout follow wake delay is set to 1 minute for the phone on the right running this PR.
I have sped up the video by a factor of 30.  

https://github.com/NightscoutFoundation/xDrip/assets/51497406/1f9615c1-f1ed-45d9-83ae-2a1eb8023721


  
**Test2**  
This is the same as Test1 except the master delay is set to 3 minutes and the wake delay, on the phone with this PR shown on the right in the sped-up video, is set to 3 minutes.

https://github.com/NightscoutFoundation/xDrip/assets/51497406/80eec6bb-6095-400a-a70a-a7d595231e9f

<br/>  
  
---  
    
**How would I know what setting to use?**
Let's find that out with an example.
I have set the custom xDrip in my test setup to 75 second.  

Choose the default setting of 0.  Let it run for 15 minutes.  
Now, look at the Nightscout Follow status page.
If you see red items (BG receive delay) on the status page, as shown below, it means that the master path delay is greater than 20 seconds, and you should choose a greater delay setting.  
![Screenshot_20231114-225217](https://github.com/NightscoutFoundation/xDrip/assets/51497406/3aab9a17-3273-4f22-9590-e7d03bf96e59)

So, let's increase the delay setting to 40s.  Let it run for 15 minutes.  And then, check the status page again.  
If you see red items again, it means that the delay in the master path is greater than 40 + 20 seconds also.  

Let's increase the delay to the next available value of 1 minute.  Let it run for 15 minutes.  Then, check the status page.
If you see a clear status page, it means you have found the correct setting.
![Screenshot_20231115-002001](https://github.com/NightscoutFoundation/xDrip/assets/51497406/f04123cf-ffa3-4bb0-96b2-cc717b04db42)
  
You should always choose the smallest delay that results in the status page consistently being clear.  So, in this case, the best setting is 1 minute.