### PR TITLE
Download treatments originated from xDrip as well

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutTreatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutTreatments.java
@@ -130,7 +130,7 @@ public class NightscoutTreatments {
                     Treatments existing = Treatments.byuuid(nightscout_id);
                     if (existing == null)
                         existing = Treatments.byuuid(uuid);
-                    if ((existing == null) && (!from_xdrip)) {
+                    if (existing == null) {
                         // check for close timestamp duplicates perhaps
                         existing = Treatments.byTimestamp(timestamp, 60000);
                         if (!((existing != null) && (JoH.roundDouble(existing.insulin, 2) == JoH.roundDouble(insulin, 2))


### PR DESCRIPTION
We have two open issues related to the transfer of treatments to and from followers:
https://github.com/NightscoutFoundation/xDrip/issues/735
https://github.com/NightscoutFoundation/xDrip/issues/1196

This PR creates a workaround:

This PR will allow a follower to download treatments uploaded to Nightscout by the master.
It also allows the master to download treatments uploaded by the follower.

1- In order for the follower to be able to upload to Nightscout, `Settings` &#8722;> `Cloud Upload` &#8722;> `Nightscout Sync` &#8722;> `Enabled` must be set.
Also, `Settings` &#8722;> `Cloud Upload` &#8722;> `Nightscout Sync` &#8722;> `Extra Options` &#8722;> `Upload treatments` must be enabled.

2- For the master to download treatments, `Settings` &#8722;> `Cloud Upload` &#8722;> `Nightscout Sync` &#8722;> `Download treatments` must be enabled.  
<br/>    
  
---  
  
#### **Tests**  
I have done a test with two test phones set up as a master and a follower confirming that treatments can be uploaded from either phone and the other phone would download it as well after this PR.
  