### PR TITLE
Battery optimization prompt clarification

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -621,7 +621,7 @@
     <string name="short_speak_readings_shortcut">Show a shortcut in the ☰ menu to toggle Speak Readings</string>
     <string name="speak_readings_shortcut">Speak Readings Shortcut</string>
     <string name="battery_optimization_off">On Android 6+ ensure battery optimization is switched off (recommended).</string>
-    <string name="battery_optimization_on">Don\'t keep asking about battery optimization (not recommended).</string>
+    <string name="battery_optimization_on">Will not keep asking about battery optimization when enabled (not recommended).</string>
     <string name="battery_optimization_prompt">Battery Optimization prompt</string>
     <string name="advanced_bluetooth_settings">Advanced Bluetooth Settings</string>
     <string name="bluetooth_settings">Bluetooth Settings</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1494,8 +1494,7 @@
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="requested_ignore_battery_optimizations_new"
-                    android:summaryOff="@string/battery_optimization_off"
-                    android:summaryOn="@string/battery_optimization_on"
+                    android:summary="@string/battery_optimization_on"
                     android:title="@string/battery_optimization_prompt" />
                 <CheckBoxPreference
                     android:defaultValue="true"


### PR DESCRIPTION
When a switch has a visual representation, it is best to have a unique summary specifying what the switch does when enabled.  
As an example, please have a look at the following screenshots of the speak reading switch.  
![Screenshot_20240615-074535](https://github.com/NightscoutFoundation/xDrip/assets/51497406/b55e2ee1-35b1-4662-80fd-ae2170f2c024) ![Screenshot_20240615-074553](https://github.com/NightscoutFoundation/xDrip/assets/51497406/b1d72baf-185f-47db-bf73-4df4490198f8)  
The summary says "it will speak each new reading" regardless of if the checkbox is enabled or not.  
This tells the user what the checkbox does if/when enabled.  This is a reasonable expectation from the user to consider the summary to explain what the switch does when enabled.  
  
If the switch did not have a visual representation, it would make sense to use the summary to tell the user what tapping on the switch will do.  
But, when the switch already has a visual representation, making the summary change depending on the switch condition makes it a confusing setup.  
<br/>  
  
The following shows what the battery optimization prompt switch does now before this PR.  
![Screenshot_20240615-074836](https://github.com/NightscoutFoundation/xDrip/assets/51497406/7fb93cae-eea2-4b93-8c95-b6de992ceb58)  ![Screenshot_20240615-074903](https://github.com/NightscoutFoundation/xDrip/assets/51497406/9f4e4f98-b92c-4559-9da1-6add666a782c)  
Look at the summary for when the checkbox is disabled.  It says "recommended".  What if the user confuses that with us telling them that we recommend that they enable the switch?  
<br/>  
<br/>  
  
---  
#### **This PR**  
This PR changes the summary to one statement regardless of if the checkbox is enabled or not as shown below.  
![Screenshot_20240615-075026](https://github.com/NightscoutFoundation/xDrip/assets/51497406/aa24642d-4109-4388-8f22-fc7b7f57e76d) ![Screenshot_20240615-075043](https://github.com/NightscoutFoundation/xDrip/assets/51497406/69d43be0-6f79-47c2-b31e-14c9388d9465)  
  
Now, we are using the summary to tell the user what the checkbox does when enabled.  And the checkbox representation (checkmark present or not) tells the user if the checkbox has been set or not.  Exactly the same as the speak reading checkbox and almost every other checkbox in xDrip.  
  