### PR TITLE
Graph smoothing settings reorganization

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1773,8 +1773,9 @@
     <string name="special_pairing_workaround">Special Pairing Workaround</string>
     <string name="save_power">Save Power</string>
     <string name="reduce_battery_and_network_overhead">Reduce battery and network overhead by using batch processing and excluding unnecessary data</string>
-    <string name="simplify_graphs_by_smoothing_out_irregularities">Simplify graphs by smoothing out irregularities</string>
+    <string name="simplify_graphs_by_smoothing_out_irregularities">Simplify graphs by smoothing out irregularities in the previous readings.  The current reading, alerts and broadcast value are not affected by this setting.  </string>
     <string name="graph_smoothing">Graph Smoothing</string>
+    <string name="enable_graph_smoothing">Enable</string>
     <string name="last_reading">Last Reading</string>
     <string name="select_file_for_alert">Select File for Alert</string>
     <string name="cannot_choose_file_without_permission">Cannot choose file without storage permission</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1514,11 +1514,6 @@
                     android:summary="@string/predictive_readings_old"
                     android:title="@string/display_predictive_values" />
                 <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="show-unsmoothed-values-as-plugin"
-                    android:summary="@string/show_unsmoothed_summary"
-                    android:title="@string/show_unsmoothed" />
-                <CheckBoxPreference
                     android:defaultValue="true"
                     android:dependency="engineering_mode"
                     android:key="use_proper_ongoing"

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -352,13 +352,21 @@
                 android:summary="@string/summary_xdrip_plus_graph_display_settings"
                 android:title="@string/title_xdrip_plus_graph_display_settings">
 
-                <SwitchPreference
-                    android:defaultValue="false"
-                    android:key="graph_smoothing"
-                    android:summary="@string/simplify_graphs_by_smoothing_out_irregularities"
-                    android:switchTextOff="@string/short_off_text_for_switches"
-                    android:switchTextOn="@string/short_on_text_for_switches"
-                    android:title="@string/graph_smoothing" />
+                <PreferenceScreen
+                    android:key="graph_smoothing_screen"
+                    android:title="@string/graph_smoothing">
+                    <CheckBoxPreference
+                        android:defaultValue="false"
+                        android:key="graph_smoothing"
+                        android:summary="@string/simplify_graphs_by_smoothing_out_irregularities"
+                        android:title="@string/enable_graph_smoothing" />
+                    <CheckBoxPreference
+                        android:defaultValue="false"
+                        android:dependency="graph_smoothing"
+                        android:key="show-unsmoothed-values-as-plugin"
+                        android:summary="@string/show_unsmoothed_summary"
+                        android:title="@string/show_unsmoothed" />
+                </PreferenceScreen>
 
                 <CheckBoxPreference
                     android:defaultValue="false"


### PR DESCRIPTION
We have two settings on two different pages that both are related to graph smoothing.
One enables or disables it.
The other shows unsmoothed values as well when enabled.

This PR puts both of these settings on the same page and removes show unsmoothed from the other misc. options page.