### PR TITLE
Native mode logs

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -953,7 +953,7 @@ public class Ob1G5StateMachine {
 
                             switch (hex) {
                                 case "2E01":
-                                    UserError.Log.e(TAG, "Invalid settings, attempting to restore defaults");
+                                    UserError.Log.e(TAG, "Invalid settings, attempting to restore Dex defaults, Native mode, no plugin");
                                     setG6Defaults();
                                     break;
                             }
@@ -1707,11 +1707,12 @@ public class Ob1G5StateMachine {
             if (FirmwareCapability.isTransmitterG6(getTransmitterID())) {
                 if (!usingG6()) {
                     setG6Defaults();
-                    JoH.showNotification("Enabled G6", "G6 Features and default settings automatically enabled", null, Constants.G6_DEFAULTS_MESSAGE, false, true, false);
+                    JoH.showNotification("Enabled defaults", "Default settings automatically enabled", null, Constants.G6_DEFAULTS_MESSAGE, false, true, false);
                 } else if (!onlyUsingNativeMode() && !Home.get_engineering_mode()) {
                     // TODO revisit this now that there is scaling
                     setG6Defaults();
-                    JoH.showNotification("Enabled G6", "G6 Native mode enabled", null, Constants.G6_DEFAULTS_MESSAGE, false, true, false);
+                    UserError.Log.e(TAG, "Dex Native mode enabled.  For your device, non-native mode is either not possible or not recommended.");
+                    JoH.showNotification("Enabled Native", "Native mode enabled", null, Constants.G6_DEFAULTS_MESSAGE, false, true, false);
                 }
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -1711,7 +1711,7 @@ public class Ob1G5StateMachine {
                 } else if (!onlyUsingNativeMode() && !Home.get_engineering_mode()) {
                     // TODO revisit this now that there is scaling
                     setG6Defaults();
-                    UserError.Log.e(TAG, "Dex Native mode enabled.  For your device, non-native mode is either not possible or not recommended.");
+                    UserError.Log.uel(TAG, "Dex Native mode enabled.  For your device, non-native mode is either not possible or not recommended.");
                     JoH.showNotification("Enabled Native", "Native mode enabled", null, Constants.G6_DEFAULTS_MESSAGE, false, true, false);
                 }
             }


### PR DESCRIPTION
The fact that Native mode cannot be disabled for many Dexcom devices is not very well known by everyone.
I have gone over the details in my guide:
https://navid200.github.io/xDrip/docs/Native-Algorithm.html
But, not everyone reads the docs before starting to use xDrip.  
  
![Screenshot 2024-02-15 123022](https://github.com/NightscoutFoundation/xDrip/assets/51497406/aaa4c32d-ec2a-4871-a590-7361405a8f99)  
  

This PR adds a log and clarifies some existing ones to hopefully better communicate the behavior to users.