### PR TITLE
Remove G5 from status page header

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
@@ -119,7 +119,7 @@ public class MegaStatus extends ActivityWithMenu {
     }
 
     private static final String G4_STATUS = "BT Device";
-    public static final String G5_STATUS = "Dexcom Status";
+    public static final String G5_STATUS = "Dex Status";
     private static final String MEDTRUM_STATUS = "Medtrum Status";
     private static final String IP_COLLECTOR = "IP Collector";
     private static final String XDRIP_PLUS_SYNC = "Followers";


### PR DESCRIPTION
This is what the status page will look like after this:  
![Screenshot_20240603-075232](https://github.com/NightscoutFoundation/xDrip/assets/51497406/fceac769-fb51-4d78-8404-9b57fc73337c)  Outdated - please see next post
 
I forgot about this one in my previous PR: https://github.com/NightscoutFoundation/xDrip/pull/3506