### PR TITLE
Increase max text length for AAPS statusline

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
@@ -27,7 +27,7 @@ public class ExternalStatusService extends IntentService {
     private static final String EXTRA_STATUSLINE = "com.eveningoutpost.dexdrip.Extras.Statusline";
     public static final String ACTION_NEW_EXTERNAL_STATUSLINE = "com.eveningoutpost.dexdrip.ExternalStatusline";
     //public static final String RECEIVER_PERMISSION = "com.eveningoutpost.dexdrip.permissions.RECEIVE_EXTERNAL_STATUSLINE";
-    private static final int MAX_LEN = 40;
+    private static final int MAX_LEN = 70;
     private final static String TAG = ExternalStatusService.class.getSimpleName();
 
     public ExternalStatusService() {


### PR DESCRIPTION
Solves https://github.com/NightscoutFoundation/xDrip/issues/1331

This change make sure all languages get all info through from AAPS to xDrip+ statusline without being cut short. 

Example of the longest statusline from AAPS I could produce which is 64 letters, 70 should be fine.
Uzavretý okruh deaktivovaný
0,40 u/h 0,42U(0,43|-0,00) -0,14 29g

Before:
![image](https://github.com/NightscoutFoundation/xDrip/assets/114103483/3d911956-0026-4e05-a02e-5224a5bf0a9b)

After:
![image](https://github.com/NightscoutFoundation/xDrip/assets/114103483/f72ed696-f6bf-47aa-b614-3f4a340208df)
