### PR TITLE
Android 15 compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,10 +89,10 @@ android {
 
     defaultConfig {
         applicationId "com.eveningoutpost.dexdrip"
-        minSdkVersion 23
+        minSdkVersion 24
         // increasing target SDK version can cause compatibility issues with Android 7+
         //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 23
+        targetSdkVersion 24
         // change versionCode only when downgrade should be prevented
         // eg, when data structures are incompatible
         versionCode 1603091400
@@ -216,7 +216,7 @@ android {
             // set minSdkVersion to 21 or higher. When using Android Studio 2.3 or higher,
             // the build automatically avoids legacy multidex when deploying to a device running
             // API level 21 or higher—regardless of what you set as your minSdkVersion.
-            minSdkVersion 23
+            minSdkVersion 24
             versionNameSuffix "-dev"
             buildConfigField "int", "buildVersion", "2021010100"
             buildConfigField "String", "buildUUID", "\"0f79a60a-5616-99be-8eb1-a430edcfd9fd\""


### PR DESCRIPTION
Attempting to install the latest Nightly (May 22, 2024) on Pixel 6a running Android 15 beta 2, installation is blocked by this message:
![Screenshot_20240524-164802](https://github.com/NightscoutFoundation/xDrip/assets/51497406/cfe6bbf6-234a-4d5a-8302-8b5ba9cfacfe)
  
This PR makes it possible to install even though you will need to tap on "install anyway" on a warning you will get similar to what is shown here:
https://navid200.github.io/xDrip/docs/FAQ/UnsafeAppBlocked.html.  
  
I am currently using this to collect from G7 and upload to Nightscout.