### PR TITLE
Treatment reminder only for 3 minutes in the future

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
@@ -249,13 +249,14 @@ public class Treatments extends Model {
     }
 
     public static synchronized Treatments create(final double carbs, final double insulinSum, final List<InsulinInjection> insulin, long timestamp, String suggested_uuid) {
-        // if treatment more than 1 minutes in the future
         final long future_seconds = (timestamp - JoH.tsl()) / 1000;
+        // if treatment more than 1 hour in the future
         if (future_seconds > (60 * 60)) {
             JoH.static_toast_long("Refusing to create a treatement more than 1 hours in the future!");
             return null;
         }
-        if ((future_seconds > 60) && (future_seconds < 86400) && ((carbs > 0) || (insulinSum > 0))) {
+        // if treatment more than 3 minutes in the future
+        if ((future_seconds > (3 * 60)) && (future_seconds < 86400) && ((carbs > 0) || (insulinSum > 0))) {
             final Context context = xdrip.getAppContext();
             JoH.scheduleNotification(context, "Treatment Reminder", "@" + JoH.hourMinuteString(timestamp) + " : "
                     + carbs + " g " + context.getString(R.string.carbs) + " / "


### PR DESCRIPTION
This comes up on a regular basis:
![Screenshot 2024-04-01 092402](https://github.com/NightscoutFoundation/xDrip/assets/51497406/a0c8b384-2f6b-4a47-b971-e21a62cef2f8)

This is what I have in my guide about it: https://navid200.github.io/xDrip/docs/Alerts/TreatmentReminders.html  

Many of the cases are caused by a slight time difference between the xDrip phone and the pump.

This PR increases the margin from 1 minute to 3 minutes hoping to reduce the number of confusions.