### PR TITLE
Offer to stop a G7 in engineering mode only

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
@@ -103,7 +103,7 @@ public class NavDrawerBuilder {
                         }
                     }
                 }
-                if (getBestCollectorHardwareName() != "G7" || Pref.getBooleanDefaultFalse("engineering_mode")) { // If we are using G7, offer the stop sensor option in engineering mode only
+                if (!getBestCollectorHardwareName().equals("G7") || Pref.getBooleanDefaultFalse("engineering_mode")) { // If we are using G7, offer the stop sensor option in engineering mode only
                     this.nav_drawer_options.add(context.getString(R.string.stop_sensor));
                     this.nav_drawer_intents.add(new Intent(context, StopSensor.class));
                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
@@ -18,6 +18,7 @@ import com.eveningoutpost.dexdrip.tables.CalibrationDataTable;
 import com.eveningoutpost.dexdrip.utilitymodels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.utilitymodels.Experience;
 import com.eveningoutpost.dexdrip.stats.StatsActivity;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.utils.Preferences;
 
@@ -25,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.eveningoutpost.dexdrip.services.Ob1G5CollectionService.getTransmitterID;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
 
 /**
  * Created by Emma Black on 11/5/14.
@@ -101,8 +103,10 @@ public class NavDrawerBuilder {
                         }
                     }
                 }
-                this.nav_drawer_options.add(context.getString(R.string.stop_sensor));
-                this.nav_drawer_intents.add(new Intent(context, StopSensor.class));
+                if (getBestCollectorHardwareName() != "G7" || Pref.getBooleanDefaultFalse("engineering_mode")) { // If we are using G7, offer the stop sensor option in engineering mode only
+                    this.nav_drawer_options.add(context.getString(R.string.stop_sensor));
+                    this.nav_drawer_intents.add(new Intent(context, StopSensor.class));
+                }
             } else {
                 this.nav_drawer_options.add(context.getString(R.string.start_sensor));
                 this.nav_drawer_intents.add(new Intent(context, StartNewSensor.class));


### PR DESCRIPTION
We have already started to see posts of people asking for help who have stopped a G7.  
Under normal circumstances, there is no reason to ever stop a G7.

This PR will not show the stop option in the main menu if we are using a G7 unless engineering mode is enabled.

I have tested this with a G7 and verified that enabling engineering mode shows the stop option and disabling engineering mode removes the stop option.
I have tested it with a G6 and confirmed that the stop sensor option is available regardless of engineering mode.