### PR TITLE
Update G7 warmup and lifetime

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/FirmwareCapability.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/FirmwareCapability.java
@@ -79,6 +79,10 @@ public class FirmwareCapability {
         return isFirmwareRawCapable(version); // hang off this for now as they are currently the same
     }
 
+    static boolean isG7Firmware(final String version) {
+        return KNOWN_ALT_FIRMWARES.contains(version);
+    }
+
     public static boolean isTransmitterPredictiveCapable(final String tx_id) {
         return isG6Firmware(getRawFirmwareVersionString(tx_id));
     }
@@ -96,6 +100,10 @@ public class FirmwareCapability {
             return true;
         }
         return false;
+    }
+
+    public static boolean isDeviceG7(final String tx_id) {
+        return isG7Firmware(getRawFirmwareVersionString(tx_id));
     }
 
     public static boolean isTransmitterG5(final String tx_id) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
@@ -5,6 +5,7 @@ import android.text.SpannableString;
 
 import com.eveningoutpost.dexdrip.models.Sensor;
 import com.eveningoutpost.dexdrip.R;
+import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utilitymodels.StatusItem.Highlight;
@@ -100,6 +101,11 @@ public class SensorDays {
                 ths.warmupMs = Math.min(Constants.SECOND_IN_MS * vr3.warmupSeconds, 2 * HOUR_IN_MS);
             } else {
                ths.warmupMs = 2 * HOUR_IN_MS;
+            }
+
+            if (FirmwareCapability.isDeviceG7(getTransmitterID())) { // If using a G7
+                ths.period = DAY_IN_MS * 10 + HOUR_IN_MS * 12; // The device lasts 10.5 days.
+                ths.warmupMs = 30 * MINUTE_IN_MS; // The warmup time is 30 minutes.
             }
 
         } else {


### PR DESCRIPTION
When starting a G7, the warmup time shows as 2 hours.  When, the correct value is 30 minutes.
And the device is shown to expire in 10 days.  But, in fact, it will expire in 10.5 days.

This PR updates both of those.

The expiry has been verified already.
The warmup will be tested in 10 days.