### PR TITLE
G6 and G7 persistent authentication logs cleanup

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -365,7 +365,7 @@ public class Ob1G5StateMachine {
                 // parent.reset_bond(true);
                 // parent.unBond(); // WARN
             } else {
-                UserError.Log.e(TAG, "authentication notification  throwable: (" + parent.getState() + ") " + throwable + " " + JoH.dateTimeText(tsl()));
+                UserError.Log.d(TAG, "authentication notification  throwable: (" + parent.getState() + ") " + throwable + " " + JoH.dateTimeText(tsl()));
                 parent.incrementErrors();
                 if (throwable instanceof BleCannotSetCharacteristicNotificationException
                         || throwable instanceof BleGattCharacteristicException) {
@@ -419,7 +419,7 @@ public class Ob1G5StateMachine {
                                                                 if (throwable instanceof OperationSuccess) {
                                                                     UserError.Log.d(TAG, "Stopping auth challenge listener due to success");
                                                                 } else {
-                                                                    UserError.Log.e(TAG, "Could not read reply to auth challenge: " + throwable);
+                                                                    UserError.Log.d(TAG, "Could not read reply to auth challenge: " + throwable);
                                                                     parent.incrementErrors();
                                                                     speakSlowly = true;
                                                                 }


### PR DESCRIPTION
This type of question has been coming up for years.  
<br/>  
  
![Screenshot 2024-05-10 224115](https://github.com/NightscoutFoundation/xDrip/assets/51497406/cbb3508a-44ad-4dca-80c1-059a6f5cb7dd)

This PR will show the logs when detail logs are enabled.
But, under normal circumstances, the two logs will not be shown.  
They neither help the users now me as I consider them expected.  Please correct me if I am wrong.
Otherwise, please merge.


