### PR TITLE
Incorrect G7 note to start sensor

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2621,7 +2621,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         if (!isSensorActive) {
             // Define a variable (notConnectedToG6Yet) that is only true if Native G6 is chosen, but, transmitter days is unknown.
             boolean notConnectedToG6Yet = DexCollectionType.getDexCollectionType() == DexcomG5 && Pref.getBooleanDefaultFalse("ob1_g5_use_transmitter_alg") && Pref.getBooleanDefaultFalse("using_g6") && DexTimeKeeper.getTransmitterAgeInDays(getTransmitterID()) == -1;
-            if (notConnectedToG6Yet) { // Only if G6 has been selected and transmitter days is unknown.
+            if (notConnectedToG6Yet || getTransmitterID().length() < 6) { // Only if G6 has been selected and transmitter days is unknown, or if G7 has been selected.
                 notificationText.setText(R.string.wait_to_connect);
             } else { // Only if G6 is not selected or G6 transmitter days is known.
                 notificationText.setText(R.string.now_start_your_sensor);


### PR DESCRIPTION
Right after first connectivity to a G7 device after transmitter days becomes known, xDrip shows the following note before full connectivity has been established:

*Now start your sensor or check Settings*

If xDrip knows transmitter days for a G7, it means that the sensor has already started.  There is never a need to start a G7 sensor except for troubleshooting if xDrip fails to automatically start.
Under normal circumstances, you never need to tap on start sensor for a G7.

This PR continues to show the following note instead until full connectivity after which warmup period is shown.

*Verify settings and wait for connectivity.*  