### PR TITLE
Sensor expiry note on home screen wrap

### DIFF
--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -540,21 +540,19 @@
 
                 <TextView
                     android:id="@+id/nanoStatusText"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_marginTop="2dp"
                     android:layout_marginStart="5dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
                     android:text="@{nano.color_watch, default=`Nano Status`}"
                     app:showIfTrue="@{nano.color_watch.length() > 0}"/>
 
                 <TextView
                     android:id="@+id/ExpiryStatusText"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_marginTop="2dp"
                     android:layout_marginStart="5dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="99"
                     android:text="@{expiry.color_watch, default=`Expiry Status`}"
                     app:showIfTrue="@{(safeUnbox(vs.included[`sensor_expiry`])) &amp;&amp; (expiry.color_watch.length() > 0)}"/>
 

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -554,7 +554,7 @@
                     android:layout_marginTop="2dp"
                     android:layout_marginStart="5dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
+                    android:layout_weight="99"
                     android:text="@{expiry.color_watch, default=`Expiry Status`}"
                     app:showIfTrue="@{(safeUnbox(vs.included[`sensor_expiry`])) &amp;&amp; (expiry.color_watch.length() > 0)}"/>
 


### PR DESCRIPTION
The following images show  what the sensor expiry looks like on May 28 and May 29, 2024 releases respectively.
![Screenshot_20240529-223455](https://github.com/NightscoutFoundation/xDrip/assets/51497406/3a9a97d5-68e5-465d-896d-328a44827e57)
![Screenshot_20240529-220259](https://github.com/NightscoutFoundation/xDrip/assets/51497406/d391a2b0-b057-4d52-a4f7-c104f2f0b6a3)

The change of the Android target has affected the behavior of linear layout and caused the sensor expiry note to wrap.
I am sorry I missed this change in my tests of Android 15 upgrade.

This issue has been reported here: https://github.com/NightscoutFoundation/xDrip/discussions/3495  

My take is that Android 6 gave no space to an item if it was invisible.  But, it seems Android 7 dedicates space to it even if it is invisible.
I am not sure what the purpose of collector status is on the home shelf.  This PR gives 99% of the space to sensor expiry and 1% to collector status.
The result is that as long as the collector status is invisible (empty), it will be effectively taking no space and the final result will be as it was before upgrade to Android 15.