### PR TITLE
Plugin Calibration: fix getting intercept

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
@@ -610,7 +610,7 @@ public class BgReading extends Model implements ShareUploadableBg {
                     Log.d(TAG, "USING CALIBRATION PLUGIN AS PRIMARY!!!");
                     if (plugin.isCalibrationSane(pcalibration)) {
                         bgReading.calculated_value = (pcalibration.slope * bgReading.age_adjusted_raw_value) + pcalibration.intercept;
-                        bgReading.filtered_calculated_value = (pcalibration.slope * bgReading.ageAdjustedFiltered()) + calibration.intercept;
+                        bgReading.filtered_calculated_value = (pcalibration.slope * bgReading.ageAdjustedFiltered()) + pcalibration.intercept;
                     } else {
                         UserError.Log.wtf(TAG, "Calibration plugin failed intercept sanity check: " + pcalibration.toS());
                         Home.toaststaticnext("Calibration plugin failed intercept sanity check");


### PR DESCRIPTION
In case of using plugin for calibrations, bgReading.filtered_calculated_value was using the plugin's slope but not the plugin's intercept.