### PR TITLE
ProGuard rule to ignore kotlinx.serialization.Serializable missing class warning

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -64,6 +64,16 @@
 -keep class android.support.v7.widget.SearchView { *; }
 -keep class kotlinx.serialization.Serializable { *; }
 
+# As long as we only deserialize (from a JSON string into an `NSDeviceStatus`
+# object in the class `AAPSStatusHandler`) we can simply ignore warnings related
+# to kotlinx serialization.
+# These rule should not cause problems: if a project actually relies on
+# serialization, then much more than just this class will be required,
+# so telling Proguard not to worry if this is missing will not prevent it
+# from emitting errors for code that does use serialization but somehow forgot
+# to depend on it.
+-dontwarn kotlinx.serialization.Serializable
+
 -dontwarn java.util.concurrent.**
 
 -keep class rx.schedulers.Schedulers {


### PR DESCRIPTION
The class `AAPSStatusHandler` uses `info.nightscout.sdk.localmodel.devicestatus.NSDeviceStatus` (`ns-sdk-full-release:@aar`) which is annotated with `@Serializable` this throws the following compile time warning:

```
Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in ...\missing_rules.txt.

Missing class kotlinx.serialization.Serializable (referenced from: info.nightscout.sdk.localmodel.devicestatus.NSDeviceStatus$Configuration and 5 other contexts)
```

Since we only deserialize a Json string into an `NSDeviceStatus` object, we can ignore this warning and disable it with a ProGuard rule.