### PR TITLE
Make X axis scaling consistent

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2296,8 +2296,12 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                 break;
         }
 
-        float ideal_hours_to_show = DEFAULT_CHART_HOURS + bgGraphBuilder.getPredictivehours();
-        // always show at least the ideal number of hours if locked or auto
+        // always show at least the ideal number of hours
+        float ideal_hours_to_show = DEFAULT_CHART_HOURS;
+        // ... and rescale to accommodate predictions if not locked
+        if (! homeShelf.get("time_locked_always")) {
+            ideal_hours_to_show += bgGraphBuilder.getPredictivehours();
+        }
         float hours_to_show =  exactHoursSpecified ? hours : Math.max(hours, ideal_hours_to_show);
 
         UserError.Log.d(TAG, "VIEWPORT " + source + " moveviewport in setHours: asked " + hours + " vs auto " + ideal_hours_to_show + " = " + hours_to_show + " full chart width: " + bgGraphBuilder.hoursShownOnChart());
@@ -2307,6 +2311,12 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         holdViewport.right = maxViewPort.right;
         holdViewport.top = maxViewPort.top;
         holdViewport.bottom = maxViewPort.bottom;
+
+        // if locked, center display on current bg values, not predictions
+        if (homeShelf.get("time_locked_always")) {
+            holdViewport.left -= hour_width * bgGraphBuilder.getPredictivehours();
+            holdViewport.right -= hour_width * bgGraphBuilder.getPredictivehours();
+        }
 
         if (d) {
             UserError.Log.d(TAG, "HOLD VIEWPORT " + holdViewport);


### PR DESCRIPTION
At present, when predictions are added to the BG line chart, the chart changes its scale.

For example, when displaying 3 hours of data, and a prediction event is added (adding a bolus, for example), the chart will now display ~6 hours (depending on the decay of the insulin) in the same view. This re-scales the chart, which can be confusing if you have locked the time period.

This commit changes this behavior, but only when "Locked Time Period Always Used" is on.

If "Locked Time Period Always Used" is set, the existing X axis scale will remain unchanged when predictions are made, instead adding the prediction offscreen to the right of the current BG value. (That is, you will see the start of the prediction, but will have to scroll right to see the full prediction.)