### PR TITLE
G7 backfill overlap fix

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -92,6 +92,7 @@ import static com.eveningoutpost.dexdrip.utilitymodels.Constants.DAY_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.HOUR_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.SECOND_IN_MS;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
 import static com.eveningoutpost.dexdrip.utils.bt.Helper.getStatusName;
 
 
@@ -1062,6 +1063,12 @@ public class Ob1G5StateMachine {
     }
 
     private static void backFillIfNeeded(Ob1G5CollectionService parent, RxBleConnection connection) {
+        if (!Sensor.isActive() && Ob1G5CollectionService.isG5SensorStarted() && getBestCollectorHardwareName().equals("G7")) { // If we are using a G7 coming from a G6
+            // and continue beyond this point without an xDrip session, we can end up with a backfill overlapping the last G6 session.
+            // So, let's start a session now.
+            JoH.static_toast_long(xdrip.gs(R.string.auto_starting_sensor));
+            Sensor.create(tsl() - HOUR_IN_MS * 24);
+        }
         final Sensor sensor = Sensor.currentSensor();
         if (sensor == null) {
             UserError.Log.e(TAG, "Cannot process backfill evaluation as no active sensor");


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/3398 
 
**How to Recreate the problem**  
You will need a G7 session in progress and a test phone.  
On the test phone, uninstall xDrip and install the latest Nightly (June 28, 2024).
If you have a G6 session in progress, establish connectivity to it.  If you don't set up fake data source.  
After establishing connectivity to your G6, wait for another read cycle so that it backfills the past 3 hours.  

Now, stop the session.  It is important to stop the xDrip session.  There is no reason to stop the real session on G6.  

After having stopped the xDrip session, change the transmitter ID to your G7 session in progress.  
After establishing connectivity to G7, wait for another read cycle so that the backfill is completed.  You will see that you will get a 24-hour backfill even though you have had 3 hours of readings from G6.  So, you will end up with an overlap.  
  
 **Tests**  
All tests were run on an Android 11 test phone.  

1- Establishing connectivity to a G7 after a fresh install results in a 24-hour backfill.  
2- Establishing connectivity to a G6 after a fresh install results in a 3-hour backfill.
3- Establishing connectivity to a G7 after having stopped a G6 session, a backfill takes place to fill only the empty time after the last G6 reading.  In other words, it does not cause an overlap.  