### PR TITLE
Don't translate Last Connected

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
@@ -751,27 +751,31 @@ public class JoH {
         return niceTimeScalar(-msSince(t));
     }
 
-    // temporary
     public static String niceTimeScalar(long t) {
-        String unit = xdrip.getAppContext().getString(R.string.unit_second);
+        return niceTimeScalar(t, false); // Calling the method with forceEn set to false so that the chosen language is used.
+    }
+
+    // temporary
+    public static String niceTimeScalar(long t, boolean forceEn) { // English will be used regardless if forceEn is true
+        String unit = forceEn? "second" : xdrip.getAppContext().getString(R.string.unit_second);
         t = t / 1000;
-        if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_seconds);
+        if (t != 1) unit = forceEn? "seconds" : xdrip.getAppContext().getString(R.string.unit_seconds);
         if (t > 59) {
-            unit = xdrip.getAppContext().getString(R.string.unit_minute);
+            unit = forceEn? "minute" : xdrip.getAppContext().getString(R.string.unit_minute);
             t = t / 60;
-            if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_minutes);
+            if (t != 1) unit = forceEn? "minutes" : xdrip.getAppContext().getString(R.string.unit_minutes);
             if (t > 59) {
-                unit = xdrip.getAppContext().getString(R.string.unit_hour);
+                unit = forceEn? "hour" : xdrip.getAppContext().getString(R.string.unit_hour);
                 t = t / 60;
-                if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_hours);
+                if (t != 1) unit = forceEn? "hours" : xdrip.getAppContext().getString(R.string.unit_hours);
                 if (t > 24) {
-                    unit = xdrip.getAppContext().getString(R.string.unit_day);
+                    unit = forceEn? "day" : xdrip.getAppContext().getString(R.string.unit_day);
                     t = t / 24;
-                    if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_days);
+                    if (t != 1) unit = forceEn? "days" : xdrip.getAppContext().getString(R.string.unit_days);
                     if (t > 28) {
-                        unit = xdrip.getAppContext().getString(R.string.unit_week);
+                        unit = forceEn? "week" :  xdrip.getAppContext().getString(R.string.unit_week);
                         t = t / 7;
-                        if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_weeks);
+                        if (t != 1) unit = forceEn? "weeks" : xdrip.getAppContext().getString(R.string.unit_weeks);
                     }
                 }
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -2172,7 +2172,9 @@ public class Ob1G5CollectionService extends G5BaseService {
         }
 
         if (static_last_connected > 0) {
-            l.add(new StatusItem("Last Connected", niceTimeScalar(msSince(static_last_connected)) + " ago"));
+            l.add(new StatusItem("Last Connected", niceTimeScalar(msSince(static_last_connected), true) + " ago")); // English is forced to avoid translating
+            // This parameter is extremely important when troubleshooting connectivity.  Let's keep it in English so that those helping won't have to
+            // translate back, which could possible cause errors.
         }
 
         if ((!lastState.startsWith("Service Stopped")) && (!lastState.startsWith("Not running")))


### PR DESCRIPTION
This is what is shown on the Dex status page when a language other than English is selected.

![Screenshot_20240727-141047](https://github.com/user-attachments/assets/85ab4636-2ce0-4363-b5e4-91e86cc7e4b7)
  
As you can see some items are translated and some aren't.  
We don't translate anything in the logs.  For the same reason, we also should not translate items on the status page that are needed for helping someone troubleshoot.  
  
The last connected item is very critical.
If last connected is less than 5 minutes, it is a good sign.  if it is not, there could be a connectivity issue.  When there is a problem, this parameter is one of the first I need to see when helping someone troubleshoot.  
But, if it is translated, I will have to translate it back.  
  
This PR changes the behavior such that last connected on the Dex status page is not translated as you can see here:  
![Screenshot_20240727-142102](https://github.com/user-attachments/assets/72f7837e-35a9-4b7c-b8d0-7a602d3686dd)
  
---  
  
My first attempt at this was very primitive: https://github.com/NightscoutFoundation/xDrip/pull/3303  
I have now added an optional parameter to the method.  
All the existing calls go to the method without the new parameter resulting in translation as they did before this PR.  
Only one call to the method, on the Dex status page, sets the new parameter to true forcing the language to be English. 