### PR TITLE
Show download treatment for nsfollow only

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1256,7 +1256,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             }
 
 
-            final Preference nsFollowDownload = findPreference("nsfollow_download_treatments");
+            final Preference nsFollowDownload = findPreference("nsfollow_download_treatments_screen");
             final Preference nsFollowUrl = findPreference("nsfollow_url");
             final Preference nsFollowLag = findPreference("nsfollow_lag"); // Show the Nightscout follow wake delay setting only when NS follow is the data source
             bindPreferenceSummaryToValue(findPreference("nsfollow_lag")); // Show the selected value as summary

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -193,7 +193,7 @@
             android:summary="@string/summary_nsfollow_url"
             android:title="@string/title_nsfollow_url" />
         <PreferenceScreen
-            android:key="_nsfollow_download_treatments_screen"
+            android:key="nsfollow_download_treatments_screen"
             android:title="@string/title_nsfollow_download_treatments">
             <CheckBoxPreference
                 android:defaultValue="false"


### PR DESCRIPTION
In this recent PR, I replaced a setting with a screen:
https://github.com/NightscoutFoundation/xDrip/pull/3357

A setting that is only supposed to be shown on the hardware data source tab for a particular data source is managed in Preferences.java.
I failed to replace the setting with the new screen there.  As a result, now download treatment is shown regardless of what hardware data source you choose.   Even if you disable collection, it will be shown.  
Please see the following image.  
![Screenshot_20240226-093216](https://github.com/NightscoutFoundation/xDrip/assets/51497406/eb66431c-d733-4e3c-88bd-c0cb055a810f)
  
It shows settings for G7.  You can see the Download Treatment option circled.  That should not be visible.  It should only be visible if Nighscout follower is chosen.  
<br/>  

This PR:
- Removes a typo underscore from the key name of the new screen.
- Replaces the setting key with the screen key in Preferences.java so that it is only shown when nsfollow is chosen.  

I have tested this.