### PR TITLE
No sensor start time for G7 on classic status page

### DIFF
--- a/app/src/main/res/layout/activity_system_status.xml
+++ b/app/src/main/res/layout/activity_system_status.xml
@@ -129,6 +129,7 @@
 
             <LinearLayout
                 android:id="@+id/layout_sensor"
+                app:showIfTrue="@{ms.bluetooth()}"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"


### PR DESCRIPTION
The xDrip sensor start time (classic status page) matches the start time reported by the transmitter (shown on Dex status page as a relative time) for a G6 under 99% of situations.
Only if you start the sensor with a different app or device, there may be a slight difference between the two.

For G7, this is a different story.
The main reason for this difference between G6 and G7 is that you run G6 sessions on the same transmitter.  You will need to stop one before you can start the next.
For G7, you run each session on a different G7.  Therefore, you can start a G7 while you have another active G7.  This happens often considering the 12-hour grace period available for G7.

The result is that the sensor start time shown on the classic status page for a G7 can be very confusing to an inexperienced user.
The question comes up occasionally why the start time shown on the classic status page is incorrect.

This PR removes the sensor start time from the classic status page for a G7 or One+.  
A user interested to know when their current session started can see that on the dex status page.  
  
The following shows what the classic status page will look like for a G7 after this PR.    
![Screenshot_20240612-225936](https://github.com/NightscoutFoundation/xDrip/assets/51497406/b8b06279-63e9-4693-b9b0-eaec08593382)
    