### PR TITLE
Missed reading alert on by default

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/MissedReadingActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/MissedReadingActivity.java
@@ -80,7 +80,7 @@ public class MissedReadingActivity extends ActivityWithMenu {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         int startMinutes = prefs.getInt("missed_readings_start", 0);
         int endMinutes = prefs.getInt("missed_readings_end", 0);
-        boolean enableAlert = prefs.getBoolean("bg_missed_alerts",false);
+        boolean enableAlert = prefs.getBoolean("bg_missed_alerts",true);
         boolean allDay = prefs.getBoolean("missed_readings_all_day",true);
         boolean enableReraise = prefs.getBoolean("bg_missed_alerts_enable_alerts_reraise",false);
         

--- a/app/src/main/res/layout/activity_missed_readings.xml
+++ b/app/src/main/res/layout/activity_missed_readings.xml
@@ -25,6 +25,7 @@
 
                         <CheckBox
                             android:id="@+id/missed_reading_enable_alert"
+                            android:checked="true"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/enable_missed_reading_alert"


### PR DESCRIPTION
The missed reading alert is disabled by default.  Anyone who needs it must enable it.

Whether we set the setting to on or off by default, a group of users need to change it to their preference.
If we set the default to enabled, the group that needs to change it is the group who is annoyed by the missed reading alert.
If we set the default to disabled, the group that needs to change it is the group that could face a disaster if they don't!
That would be a parent waking up in the morning and finding out that they have had no reading from their child for hours.

Please also note that when we face the database corruption, the sensor could stop working.  If the missed reading alert is disabled, the user will have no idea until they check.