### PR TITLE
Broadcast correct G7 sensor start time

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
@@ -2,6 +2,7 @@ package com.eveningoutpost.dexdrip.utilitymodels;
 
 import static com.eveningoutpost.dexdrip.models.JoH.dateTimeText;
 import static com.eveningoutpost.dexdrip.models.JoH.msSince;
+import static com.eveningoutpost.dexdrip.services.Ob1G5CollectionService.getTransmitterID;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Unitized.usingMgDl;
 
@@ -10,6 +11,8 @@ import android.os.Bundle;
 
 import com.eveningoutpost.dexdrip.BestGlucose;
 import com.eveningoutpost.dexdrip.BuildConfig;
+import com.eveningoutpost.dexdrip.g5model.DexSessionKeeper;
+import com.eveningoutpost.dexdrip.g5model.FirmwareCapability;
 import com.eveningoutpost.dexdrip.models.BgReading;
 import com.eveningoutpost.dexdrip.models.Calibration;
 import com.eveningoutpost.dexdrip.models.JoH;
@@ -147,7 +150,11 @@ public class BroadcastGlucose {
                 }
 
                 bundle.putInt(Intents.EXTRA_SENSOR_BATTERY, BridgeBattery.getBestBridgeBattery());
-                bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, sensor.started_at);
+                if (FirmwareCapability.isDeviceG7(getTransmitterID())) { // If there is connectivity and firmware is known and it is either G7 or One+
+                    bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, DexSessionKeeper.getStart());
+                } else { // If there is no connectivity yet or if we are not using G7 ot One+
+                    bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, sensor.started_at);
+                }
                 bundle.putLong(Intents.EXTRA_TIMESTAMP, bgReading.timestamp);
 
                 addDisplayInformation(bundle);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
@@ -5,6 +5,7 @@ import static com.eveningoutpost.dexdrip.models.JoH.msSince;
 import static com.eveningoutpost.dexdrip.services.Ob1G5CollectionService.getTransmitterID;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Unitized.usingMgDl;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -66,7 +67,7 @@ public class BroadcastGlucose {
 
                 UserError.Log.i("SENSOR QUEUE:", "Broadcast data");
 
-                String collectorName = DexCollectionType.getBestCollectorHardwareName();
+                String collectorName = getBestCollectorHardwareName();
                 if (collectorName.equals("G6 Native") || collectorName.equals("G7")) {
                     if (collectorName.equals("G7")) {
                         collectorName = "G6 Native"; // compatibility for older AAPS
@@ -150,9 +151,11 @@ public class BroadcastGlucose {
                 }
 
                 bundle.putInt(Intents.EXTRA_SENSOR_BATTERY, BridgeBattery.getBestBridgeBattery());
-                if (FirmwareCapability.isDeviceG7(getTransmitterID())) { // If there is connectivity and firmware is known and it is either G7 or One+
-                    bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, DexSessionKeeper.getStart());
-                } else { // If there is no connectivity yet or if we are not using G7 ot One+
+                if (getBestCollectorHardwareName().equals("G7")) {// If we are using G7 or One+
+                    if (FirmwareCapability.isDeviceG7(getTransmitterID())) { // Only if there is connectivity
+                        bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, DexSessionKeeper.getStart());
+                    }
+                } else { // If we are not using G7 or One+
                     bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, sensor.started_at);
                 }
                 bundle.putLong(Intents.EXTRA_TIMESTAMP, bgReading.timestamp);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
@@ -30,6 +30,7 @@ public class BroadcastGlucose {
 
     private static final String TAG = "BroadcastGlucose";
     private static long lastTimestamp = 0;
+    private static long dexStartedAt = 0;
 
     public static void sendLocalBroadcast(final BgReading bgReading) {
         if (SendXdripBroadcast.enabled()) {
@@ -153,7 +154,10 @@ public class BroadcastGlucose {
                 bundle.putInt(Intents.EXTRA_SENSOR_BATTERY, BridgeBattery.getBestBridgeBattery());
                 if (getBestCollectorHardwareName().equals("G7")) {// If we are using G7 or One+
                     if (FirmwareCapability.isDeviceG7(getTransmitterID())) { // Only if there is connectivity
-                        bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, DexSessionKeeper.getStart());
+                        dexStartedAt = DexSessionKeeper.getStart(); // Session start time reported by the Dexcom transmitter
+                        if (dexStartedAt > 0) { // Only if dexStartedAt is valid
+                            bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, dexStartedAt);
+                        }
                     }
                 } else { // If we are not using G7 or One+
                     bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, sensor.started_at);


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/3250 

This PR changes what is broadcasted, for sensor start time, only if a known G7 firmware is being used.
The G7 firmware is true either when using a G7 or One+.

What is then broadcasted is the start time from the device instead of the start time of the xDrip session.

I have not tested this because I cannot compile AAPS since we use a different version of gradle.