### PR TITLE
Remove duplicate Norwegian language and add legacy settings update to transfer to correct language

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -59,6 +59,7 @@ public class IdempotentMigrations {
         legacySettingsFix();
         IncompatibleApps.notifyAboutIncompatibleApps();
         CompatibleApps.notifyAboutCompatibleApps();
+        legacySettingsMoveLanguageFromNoToNb();
 
     }
 
@@ -149,5 +150,11 @@ public class IdempotentMigrations {
         Pref.setBoolean("always_unbond_G5", false);
         Pref.setBoolean("always_get_new_keys", true);
     }
-
+    private static void legacySettingsMoveLanguageFromNoToNb() {
+        // Check if the user's language preference is set to "no"
+        if ("no".equals(Pref.getString("forced_language", ""))) {
+        // Update the language preference to "nb"
+        Pref.setString("forced_language", "nb");
+        }
+    }
 }

--- a/app/src/main/res/values/locales.xml
+++ b/app/src/main/res/values/locales.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="LocaleChoices">
-        <item>Bokmal</item>
         <item>български език</item>
         <item>čeština</item>
         <item>Deutsch</item>
@@ -26,7 +25,6 @@
         <item>Українська</item>
     </string-array>
     <string-array name="LocaleChoicesValues">
-        <item>nb</item>
         <item>bg</item>
         <item>cs</item>
         <item>de</item>
@@ -38,7 +36,7 @@
         <item>it</item>
         <item>hu</item>
         <item>nl</item>
-        <item>no</item>
+        <item>nb</item>
         <item>pl</item>
         <item>pt</item>
         <item>ro</item>

--- a/app/src/test/java/com/eveningoutpost/dexdrip/ui/TranslationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/ui/TranslationTest.java
@@ -38,7 +38,7 @@ public class TranslationTest extends RobolectricTestWithConfig {
     public void testFormatStrings() throws IOException {
         val config = xdrip.getAppContext().getResources().getConfiguration();
         val internal = xdrip.getAppContext().getResources().getStringArray(R.array.LocaleChoicesValues);
-        val extra = new String[]{"ar", "cs", "de", "el", "en", "es", "fi", "fr", "he", "hr", "it", "iw", "ja", "ko", "nb", "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "zh"};
+        val extra = new String[]{"ar", "cs", "de", "el", "en", "es", "fi", "fr", "he", "hr", "it", "iw", "ja", "ko", "nb", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "zh"};
         val inset = "^values-";
         Set<String> locales = new TreeSet<>(Arrays.asList(internal));
         class ResourceLocaleParser implements FileVisitor<Path> {


### PR DESCRIPTION
This is my attempt to fix first part of https://github.com/NightscoutFoundation/xDrip/issues/3243

This will remove "Bokmal"-option in Language-preferences and change so that "Norsk" points to "nb"-language in Crowdin (100% translated). It will also transfer users who have forced "no"-language over to "nb"-language.

I have built and verified that this works as expected locally. Please advise if there is something I haven't thought of.

What I tested: Forced language = "no" before updating. Then update to this PR and verified that I was moved to the correct "nb"-translations for Norwegian.

Second part removing files from /res folders and "no"-language from Crowdin I need some assistance from @jamorham or  @tolot27 