### PR TITLE
Identify G7 using settings instead of firmware

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
@@ -5,7 +5,6 @@ import android.text.SpannableString;
 
 import com.eveningoutpost.dexdrip.models.Sensor;
 import com.eveningoutpost.dexdrip.R;
-import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utilitymodels.StatusItem.Highlight;
@@ -32,6 +31,7 @@ import static com.eveningoutpost.dexdrip.utilitymodels.Constants.DAY_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.HOUR_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.None;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getDexCollectionType;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.hasDexcomRaw;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.hasLibre;
@@ -103,7 +103,7 @@ public class SensorDays {
                ths.warmupMs = 2 * HOUR_IN_MS;
             }
 
-            if (FirmwareCapability.isDeviceG7(getTransmitterID())) { // If using a G7
+            if (getBestCollectorHardwareName().equals("G7")) { // If using a G7
                 ths.period = DAY_IN_MS * 10 + HOUR_IN_MS * 12; // The device lasts 10.5 days.
                 ths.warmupMs = 30 * MINUTE_IN_MS; // The warmup time is 30 minutes.
             }


### PR DESCRIPTION
When I submitted this PR, https://github.com/NightscoutFoundation/xDrip/pull/3195, I relied on the firmware to identify G7.
As a result, xDrip still shows a 2-hour warmup time for the very first 5 minutes after establishing connectivity as shown here.
![Screenshot_20240225-085747](https://github.com/NightscoutFoundation/xDrip/assets/51497406/45464c2f-3c7f-4930-a831-d445183e9dec)  
  
After the second reading, xDrip has the firmware and shows the correct warmup time.
  
This PR changes that and uses the selected settings to identify G7, which are valid even before xDrip reads the firmware code.
This is not an extremely critical change.  it is another cleanup step.

I will test this in 10 days.

