### PR TITLE
Allow history to show all readings even for 1 reading per minute

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
@@ -50,6 +50,8 @@ public class BGHistory extends ActivityWithMenu {
     private int noDays = 1;
     private SharedPreferences prefs;
     private TextView statisticsTextView;
+    private static final int SAMPLE_PERIOD = 1; // In minutes - The time between two consecutive readings - The lowest period we currently support: 1 minute
+    private static final int GRACE_READINGS_PER_DAY = 2; // When switching from one source to another, there may be a misalignment in sample timing resulting in more readings per day
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -148,7 +150,7 @@ public class BGHistory extends ActivityWithMenu {
 
         Calendar endDate = (GregorianCalendar) date1.clone();
         endDate.add(Calendar.DATE, noDays);
-        int numValues = noDays * (60 / 2) * 24; // LimiTTer sample rate 1 per 2 minutes
+        int numValues = noDays * (24 * (60 / SAMPLE_PERIOD) + GRACE_READINGS_PER_DAY); // The highest sample rate we currently support
         BgGraphBuilder bgGraphBuilder = new BgGraphBuilder(this, date1.getTimeInMillis(), endDate.getTimeInMillis(), numValues, false);
 
         chart = (LineChartView) findViewById(R.id.chart);


### PR DESCRIPTION
To recreate the problem reported here, https://github.com/NightscoutFoundation/xDrip/discussions/3190, I created a test version in which, I increased the period to 10 minutes (1 reading per 10 minutes rate).
Then, history I had generated with a 5 minute period (1 reading per 5 minutes), was shown only covering half a day everyday.

This PR increases the max rate to 1 reading per minute for history.

Fixes: https://github.com/NightscoutFoundation/xDrip/discussions/3190