### PR TITLE
G7 transmitter days

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1DexTransmitterBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1DexTransmitterBattery.java
@@ -1,7 +1,12 @@
 package com.eveningoutpost.dexdrip.g5model;
 
 
+import static androidx.constraintlayout.widget.Constraints.TAG;
+
+import static com.eveningoutpost.dexdrip.g5model.Ob1G5StateMachine.shortTxId;
+
 import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.services.G5BaseService;
 import com.eveningoutpost.dexdrip.services.Ob1G5CollectionService;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
@@ -61,7 +66,7 @@ public class Ob1DexTransmitterBattery {
 
         StringBuilder b = new StringBuilder();
 
-        if (battery.runtime > -1) {
+        if (battery.runtime > -1 && !shortTxId()) { // Excluding G7
             b.append(battery.runtime);
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1DexTransmitterBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1DexTransmitterBattery.java
@@ -1,12 +1,9 @@
 package com.eveningoutpost.dexdrip.g5model;
 
 
-import static androidx.constraintlayout.widget.Constraints.TAG;
-
 import static com.eveningoutpost.dexdrip.g5model.Ob1G5StateMachine.shortTxId;
 
 import com.eveningoutpost.dexdrip.models.JoH;
-import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.services.G5BaseService;
 import com.eveningoutpost.dexdrip.services.Ob1G5CollectionService;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;


### PR DESCRIPTION
For a G7, transmitter days shows a 0 before the correct value separated by a /.

This PR removes 0/.

Before:
![Screenshot_20240107-225938](https://github.com/NightscoutFoundation/xDrip/assets/51497406/2c3ce186-ab6c-44ee-beff-c6d4fec41970)
  
After:
![Screenshot_20240107-233006](https://github.com/NightscoutFoundation/xDrip/assets/51497406/1244bde7-7dc8-41f7-a3ed-2fb54a39e664)
