### PR TITLE
Correct warmup time even before firmware is known

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.val;
 
 import static com.eveningoutpost.dexdrip.g5model.Ob1G5StateMachine.getFirmwareXDetails;
+import static com.eveningoutpost.dexdrip.g5model.Ob1G5StateMachine.shortTxId;
 import static com.eveningoutpost.dexdrip.models.JoH.msSince;
 import static com.eveningoutpost.dexdrip.models.JoH.roundDouble;
 import static com.eveningoutpost.dexdrip.models.JoH.tsl;
@@ -31,6 +32,7 @@ import static com.eveningoutpost.dexdrip.services.Ob1G5CollectionService.usingNa
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.DAY_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.HOUR_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.DexcomG5;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.None;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getDexCollectionType;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.hasDexcomRaw;
@@ -103,7 +105,7 @@ public class SensorDays {
                ths.warmupMs = 2 * HOUR_IN_MS;
             }
 
-            if (FirmwareCapability.isDeviceG7(getTransmitterID())) { // If using a G7
+            if (DexCollectionType.getDexCollectionType() == DexCollectionType.DexcomG5 && shortTxId()) { // If using a G7
                 ths.period = DAY_IN_MS * 10 + HOUR_IN_MS * 12; // The device lasts 10.5 days.
                 ths.warmupMs = 30 * MINUTE_IN_MS; // The warmup time is 30 minutes.
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
@@ -5,7 +5,6 @@ import android.text.SpannableString;
 
 import com.eveningoutpost.dexdrip.models.Sensor;
 import com.eveningoutpost.dexdrip.R;
-import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utilitymodels.StatusItem.Highlight;
@@ -22,7 +21,6 @@ import lombok.Getter;
 import lombok.val;
 
 import static com.eveningoutpost.dexdrip.g5model.Ob1G5StateMachine.getFirmwareXDetails;
-import static com.eveningoutpost.dexdrip.g5model.Ob1G5StateMachine.shortTxId;
 import static com.eveningoutpost.dexdrip.models.JoH.msSince;
 import static com.eveningoutpost.dexdrip.models.JoH.roundDouble;
 import static com.eveningoutpost.dexdrip.models.JoH.tsl;
@@ -32,8 +30,8 @@ import static com.eveningoutpost.dexdrip.services.Ob1G5CollectionService.usingNa
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.DAY_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.HOUR_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
-import static com.eveningoutpost.dexdrip.utils.DexCollectionType.DexcomG5;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.None;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getDexCollectionType;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.hasDexcomRaw;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.hasLibre;
@@ -105,7 +103,7 @@ public class SensorDays {
                ths.warmupMs = 2 * HOUR_IN_MS;
             }
 
-            if (DexCollectionType.getDexCollectionType() == DexCollectionType.DexcomG5 && shortTxId()) { // If using a G7
+            if (getBestCollectorHardwareName() == "G7") { // If using a G7
                 ths.period = DAY_IN_MS * 10 + HOUR_IN_MS * 12; // The device lasts 10.5 days.
                 ths.warmupMs = 30 * MINUTE_IN_MS; // The warmup time is 30 minutes.
             }


### PR DESCRIPTION
I relied on firmware, in this PR https://github.com/NightscoutFoundation/xDrip/pull/3195, to show the correct warmup time for a G7.
Today, I noticed that it still showed 2 hours for warmup right after connecting to G7.  
![Screenshot_20240126-093424](https://github.com/NightscoutFoundation/xDrip/assets/51497406/a8e7126b-40af-447a-a82b-25847ff3abf7)


After one more read cycle, it showed the correct value.
I suspect the reason is that Firmware is not known right away after connectivity.

This PR changes the condition to rely on what the user has chosen instead of relying on the firmware.

I will be testing this in 10 days.