### PR TITLE
Add a 12-hour notification to sensor expiry

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
@@ -27,7 +27,8 @@ public class SensorExpiry extends BaseAlert {
     private static final long[] THRESHOLDS = {
             // need to be in ascending order so first hit is first applicable to avoid multiple triggers
             Constants.HOUR_IN_MS * 2,
-            Constants.HOUR_IN_MS * 9,
+            Constants.HOUR_IN_MS * 6,
+            Constants.HOUR_IN_MS * 12,
             Constants.HOUR_IN_MS * 24,
     };
 


### PR DESCRIPTION
12 hours has a significance for G7.
It's useful for someone who likes to start their sensor about the same time every 12 hours considering that the sensor runtime is 10 days + 12 hours.

After adding 12 hours, a 9-hour option seems not the best option.  So, I moved it to 6 hours.