### PR TITLE
Remove setting Authenticate before each read

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -147,7 +147,7 @@ public class IdempotentMigrations {
         Pref.setBoolean("use_ob1_g5_collector_service", true);
         Pref.setBoolean("ob1_g5_fallback_to_xdrip", false);
         Pref.setBoolean("always_unbond_G5", false);
-        Pref.setBoolean("authentificate_before_reading", true);
+        Pref.setBoolean("always_get_new_keys", true);
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -147,6 +147,7 @@ public class IdempotentMigrations {
         Pref.setBoolean("use_ob1_g5_collector_service", true);
         Pref.setBoolean("ob1_g5_fallback_to_xdrip", false);
         Pref.setBoolean("always_unbond_G5", false);
+        Pref.setBoolean("authentificate_before_reading", true);
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -2493,7 +2493,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
            //  removePreferenceFromCategory("use_ob1_g5_collector_service", "ob1_options");
            //  removePreferenceFromCategory("ob1_g5_fallback_to_xdrip", "ob1_options");
            //  removePreferenceFromCategory("always_unbond_G5", "ob1_options");
-           //  removePreferenceFromCategory("authentificate_before_reading", "ob1_options");
+           //  removePreferenceFromCategory("always_get_new_keys", "ob1_options");
        }
 
        private void removePreferenceFromCategory(final String preference, final String category) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -2493,6 +2493,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
            //  removePreferenceFromCategory("use_ob1_g5_collector_service", "ob1_options");
            //  removePreferenceFromCategory("ob1_g5_fallback_to_xdrip", "ob1_options");
            //  removePreferenceFromCategory("always_unbond_G5", "ob1_options");
+           //  removePreferenceFromCategory("authentificate_before_reading", "ob1_options");
        }
 
        private void removePreferenceFromCategory(final String preference, final String category) {

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -406,11 +406,6 @@
                     android:key="run_G5_ble_tasks_on_uithread"
                     android:summary="@string/g5_force_ui_thread"
                     android:title="@string/force_g5_ui_thread" />
-                <CheckBoxPreference
-                    android:defaultValue="true"
-                    android:key="always_get_new_keys"
-                    android:summary="@string/g5_full_authentification"
-                    android:title="@string/authentificate_before_reading" />
             </PreferenceCategory>
             <PreferenceCategory
                 android:key="dex_battery_category"


### PR DESCRIPTION
This PR permanently enables the setting "Authenticate before each read" on the G5/G6/Dex1 Debug Settings page, and removes the setting.  
There are individuals who disable it and wonder why they have trouble.

This image shows what the settings page looks after:
![Screenshot_20231113-142044](https://github.com/NightscoutFoundation/xDrip/assets/51497406/c512b305-3a7a-48e5-a734-63e0547ab704)

Selecting different Libre options, the logs show the exception the same as selecting G6.
![Screenshot_20231113-141719](https://github.com/NightscoutFoundation/xDrip/assets/51497406/41c6b0a6-b1dd-4f13-bb77-6340df4afd98)
