### PR TITLE
Persistent High alert threshold

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/evaluators/PersistentHigh.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/evaluators/PersistentHigh.java
@@ -49,7 +49,7 @@ public class PersistentHigh {
         if ((last != null) && (last.size() > 0)) {
 
             final double vThreshold = Home.convertToMgDlIfMmol(
-                    JoH.tolerantParseDouble(Pref.getString("persistent_high_threshold", "135"), 135d));
+                    JoH.tolerantParseDouble(Pref.getString("persistent_high_threshold", "170"), 170d));
 
             final long now = JoH.tsl();
             final long since = now - last.get(0).timestamp;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
@@ -1834,10 +1834,10 @@ public class BgReading extends Model implements ShareUploadableBg {
             final long since = now - last.get(0).timestamp;
             // only process if last reading <10 mins
             if (since < 600000) {
-                // check if exceeding high
+                // check if exceeding persistent high threshold
                 if (last.get(0).calculated_value >
                         Home.convertToMgDlIfMmol(
-                                JoH.tolerantParseDouble(Pref.getString("highValue", "170")))) {
+                                JoH.tolerantParseDouble(Pref.getString("persistent_high_threshold", "135")))) {
 
                     final double this_slope = last.get(0).calculated_value_slope * 60000;
                     //Log.d(TAG, "CheckForPersistentHigh: Slope: " + JoH.qs(this_slope));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
@@ -1837,7 +1837,7 @@ public class BgReading extends Model implements ShareUploadableBg {
                 // check if exceeding persistent high threshold
                 if (last.get(0).calculated_value >
                         Home.convertToMgDlIfMmol(
-                                JoH.tolerantParseDouble(Pref.getString("persistent_high_threshold", "135")))) {
+                                JoH.tolerantParseDouble(Pref.getString("persistent_high_threshold", "170")))) {
 
                     final double this_slope = last.get(0).calculated_value_slope * 60000;
                     //Log.d(TAG, "CheckForPersistentHigh: Slope: " + JoH.qs(this_slope));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1000,6 +1000,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             bindPreferenceSummaryToValue(findPreference("rising_bg_val"));
             bindPreferenceSummaryToValue(findPreference("other_alerts_sound"));
             bindPreferenceSummaryToValue(findPreference("bridge_battery_alert_level"));
+            bindPreferenceSummaryToValueAndEnsureNumeric(findPreference("persistent_high_threshold"));
 
             addPreferencesFromResource(R.xml.pref_data_source);
 
@@ -2972,6 +2973,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             final Double lowVal = Double.parseDouble(preferences.getString("lowValue", "0"));
             final Double default_insulin_sensitivity = Double.parseDouble(preferences.getString("profile_insulin_sensitivity_default", "54"));
             final Double default_target_glucose = Double.parseDouble(preferences.getString("plus_target_range", "100"));
+            final Double persistent_high_Val = Double.parseDouble(preferences.getString("persistent_high_threshold", "0"));
 
 
             static_units = newValue.toString();
@@ -2990,6 +2992,11 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     preferences.edit().putString("plus_target_range", Long.toString(Math.round(default_target_glucose * Constants.MMOLL_TO_MGDL))).apply();
                     Profile.invalidateProfile();
                 }
+                if (persistent_high_Val < 36) {
+                    ProfileEditor.convertData(Constants.MMOLL_TO_MGDL);
+                    preferences.edit().putString("persistent_high_threshold", Long.toString(Math.round(persistent_high_Val * Constants.MMOLL_TO_MGDL))).apply();
+                    Profile.invalidateProfile();
+                }
 
             } else {
                 if (highVal > 35) {
@@ -3006,11 +3013,17 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     preferences.edit().putString("plus_target_range", JoH.qs(default_target_glucose * Constants.MGDL_TO_MMOLL,1)).apply();
                     Profile.invalidateProfile();
                 }
+                if (persistent_high_Val > 35) {
+                    ProfileEditor.convertData(Constants.MGDL_TO_MMOLL);
+                    preferences.edit().putString("persistent_high_threshold", JoH.qs(persistent_high_Val * Constants.MGDL_TO_MMOLL, 1)).apply();
+                    Profile.invalidateProfile();
+                }
             }
             if (preference != null) preference.setSummary(newValue.toString());
             if (allPrefsFragment != null) {
                 allPrefsFragment.setSummary("highValue");
                 allPrefsFragment.setSummary("lowValue");
+                allPrefsFragment.setSummary("persistent_high_threshold");
             }
             if (profile_insulin_sensitivity_default != null) {
                 Log.d(TAG, "refreshing profile insulin sensitivity default display");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
@@ -81,6 +81,7 @@ public class xdrip extends Application {
         executor = new PlusAsyncExecutor();
 
         IdempotentMigrations.migrateOOP2CalibrationPreferences(); // needs to run before preferences get defaults
+        IdempotentMigrations.startup(); // Must run before defaults are loaded
 
         PreferenceManager.setDefaultValues(this, R.xml.pref_general, true);
         PreferenceManager.setDefaultValues(this, R.xml.pref_data_sync, true);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,6 +236,7 @@
     <string name="other_alerts">Other Alerts</string>
     <string name="extra_alerts_xdrip_plus">Extra Alerts (xDrip+)</string>
     <string name="persistent_high_alert">Persistent High Alert</string>
+    <string name="summary_persistent_high_alert">Notify if above threshold, and not falling, for long</string>
     <string name="forecasted_low_alert">Forecasted Low Alert</string>
     <string name="extrapolate_data_to_try_to_predict_lows">Extrapolate data to try to predict lows</string>
     <string name="alarm_at_forecasted_low_mins">Alarm at Forecasted Low mins</string>
@@ -1501,7 +1502,6 @@
     <string name="category_noisy_readings">Noisy Readings</string>
     <string name="category_falling_rising_bg">Falling/Rising BG</string>
     <string name="category_alert_prefs">Alert Preferences (for these alerts)</string>
-    <string name="summary_persistent_high_alert">When above High level for too long and not heading downwards</string>
     <string name="note_search_button">SEARCH</string>
     <string name="all_note_button">ALL</string>
     <string name="title_full_screen_mode">Full Screen mode</string>
@@ -1786,6 +1786,8 @@
     <string name="select_tone_for_alerts">Select tone for Alerts</string>
     <string name="show_unsmoothed">Show unsmoothed</string>
     <string name="show_unsmoothed_summary">Show unsmoothed data also if Graph Smoothing is enabled. If calibration plugin is used, will show unsmoothed data instead of plugin data.</string>
+    <string name="title_persistent_high_threshold">Persistent high threshold</string>
+    <string name="summary_persistent_high_threshold">Persistent high alert threshold</string>
     <string name="you_can_use_google_drive_for_backup">You can use Google Drive for backup</string>
     <string name="select_backup_location">Select Backup Location</string>
     <string name="do_backup_now">Do Backup Now</string>

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -302,7 +302,7 @@
                         android:summary="@string/summary_persistent_high_alert"
                         android:title="@string/persistent_high_alert" />
                     <EditTextPreference
-                        android:defaultValue="135"
+                        android:defaultValue="170"
                         android:dependency="persistent_high_alert_enabled"
                         android:inputType="numberDecimal"
                         android:key="persistent_high_threshold"

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -299,8 +299,15 @@
                     <SwitchPreference
                         android:defaultValue="false"
                         android:key="persistent_high_alert_enabled"
-                        android:summary="@string/alarm_if_above_high_value"
+                        android:summary="@string/summary_persistent_high_alert"
                         android:title="@string/persistent_high_alert" />
+                    <EditTextPreference
+                        android:defaultValue="135"
+                        android:dependency="persistent_high_alert_enabled"
+                        android:inputType="numberDecimal"
+                        android:key="persistent_high_threshold"
+                        android:title="@string/title_persistent_high_threshold"
+                        android:summary="@string/summary_persistent_high_threshold"/>
                     <EditTextPreference
                         android:defaultValue="60"
                         android:dependency="persistent_high_alert_enabled"


### PR DESCRIPTION
After this change, a user can set a persistent high alert threshold different than the High Value, used for statistics.  
  
Since xDrip persistent high alert has been there for years, we must be careful not to cause any unintended change to its behavior.  
If an existing user updates to a release after this PR is merged, their High Value is automatically used as their new Persistent High alert threshold.  

This is what the persistent high alert menu looks after this PR:  
![Screenshot_20240701-144255](https://github.com/NightscoutFoundation/xDrip/assets/51497406/5720b8e7-c31a-408a-b71c-b25c296e32dd)
  
This is the log that is shown after an update:  
![Screenshot_20240701-144207](https://github.com/NightscoutFoundation/xDrip/assets/51497406/359c60ff-de5e-469d-9d10-98702263ab85)
  
There are two concerns I have about this PR explained in the next post.  