### PR TITLE
Session stop notification for G7

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/CalibrationState.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/CalibrationState.java
@@ -58,7 +58,7 @@ public enum CalibrationState {
 
     private static final SparseArray<CalibrationState> lookup = new SparseArray<>();
     private static final ImmutableSet<CalibrationState> failed = ImmutableSet.of(SensorFailed, SensorFailed2, SensorFailed3, SensorFailed4, SensorFailed5, SensorFailed6, SensorFailedStart);
-    private static final ImmutableSet<CalibrationState> stopped = ImmutableSet.of(Stopped, Ended, SensorFailed, SensorFailed2, SensorFailed3, SensorFailed4, SensorFailed5, SensorFailed6, SensorFailedStart, SensorStopped);
+    private static final ImmutableSet<CalibrationState> stopped = ImmutableSet.of(Stopped, Ended, SensorExpired, SensorFailed, SensorFailed2, SensorFailed3, SensorFailed4, SensorFailed5, SensorFailed6, SensorFailedStart, SensorStopped);
     private static final ImmutableSet<CalibrationState> transitional = ImmutableSet.of(WarmingUp, SensorStarted, SensorStopped, CalibrationSent);
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -39,7 +39,6 @@ import static com.eveningoutpost.dexdrip.utilitymodels.Constants.G5_CALIBRATION_
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.G5_SENSOR_FAILED;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.G5_SENSOR_RESTARTED;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.G5_SENSOR_STARTED;
-import static com.eveningoutpost.dexdrip.utilitymodels.Constants.G7_SESSION_EXPIRED;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.HOUR_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.SECOND_IN_MS;
@@ -48,7 +47,6 @@ import static com.eveningoutpost.dexdrip.utilitymodels.StatusItem.Highlight.CRIT
 import static com.eveningoutpost.dexdrip.utilitymodels.StatusItem.Highlight.NORMAL;
 import static com.eveningoutpost.dexdrip.utilitymodels.StatusItem.Highlight.NOTICE;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.DexcomG5;
-import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
 import static com.eveningoutpost.dexdrip.utils.bt.Subscription.addErrorHandler;
 import static com.eveningoutpost.dexdrip.watch.thinjam.BlueJayEntry.isNative;
 import static com.eveningoutpost.dexdrip.xdrip.gs;
@@ -93,7 +91,6 @@ import com.eveningoutpost.dexdrip.g5model.DexTimeKeeper;
 import com.eveningoutpost.dexdrip.g5model.FirmwareCapability;
 import com.eveningoutpost.dexdrip.g5model.Ob1DexTransmitterBattery;
 import com.eveningoutpost.dexdrip.g5model.Ob1G5StateMachine;
-import com.eveningoutpost.dexdrip.g5model.SensorDays;
 import com.eveningoutpost.dexdrip.g5model.TransmitterStatus;
 import com.eveningoutpost.dexdrip.g5model.VersionRequest1RxMessage;
 import com.eveningoutpost.dexdrip.g5model.VersionRequest2RxMessage;
@@ -1156,7 +1153,7 @@ public class Ob1G5CollectionService extends G5BaseService {
             }
 
             minimize_scanning = Pref.getBooleanDefaultFalse("ob1_minimize_scanning");
-           // allow_scan_by_mac = Build.VERSION.SDK_INT >= 32 && shortTxId();
+            // allow_scan_by_mac = Build.VERSION.SDK_INT >= 32 && shortTxId();
             automata(); // sequence logic
 
             UserError.Log.d(TAG, "Releasing service start");
@@ -1933,13 +1930,6 @@ public class Ob1G5CollectionService extends G5BaseService {
             final PendingIntent pi = PendingIntent.getActivity(xdrip.getAppContext(), G5_SENSOR_FAILED, JoH.getStartActivityIntent(Home.class), PendingIntent.FLAG_UPDATE_CURRENT);
             JoH.showNotification(state.getText(), "Sensor FAILED", pi, G5_SENSOR_FAILED, true, true, false);
             UserError.Log.ueh(TAG, "Native Sensor is now marked FAILED: " + state.getExtendedText());
-        }
-
-        if (is_started && getBestCollectorHardwareName().equals("G7") && SensorDays.get().getRemainingSensorPeriodInMs() == 0) { // If we have an active G7 session and sensor has expired
-            Sensor.stopSensor(); // We might as well stop the xDrip session
-            final PendingIntent pi = PendingIntent.getActivity(xdrip.getAppContext(), G7_SESSION_EXPIRED, JoH.getStartActivityIntent(Home.class), PendingIntent.FLAG_UPDATE_CURRENT);
-            JoH.showNotification(state.getText(), "Session ended", pi, G7_SESSION_EXPIRED, true, true, false); // Let's notify the user that the session has ended.
-            UserError.Log.ueh(TAG, "Native Session has now ended: " + state.getExtendedText());
         }
         // we can't easily auto-cancel a failed notice as auto-restart may mean the user is not aware of it?
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -20,7 +20,6 @@ import static com.eveningoutpost.dexdrip.models.JoH.emptyString;
 import static com.eveningoutpost.dexdrip.models.JoH.joinBytes;
 import static com.eveningoutpost.dexdrip.models.JoH.msSince;
 import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalar;
-import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalarNatural;
 import static com.eveningoutpost.dexdrip.models.JoH.tolerantHexStringToByteArray;
 import static com.eveningoutpost.dexdrip.models.JoH.tsl;
 import static com.eveningoutpost.dexdrip.models.JoH.upForAtLeastMins;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
@@ -55,7 +55,6 @@ public class Constants {
     public static final int WEBFOLLOW_SERVICE_FAILOVER_ID = 1028;
     public static final int BACKUP_ACTIVITY_ID = 1029;
     public static final int CARELINK_SERVICE_FAILOVER_ID = 1030;
-    public static final int G7_SESSION_EXPIRED = 1031;
 
     static final int NIGHTSCOUT_ERROR_NOTIFICATION_ID = 2001;
     public static final int HEALTH_CONNECT_RESPONSE_ID = 2002;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
@@ -55,6 +55,7 @@ public class Constants {
     public static final int WEBFOLLOW_SERVICE_FAILOVER_ID = 1028;
     public static final int BACKUP_ACTIVITY_ID = 1029;
     public static final int CARELINK_SERVICE_FAILOVER_ID = 1030;
+    public static final int G7_SESSION_EXPIRED = 1031;
 
     static final int NIGHTSCOUT_ERROR_NOTIFICATION_ID = 2001;
     public static final int HEALTH_CONNECT_RESPONSE_ID = 2002;


### PR DESCRIPTION
When a G7 comes close to 10.5 days of life, 2 different things can happen:  

1- User switches xDrip to their new G7 before the current session expires.
In that case, this PR changes nothing.  
  
2- User waits for the session on their current G7 to end while still connected to it in xDrip.  
In that case, this PR will end the xDrip session and issues a notification the same as what it would do for a G6.  

Without this PR, xDrip never issues a notification.  
I have been in this situation when the session has expired and I had no idea for a while until I got a missed reading alert.  
<br/>  
  
---  
  
**Test**  
I installed this on a test phone.  I established connectivity to my active G7.  
After getting readings for a few cycles, I switched to an expired G7.  The xDrip session was successfully ended and a notification was received.  
  
I can test this in a real scenario where the session really expires in 4 days.  