### PR TITLE
Don't offer initial calibration for G7

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
@@ -90,7 +90,7 @@ public class NavDrawerBuilder {
                             }
                         } else { //If there haven't been two initial calibrations
                             if (BgReading.isDataSuitableForDoubleCalibration() || Ob1G5CollectionService.isG5WantingInitialCalibration()) {
-                                if (FirmwareCapability.isTransmitterRawIncapable(getTransmitterID()) && last_two_bgReadings.size() > 1) { //A Firefly G6 after third reading
+                                if ((FirmwareCapability.isTransmitterRawIncapable(getTransmitterID()) && last_two_bgReadings.size() > 1) || FirmwareCapability.isDeviceG7(getTransmitterID()) ) { //A Firefly G6 after third reading
                                     this.nav_drawer_options.add(context.getString(R.string.add_calibration));
                                     this.nav_drawer_intents.add(new Intent(context, AddCalibration.class));
                                 } else { //G5 or non-Firefly G6 or Firefly G6 in no-code mode, after warm-up before initial calibration

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
@@ -90,7 +90,7 @@ public class NavDrawerBuilder {
                             }
                         } else { //If there haven't been two initial calibrations
                             if (BgReading.isDataSuitableForDoubleCalibration() || Ob1G5CollectionService.isG5WantingInitialCalibration()) {
-                                if ((FirmwareCapability.isTransmitterRawIncapable(getTransmitterID()) && last_two_bgReadings.size() > 1) || FirmwareCapability.isDeviceG7(getTransmitterID()) ) { //A Firefly G6 after third reading
+                                if ((FirmwareCapability.isTransmitterRawIncapable(getTransmitterID()) && last_two_bgReadings.size() > 1) || FirmwareCapability.isDeviceG7(getTransmitterID()) ) { //A Firefly G6 after third reading or a G7
                                     this.nav_drawer_options.add(context.getString(R.string.add_calibration));
                                     this.nav_drawer_intents.add(new Intent(context, AddCalibration.class));
                                 } else { //G5 or non-Firefly G6 or Firefly G6 in no-code mode, after warm-up before initial calibration

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/FirmwareCapability.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/FirmwareCapability.java
@@ -79,6 +79,10 @@ public class FirmwareCapability {
         return isFirmwareRawCapable(version); // hang off this for now as they are currently the same
     }
 
+    static boolean isG7Firmware(final String version) {
+        return KNOWN_ALT_FIRMWARES.contains(version);
+    }
+
     public static boolean isTransmitterPredictiveCapable(final String tx_id) {
         return isG6Firmware(getRawFirmwareVersionString(tx_id));
     }
@@ -96,6 +100,10 @@ public class FirmwareCapability {
             return true;
         }
         return false;
+    }
+
+    public static boolean isDeviceG7(final String tx_id) {
+        return isG7Firmware(getRawFirmwareVersionString(tx_id));
     }
 
     public static boolean isTransmitterG5(final String tx_id) {


### PR DESCRIPTION
After starting a G7, and after readings start, for a reading or 3, you will see an option for initial calibration.  
![Screenshot_20231117-095600](https://github.com/NightscoutFoundation/xDrip/assets/51497406/ceceb99c-d13d-409c-8874-8422bd8114be)

This should not happen.  
<br/>  

When we use a G6 in no-code mode, we do need to have the option to enter initial calibrations.  

This PR adds the logic to identify a G7 and not offer initial calibration ever.  
<br/>  

**Tested?**
No!

This will be tested in 10 days.