### PR TITLE
No G7 hard reset

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexTimeKeeper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexTimeKeeper.java
@@ -36,9 +36,9 @@ public class DexTimeKeeper {
         if (dexTimeStamp < 1) {
             UserError.Log.e(TAG, "Invalid dex timestamp in updateAge: " + dexTimeStamp);
             if (dexTimeStamp == 0 && absolute) {
-                if (FirmwareCapability.isTransmitterStandardFirefly(getTransmitterID())) { // Firefly, which cannot be hard reset
-                    UserError.Log.e(TAG, "Your transmitter clock has stopped or never started.");
-                } else {
+                if (FirmwareCapability.isTransmitterG5(getTransmitterID()) || FirmwareCapability.isTransmitterTimeTravelCapable(getTransmitterID()) || FirmwareCapability.isTransmitterModified(getTransmitterID())) { // Devices that can be hard reset only
+                    DexResetHelper.offer("Your transmitter clock has stopped or never started. Do you want to hard reset it?");
+                } else { // Everything else - future devices will be gere.  If a future device can be hard reset, they should be added to the true (other) side
                     DexResetHelper.offer("Your transmitter clock has stopped or never started. Do you want to hard reset it?");
                 }
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexTimeKeeper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexTimeKeeper.java
@@ -39,7 +39,7 @@ public class DexTimeKeeper {
                 if (FirmwareCapability.isTransmitterG5(getTransmitterID()) || FirmwareCapability.isTransmitterTimeTravelCapable(getTransmitterID()) || FirmwareCapability.isTransmitterModified(getTransmitterID())) { // Devices that can be hard reset only
                     DexResetHelper.offer("Your transmitter clock has stopped or never started. Do you want to hard reset it?");
                 } else { // Everything else - future devices will be here.  If a future device can be hard reset, they should be added to the true (other) side.
-                    DexResetHelper.offer("Your transmitter clock has stopped or never started. Do you want to hard reset it?");
+                    UserError.Log.e(TAG, "Your transmitter clock has stopped or never started.");
                 }
             }
             return;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexTimeKeeper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexTimeKeeper.java
@@ -38,7 +38,7 @@ public class DexTimeKeeper {
             if (dexTimeStamp == 0 && absolute) {
                 if (FirmwareCapability.isTransmitterG5(getTransmitterID()) || FirmwareCapability.isTransmitterTimeTravelCapable(getTransmitterID()) || FirmwareCapability.isTransmitterModified(getTransmitterID())) { // Devices that can be hard reset only
                     DexResetHelper.offer("Your transmitter clock has stopped or never started. Do you want to hard reset it?");
-                } else { // Everything else - future devices will be gere.  If a future device can be hard reset, they should be added to the true (other) side
+                } else { // Everything else - future devices will be here.  If a future device can be hard reset, they should be added to the true (other) side.
                     DexResetHelper.offer("Your transmitter clock has stopped or never started. Do you want to hard reset it?");
                 }
             }


### PR DESCRIPTION
My PR (https://github.com/NightscoutFoundation/xDrip/pull/3113) 2 months ago improved the logic.
But, it was not future-proof.
Now, with G7 added, it may offer to hard reset a G7.

This PR changes the logic from negative to positive.  There are two outcomes:
1- G7 will not be offered a hard reset.  
2- In the future, any new devices added, by default will not be offered a hard reset.

Of course if we add a new device in the future that can be hard reset, we will still need to change this to make it complete.  But, there is no way to predict the future.  However, I would say it is more likely that future devices will not be hard reset capable.