### PR TITLE
Wake up for G7 once a minute

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexSyncKeeper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/DexSyncKeeper.java
@@ -58,7 +58,6 @@ public class DexSyncKeeper {
     // anticipate next wake up from time
     // -1 means we don't know anything
     static long anticipate(final String transmitterId, final long now) {
-
         final long last = PersistentStore.getLong(DEX_SYNC_STORE + transmitterId);
         if (last < OLDEST_POSSIBLE) {
             return -1;


### PR DESCRIPTION
A G7 could shift the time stamp off the one-per-5-minute grid as a result of a disconnect.
xDrip uses the timestamp and wakes up 5 minutes after.  However, considering the timestamp may not be on the correct grid, xDrip may wake up when G7  does not transmit.

There are many reports of users having disconnect issues.

This PR changes the wake schedule from once every 5 minutes to every minute for a G7 or One+ only.
My concern is if battery consumption may go up.
My hope is that the impact on battery will be negligible.