### PR TITLE
migrate Espresso test to Android X

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -372,7 +372,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5', {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestImplementation 'androidx.test:core:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -369,9 +369,13 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1', {
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5', {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
+    androidTestImplementation 'androidx.test:core:1.2.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.1.0'
     // add this for intent mocking support
     //androidTestImplementation 'com.android.support.test.espresso:espresso-intents:3.0.1'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -64,6 +64,11 @@
 -keep class android.support.v7.widget.SearchView { *; }
 -keep class kotlinx.serialization.Serializable { *; }
 
+# The lib net.sf.kxml:kxml2:2.3.0 is referenced in same required libraries used for
+# Android testing. R8 is showing missing classes warnings which can be safely ignored.
+-dontwarn org.kxml2.io.KXmlParser
+-dontwarn org.kxml2.io.KXmlSerializer
+
 -dontwarn java.util.concurrent.**
 
 -keep class rx.schedulers.Schedulers {

--- a/app/src/androidTest/java/com/eveningoutpost/dexdrip/HomeEspressoTest.java
+++ b/app/src/androidTest/java/com/eveningoutpost/dexdrip/HomeEspressoTest.java
@@ -5,14 +5,27 @@ package com.eveningoutpost.dexdrip;
  */
 
 
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.schibsted.spain.barista.BaristaClickActions.click;
+import static com.schibsted.spain.barista.BaristaScrollActions.scrollTo;
+import static com.schibsted.spain.barista.custom.NestedEnabledScrollToAction.scrollTo;
+import static org.hamcrest.core.AllOf.allOf;
+
 import android.app.Activity;
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.annotation.UiThreadTest;
-import android.support.test.espresso.ViewInteraction;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
 import android.view.WindowManager;
+
+import androidx.test.InstrumentationRegistry;
+import androidx.test.annotation.UiThreadTest;
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.schibsted.spain.barista.flakyespresso.AllowFlaky;
 
@@ -25,18 +38,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 
 import java.io.File;
-
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.RootMatchers.isDialog;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static com.schibsted.spain.barista.BaristaClickActions.click;
-import static com.schibsted.spain.barista.BaristaScrollActions.scrollTo;
-import static com.schibsted.spain.barista.custom.NestedEnabledScrollToAction.scrollTo;
-import static org.hamcrest.core.AllOf.allOf;
 
 @RunWith(AndroidJUnit4.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)


### PR DESCRIPTION
During compilation of the debug app missing libraries are shown in `HomeEspressoTest.java` because this test was not migrated (74a4f02) to the androidx libraries. This was also mentioned in #3255.
This PR migrates this Espresso test to androidx. Still not all tests are passing, but many. Upgrading the libraries to newer ones will break even the first test. But this is out of scope for this PR.