### PR TITLE
Data table crash

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/tables/BgReadingTable.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tables/BgReadingTable.java
@@ -62,10 +62,10 @@ public class BgReadingTable extends BaseListActivity implements NavigationDrawer
 
     private void getData() {
         final List<BgReading> latest = BgReading.latest(5000);
-        parseDataForStats(latest);
-        ListAdapter adapter = new BgReadingAdapter(this, latest);
-        this.setListAdapter(adapter);
         try {
+            parseDataForStats(latest);
+            ListAdapter adapter = new BgReadingAdapter(this, latest);
+            this.setListAdapter(adapter);
             if (total > 0) {
                 this.getActionBar().setSubtitle(String.format(Locale.getDefault(), "%d in 24h, bf:%d%% mis:%d", total, ((backfilled * 100) / total), missing));
             }


### PR DESCRIPTION
Install xDrip (not over a previous install).
Do not set up a hardware data source.
Enable data tables.  
Tap on data table.  xDrip will crash.  

It crashes when calling parseDataForStats.
And what causes the crash is the for loop in that method.  

I have extended the existing try and catch to also include the call to the parseDataForStats method.

The same test shows no crash anymore after this PR.  It shows an empty data table.