### PR TITLE
fix bluetooth device disconnection not being correctly detected

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/HeadsetStateReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/HeadsetStateReceiver.java
@@ -44,18 +44,16 @@ public class HeadsetStateReceiver extends BroadcastReceiver {
                 final int state = intent.getIntExtra(BluetoothHeadset.EXTRA_STATE, -1);
                 final int previousState = intent.getIntExtra(BluetoothHeadset.EXTRA_PREVIOUS_STATE, -1);
                 final String deviceInfo = device.getName() + "\n" + device.getAddress() + " " + (device.getBluetoothClass() != null ? device.getBluetoothClass() : "<unknown class>");
-                //UserError.Log.uel(TAG, "Bluetooth audio connection state change: " + state + " was " + previousState + " " + device.getAddress() + " " + device.getName());
+                // UserError.Log.uel(TAG, "Bluetooth audio connection state change: from " + previousState + " to " + state + " " + device.getAddress() + " " + device.getName());
                 if (state == BluetoothProfile.STATE_CONNECTED && previousState != BluetoothProfile.STATE_CONNECTED) {
                     PersistentStore.setString(PREF_LAST_CONNECTED_MAC, device.getAddress());
                     PersistentStore.setString(PREF_LAST_CONNECTED_NAME, device.getName());
                     UserError.Log.uel(TAG, "Bluetooth Audio connected: " + deviceInfo);
                     processDevice(device.getAddress(), true);
-
-                } else if (state == BluetoothProfile.STATE_DISCONNECTED && previousState == BluetoothProfile.STATE_CONNECTED) {
+                } else if (state == BluetoothProfile.STATE_DISCONNECTED && previousState != BluetoothProfile.STATE_DISCONNECTED) {
                     UserError.Log.uel(TAG, "Bluetooth Audio disconnected: " + deviceInfo);
                     processDevice(device.getAddress(), false);
                 }
-
             } else {
                 UserError.Log.d(TAG, "Device was null in intent!");
             }


### PR DESCRIPTION
This should fix https://github.com/NightscoutFoundation/xDrip/issues/3219

The underlying issue is that xDrip is expecting disconnected bluetooth devices to go straight from `STATE_CONNECTED` to `STATE_DISCONNECTED`, but as of Android 14, there's a transition to `STATE_DISCONNECTING` in between.

This doesn't seem to be a new state, and I'm not sure why or when this changed - I can't find any Android changelogs that mention this.

I've made a minimal change to the condition, and I've tested it locally and it works on my device.

![Screenshot_20240511-152008](https://github.com/NightscoutFoundation/xDrip/assets/14271785/92949db2-390d-4924-bb74-085c7a658316)
