### PR TITLE
Broadcast start time from G7

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
@@ -2,6 +2,7 @@ package com.eveningoutpost.dexdrip.utilitymodels;
 
 import static com.eveningoutpost.dexdrip.models.JoH.dateTimeText;
 import static com.eveningoutpost.dexdrip.models.JoH.msSince;
+import static com.eveningoutpost.dexdrip.services.Ob1G5CollectionService.getTransmitterID;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
 
 import android.content.Intent;
@@ -9,6 +10,8 @@ import android.os.Bundle;
 
 import com.eveningoutpost.dexdrip.BestGlucose;
 import com.eveningoutpost.dexdrip.BuildConfig;
+import com.eveningoutpost.dexdrip.g5model.DexSessionKeeper;
+import com.eveningoutpost.dexdrip.g5model.FirmwareCapability;
 import com.eveningoutpost.dexdrip.models.BgReading;
 import com.eveningoutpost.dexdrip.models.Calibration;
 import com.eveningoutpost.dexdrip.models.JoH;
@@ -143,7 +146,11 @@ public class BroadcastGlucose {
                 }
 
                 bundle.putInt(Intents.EXTRA_SENSOR_BATTERY, BridgeBattery.getBestBridgeBattery());
-                bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, sensor.started_at);
+                if (FirmwareCapability.isDeviceG7(getTransmitterID())) { // If we are using G7 and there is connectivity and firmware is known
+                    bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, DexSessionKeeper.getStart()); // Broadcast the start time reported by G7.
+                } else { // If we are using anything other than G7, or if we still have no connectivity to G7
+                    bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, sensor.started_at); // Broadcast the start time on record by xDrip.
+                }
                 bundle.putLong(Intents.EXTRA_TIMESTAMP, bgReading.timestamp);
 
                 //raw value


### PR DESCRIPTION
**PLEASE DON'T REVIEW**
**Please review 3263 instead**
<br/>  
  
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/3250

This PR changes what is broadcasted, for sensor start time, only if a known G7 firmware is being used to the time coming from G7, which is the only time that matters as far as when the device will stop working.

I have not tested this because I cannot compile AAPS since we use a different version of gradle.

I will update if I can test.
