### PR TITLE
Broadcast start time from transmitter for G6 as well

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
@@ -31,6 +31,8 @@ public class BroadcastGlucose {
     private static final String TAG = "BroadcastGlucose";
     private static long lastTimestamp = 0;
     private static long dexStartedAt = 0;
+    private static boolean connectedToG7 = false;
+    private static boolean connectedToG6 = false;
 
     public static void sendLocalBroadcast(final BgReading bgReading) {
         if (SendXdripBroadcast.enabled()) {
@@ -152,14 +154,18 @@ public class BroadcastGlucose {
                 }
 
                 bundle.putInt(Intents.EXTRA_SENSOR_BATTERY, BridgeBattery.getBestBridgeBattery());
-                if (getBestCollectorHardwareName().equals("G7")) {// If we are using G7 or One+
-                    if (FirmwareCapability.isDeviceG7(getTransmitterID())) { // Only if there is connectivity
-                        dexStartedAt = DexSessionKeeper.getStart(); // Session start time reported by the Dexcom transmitter
-                        if (dexStartedAt > 0) { // Only if dexStartedAt is valid
-                            bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, dexStartedAt);
-                        }
+                if (getBestCollectorHardwareName().equals("G7") && FirmwareCapability.isDeviceG7(getTransmitterID())) {// If we are using G7 or One+ and there is connectivity
+                    connectedToG7 = true;
+                }
+                if (getBestCollectorHardwareName().equals("G6 Native") && FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) {// If we are using a Firefly (modified or not) and there is connectivity
+                    connectedToG6 = true;
+                }
+                if (connectedToG6 || connectedToG7) { // Only if there is connectivity with G6 or G7
+                    dexStartedAt = DexSessionKeeper.getStart(); // Session start time reported by the Dexcom transmitter
+                    if (dexStartedAt > 0) { // Only if dexStartedAt is valid
+                        bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, dexStartedAt);
                     }
-                } else { // If we are not using G7 or One+
+                } else { // If we are not using G7, One+ or G6, or there is no connectivity yet
                     bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, sensor.started_at);
                 }
                 bundle.putLong(Intents.EXTRA_TIMESTAMP, bgReading.timestamp);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
@@ -164,14 +164,14 @@ public class BroadcastGlucose {
                 if (getBestCollectorHardwareName().equals("G6 Native") && FirmwareCapability.isTransmitterG6(getTransmitterID())) { // If we are using a G6 in native mode and there is connectivity
                     connectedToG6 = true;
                 }
-                if (usingG6OrG7) { // If we are using Firefly or G7
+                if (usingG6OrG7) { // If we are using G7 or G6 in native mode
                     if (connectedToG6 || connectedToG7) { // Only if there is connectivity
                         dexStartedAt = DexSessionKeeper.getStart(); // Session start time reported by the Dexcom transmitter
                         if (dexStartedAt > 0) { // Only if dexStartedAt is valid
                             bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, dexStartedAt);
                         }
                     }
-                } else { // If we are not using G7, One+ or Firefly
+                } else { // If we are not using G7, One+ or G6 in native mode
                     bundle.putLong(Intents.EXTRA_SENSOR_STARTED_AT, sensor.started_at);
                 }
                 bundle.putLong(Intents.EXTRA_TIMESTAMP, bgReading.timestamp);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BroadcastGlucose.java
@@ -155,13 +155,13 @@ public class BroadcastGlucose {
                 }
 
                 bundle.putInt(Intents.EXTRA_SENSOR_BATTERY, BridgeBattery.getBestBridgeBattery());
-                if (getBestCollectorHardwareName().equals("G7") || getBestCollectorHardwareName().equals("Native G6")) { // If we are using Firefly, G7 or One+
+                if (getBestCollectorHardwareName().equals("G7") || getBestCollectorHardwareName().equals("Native G6")) { // If we are using G7 or One+, or G6 in native mode
                     usingG6OrG7 = true;
                 }
                 if (getBestCollectorHardwareName().equals("G7") && FirmwareCapability.isDeviceG7(getTransmitterID())) { // If we are using G7 or One+ and there is connectivity
                     connectedToG7 = true;
                 }
-                if (getBestCollectorHardwareName().equals("G6 Native") && FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) { // If we are using a Firefly (modified or not) and there is connectivity
+                if (getBestCollectorHardwareName().equals("G6 Native") && FirmwareCapability.isTransmitterG6(getTransmitterID())) { // If we are using a G6 in native mode and there is connectivity
                     connectedToG6 = true;
                 }
                 if (usingG6OrG7) { // If we are using Firefly or G7


### PR DESCRIPTION
We changed the broadcasted start time for G7 to what G7 reports instead of the xDrip's local start time.
So far, we have had positive feedback from users and no complaints.

However, we now have one similar complaint about G6.

This PR does the exact same thing for Firefly G6 as well.