### PR TITLE
Disable "Restart Sensor" when incompatible

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -1725,6 +1725,12 @@ public class Ob1G5StateMachine {
                     UserError.Log.uel(TAG, "Dex Native mode enabled.  For your device, non-native mode is either not possible or not recommended.");
                     JoH.showNotification("Enabled Native", "Native mode enabled", null, Constants.G6_DEFAULTS_MESSAGE, false, true, false);
                 }
+                if (FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) { // If we are using a G7 or G6 Firefly (mod or not)
+                    if (Pref.getBooleanDefaultFalse("ob1_g5_restart_sensor") && !Home.get_engineering_mode()) { // If restart is enabled, not in engineering mode
+                        Pref.setBoolean("ob1_g5_restart_sensor", false); // Disable restart
+                        UserError.Log.uel(TAG, "Restart sensor disabled.  You cannot simply restart sensor with your device.");
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -1722,13 +1722,13 @@ public class Ob1G5StateMachine {
                 } else if (!onlyUsingNativeMode() && !Home.get_engineering_mode()) {
                     // TODO revisit this now that there is scaling
                     setG6Defaults();
-                    UserError.Log.uel(TAG, "Dex Native mode enabled.  For your device, non-native mode is either not possible or not recommended.");
+                    UserError.Log.wtf(TAG, "Dex Native mode enabled.  For your device, non-native mode is either not possible or not recommended.");
                     JoH.showNotification("Enabled Native", "Native mode enabled", null, Constants.G6_DEFAULTS_MESSAGE, false, true, false);
                 }
                 if (FirmwareCapability.isTransmitterRawIncapable(getTransmitterID())) { // If we are using a G7 or G6 Firefly (mod or not)
                     if (Pref.getBooleanDefaultFalse("ob1_g5_restart_sensor") && !Home.get_engineering_mode()) { // If restart is enabled, not in engineering mode
                         Pref.setBoolean("ob1_g5_restart_sensor", false); // Disable restart
-                        UserError.Log.uel(TAG, "Restart sensor disabled.  You cannot simply restart sensor with your device.");
+                        UserError.Log.wtf(TAG, "Restart sensor disabled.  You cannot simply restart sensor with your device.");
                     }
                 }
             }


### PR DESCRIPTION
This PR will disable `Restart Sensor` for devices that cannot be restarted.  
  
Without this, an inexperienced user may enable the setting and when the time comes for the next sensor, it may take up to half an hour for their restart attempt to fail and be obvious that something may be wrong.  
  
I have also seen a case where the failure would happen in just a few minutes, but it would attempt another restart.
The user had posted on facebook asking for help.
It took quite a while to realize that they had enabled restart sensor for a new G6.  

I cannot think of any case that would be at a disadvantage after including this.  Can you think of a scenario where this PR would disable restart sensor where it would actually be possible?  

G5 and very old G6 devices are the only ones that can benefit from enabling restart sensor.  This PR does not change that.  They will still be able to enable, and use, restart.