### PR TITLE
No stop sensor for G7

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
@@ -101,8 +101,10 @@ public class NavDrawerBuilder {
                         }
                     }
                 }
-                this.nav_drawer_options.add(context.getString(R.string.stop_sensor));
-                this.nav_drawer_intents.add(new Intent(context, StopSensor.class));
+                if (!FirmwareCapability.isDeviceG7(getTransmitterID())) { // Offer a stop sensor option only if this is not a G7.
+                    this.nav_drawer_options.add(context.getString(R.string.stop_sensor));
+                    this.nav_drawer_intents.add(new Intent(context, StopSensor.class));
+                }
             } else {
                 this.nav_drawer_options.add(context.getString(R.string.start_sensor));
                 this.nav_drawer_intents.add(new Intent(context, StartNewSensor.class));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/FirmwareCapability.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/FirmwareCapability.java
@@ -79,6 +79,10 @@ public class FirmwareCapability {
         return isFirmwareRawCapable(version); // hang off this for now as they are currently the same
     }
 
+    static boolean isG7Firmware(final String version) {
+        return KNOWN_ALT_FIRMWARES.contains(version);
+    }
+
     public static boolean isTransmitterPredictiveCapable(final String tx_id) {
         return isG6Firmware(getRawFirmwareVersionString(tx_id));
     }
@@ -96,6 +100,10 @@ public class FirmwareCapability {
             return true;
         }
         return false;
+    }
+
+    public static boolean isDeviceG7(final String tx_id) {
+        return isG7Firmware(getRawFirmwareVersionString(tx_id));
     }
 
     public static boolean isTransmitterG5(final String tx_id) {


### PR DESCRIPTION
There is no circumstance under which anyone would need to stop a G7 session in progress.

If you disagree, please explain.  Why would anyone ever need to stop a G7 session?

Otherwise, please let's remove the (redundant) option.