### PR TITLE
Retire allow OB1 initiate bonding

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -1785,7 +1785,7 @@ public class Ob1G5CollectionService extends G5BaseService {
 
 
     private boolean getInitiateBondingFlag() {
-        return Pref.getBoolean("ob1_initiate_bonding_flag", true);
+        return true; // There is no reason not to initiate bonding
     }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -151,6 +151,7 @@ public class IdempotentMigrations {
         Pref.setBoolean("always_get_new_keys", true);
         Pref.setBoolean("run_ble_scan_constantly", false);
         Pref.setBoolean("run_G5_ble_tasks_on_uithread", false);
+        Pref.setBoolean("ob1_initiate_bonding_flag", true);
     }
     private static void legacySettingsMoveLanguageFromNoToNb() {
         // Check if the user's language preference is set to "no"

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -400,12 +400,6 @@
                     android:key="ob1_special_pairing_workaround"
                     android:summary="Some Samsung devices can have an error where they lose the pairing information. This attempts to work around the issue."
                     android:title="@string/special_pairing_workaround" />
-                <CheckBoxPreference
-                    android:defaultValue="true"
-                    android:key="ob1_initiate_bonding_flag"
-                    android:summary="@string/summary_ob1_initiate_bonding_flag"
-                    android:title="@string/title_ob1_initiate_bonding_flag"
-                    />
                 <EditTextPreference
                     android:defaultValue=""
                     android:inputType="number"


### PR DESCRIPTION
This PR will remove another setting from the Dex Settings page.  

I cannot think of a scenario when one may need to disable this.  Of course there is a case where you don't intend to connect to a device.  But, why would you enter the transmitter ID if you don't intend to connect.  I mean you can avoid xDrip attempting to connect by just disabling collector.  

Considering there is an alternative way to accomplish the same thing, I hope you allow this setting to be removed.
A considerable percentage of the requests for help is related to wrong settings on this page.
Even though we have a guide that shows the correct settings, incorrect settings still appear on facebook requests for help.
So, I wish to minimize the number of settings on this page.  

Is there a scenario in which we may need to disable this setting?

Thanks