### PR TITLE
Fix WearOS complication not working with G7

### DIFF
--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
@@ -2418,7 +2418,7 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                                     changed = true;
                                     bgData.save();
                                 } else {
-                                    if (bgData.source_info != null && (bgData.source_info.contains("Native") || bgData.source_info.contains("Follow"))) {
+                                    if (bgData.source_info != null && (bgData.source_info.contains("Native") || bgData.source_info.contains("Follow") || bgData.source_info.contains("G7"))) {
                                         UserError.Log.d(TAG, "Saving BgData without calibration as source info is native or follow");
                                         bgData.sensor = sensor;
                                         bgData.sensor_uuid = sensor.uuid;


### PR DESCRIPTION
This should fix #303. The G7 does not report as "G7 Native" like the G5/G6 does. Instead it just reports as "G7" causing the ListenerService abomination to fail when saving new values.

Related: #3220 is the pr introducing this change