### PR TITLE
Remove the stop sensor option for G7 completely

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
@@ -18,7 +18,6 @@ import com.eveningoutpost.dexdrip.tables.CalibrationDataTable;
 import com.eveningoutpost.dexdrip.utilitymodels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.utilitymodels.Experience;
 import com.eveningoutpost.dexdrip.stats.StatsActivity;
-import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.utils.Preferences;
 
@@ -103,7 +102,7 @@ public class NavDrawerBuilder {
                         }
                     }
                 }
-                if (!getBestCollectorHardwareName().equals("G7") || Pref.getBooleanDefaultFalse("engineering_mode")) { // If we are using G7, offer the stop sensor option in engineering mode only
+                if (!getBestCollectorHardwareName().equals("G7")) { // If we are using G7, there will be no stop sensor option in the menu.
                     this.nav_drawer_options.add(context.getString(R.string.stop_sensor));
                     this.nav_drawer_intents.add(new Intent(context, StopSensor.class));
                 }


### PR DESCRIPTION
There has been no option to stop a G7, or One+, since the Nightly February 17.
Since May 18, 3 weeks ago, the stable release has had no stop option either.
There have been no complaints.

This page is used to help anyone confused by the missing stop/start:
https://navid200.github.io/xDrip/docs/Dexcom/WhyNoG7Stop.html

Please let's remove the option completely.