### PR TITLE
US server setting in the Dex share follow menu

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1275,6 +1275,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
             final Preference shFollowUser = findPreference("shfollow_user");
             final Preference shFollowPass = findPreference("shfollow_pass");
+            final Preference shFollowServerUS = findPreference("dex_share_us_acct");
 
             if (collectionType == DexCollectionType.SHFollow) {
                 final Preference.OnPreferenceChangeListener shFollowListener = new Preference.OnPreferenceChangeListener() {
@@ -1289,6 +1290,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 try {
                     shFollowUser.setOnPreferenceChangeListener(shFollowListener);
                     shFollowPass.setOnPreferenceChangeListener(shFollowListener);
+                    shFollowServerUS.setOnPreferenceChangeListener(shFollowListener);
                 } catch (Exception e) {
                     //
                 }
@@ -1297,6 +1299,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 try {
                     collectionCategory.removePreference(shFollowUser);
                     collectionCategory.removePreference(shFollowPass);
+                    collectionCategory.removePreference(shFollowServerUS);
                 } catch (Exception e) {
                     //
                 }

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -232,6 +232,11 @@
             android:singleLine="true"
             android:summary="Login password for Dex Share Following"
             android:title="Share Password" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="dex_share_us_acct"
+            android:summary="Your account and follower app are from the USA"
+            android:title="US Servers" />
 
         <ListPreference
             android:defaultValue="gb"


### PR DESCRIPTION
This setting is only available in the Dex share upload menu.
But, it is required to be set correctly for a Dex share follower to operate as well.  
This PR adds the US server setting to the conditional Dex share follower menu.  
The menu before and after this PR is shown below.  
  
| Before | After |  
| ------- | ------ |  
| ![Screenshot_20240614-172942](https://github.com/NightscoutFoundation/xDrip/assets/51497406/a92c2a0f-cd24-4266-8f67-e8cafe20e747) | ![Screenshot_20240614-173252](https://github.com/NightscoutFoundation/xDrip/assets/51497406/23f79896-a3d8-45c9-aefe-c3e51d59afd2) |  
  

