### PR TITLE
Retire old G5 settings

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -149,6 +149,8 @@ public class IdempotentMigrations {
         Pref.setBoolean("ob1_g5_fallback_to_xdrip", false);
         Pref.setBoolean("always_unbond_G5", false);
         Pref.setBoolean("always_get_new_keys", true);
+        Pref.setBoolean("run_ble_scan_constantly", false);
+        Pref.setBoolean("run_G5_ble_tasks_on_uithread", false);
     }
     private static void legacySettingsMoveLanguageFromNoToNb() {
         // Check if the user's language preference is set to "no"

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -2522,6 +2522,8 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
            //  removePreferenceFromCategory("ob1_g5_fallback_to_xdrip", "ob1_options");
            //  removePreferenceFromCategory("always_unbond_G5", "ob1_options");
            //  removePreferenceFromCategory("always_get_new_keys", "ob1_options");
+           // removePreferenceFromCategory("run_ble_scan_constantly", "ob1_options");
+           // removePreferenceFromCategory("run_G5_ble_tasks_on_uithread", "ob1_options");
        }
 
        private void removePreferenceFromCategory(final String preference, final String category) {

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -411,20 +411,6 @@
                     android:title="@string/title_dex_specified_slot" />
             </PreferenceCategory>
             <PreferenceCategory
-                android:key="old_g5_options"
-                android:title="@string/title_old_g5_options">
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="run_ble_scan_constantly"
-                    android:summary="@string/g5_scan_constantly"
-                    android:title="@string/scan_for_g5_constantly" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="run_G5_ble_tasks_on_uithread"
-                    android:summary="@string/g5_force_ui_thread"
-                    android:title="@string/force_g5_ui_thread" />
-            </PreferenceCategory>
-            <PreferenceCategory
                 android:key="dex_battery_category"
                 android:title="@string/title_g5g6_battery_options">
                 <EditTextPreference


### PR DESCRIPTION
This PR removes 2 settings and the category that only contains the two.
The settings are titled:
Scan constantly
Force Dex to UI thread

Considering we have retired Android 4, 5 and 6, am I wrong to think that no one should need these two settings any longer?  
 
![Screenshot_20240612-130522](https://github.com/NightscoutFoundation/xDrip/assets/51497406/e23ef073-18f2-4d71-889d-2b8d0b1a61e6)
  
The following image shows what the Debug settings page will look like for G7 after this PR.  
It will look exactly the same for a G6 with the addition of the battery options at the bottom also present.  

![Screenshot_20240612-122431](https://github.com/NightscoutFoundation/xDrip/assets/51497406/611e2a09-b52f-455d-bb14-8a5ed3f35807)
