### PR TITLE
Handling Temp Basal events in NightscoutTreatments.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
@@ -125,8 +125,6 @@ public class NightscoutFollow {
             try {
                 List<Double> profile = session.currentProfile.getDefaultBasalProfile();
 
-                UserError.Log.uel(TAG, "Profile: " + profile.toString());
-
                 BasalProfile.save(BasalProfile.getActiveRateName(), profile);
                 NightscoutBasalRate.setProfile(profile);
             } catch (Exception e) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
@@ -110,7 +110,9 @@ public class NightscoutFollow {
                     NightscoutFollowService.updateTreatmentDownloaded();
                 }
 
-                NightscoutBasalRate.setTreatments(response);
+                if (basalRateDownloadEnabled()) {
+                    NightscoutBasalRate.setTreatments(response);
+                }
             } catch (Exception e) {
                 msg("Treatments: " + e);
             }
@@ -144,7 +146,7 @@ public class NightscoutFollow {
                 msg("Nightscout follow entries error: " + e);
             }
 
-            if (profileDownloadEnabled()) {
+            if (basalRateDownloadEnabled()) {
                 if (JoH.ratelimit("nsfollow-profile-download", 60)) {
                     try {
                         getService().getProfiles(session.url.getHashedSecret()).enqueue(session.profilesCallback);
@@ -155,7 +157,7 @@ public class NightscoutFollow {
                 }
             }
 
-            if (treatmentDownloadEnabled() || profileDownloadEnabled()) {
+            if (treatmentDownloadEnabled() || basalRateDownloadEnabled()) {
                 if (JoH.ratelimit("nsfollow-treatment-download", 60)) {
                     try {
                         getService().getTreatments(session.url.getHashedSecret()).enqueue(session.treatmentsCallback);
@@ -178,8 +180,8 @@ public class NightscoutFollow {
         return Pref.getBooleanDefaultFalse("nsfollow_download_treatments");
     }
 
-    static boolean profileDownloadEnabled() {
-        return Pref.getBoolean("nsfollow_download_profile", true);
+    static boolean basalRateDownloadEnabled() {
+        return Pref.getBoolean("nsfollow_download_basalrate", true);
     }
 
     public static final TypeAdapter<Number> UNRELIABLE_INTEGER = new TypeAdapter<Number>() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -44,7 +44,7 @@ import static com.eveningoutpost.dexdrip.xdrip.gs;
 public class NightscoutFollowService extends ForegroundService {
 
     private static final String TAG = "NightscoutFollow";
-    private static final long SAMPLE_PERIOD = DEXCOM_PERIOD;
+    private static final long SAMPLE_PERIOD = 60_000;
 
     protected static volatile String lastState = "";
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -44,7 +44,8 @@ import static com.eveningoutpost.dexdrip.xdrip.gs;
 public class NightscoutFollowService extends ForegroundService {
 
     private static final String TAG = "NightscoutFollow";
-    private static final long SAMPLE_PERIOD = 60_000;
+    private static final long SAMPLE_PERIOD = DEXCOM_PERIOD;
+    private static final long FREQUENT_PERIOD = 60_000;
 
     protected static volatile String lastState = "";
 
@@ -65,6 +66,10 @@ public class NightscoutFollowService extends ForegroundService {
         }
         buggySamsung.evaluate(wakeup_time);
         wakeup_time = 0;
+    }
+
+    static long connectPeriod() {
+        return Pref.getBoolean("nsfollow_download_per_minute", false) ? FREQUENT_PERIOD : SAMPLE_PERIOD;
     }
 
     @Override
@@ -88,7 +93,7 @@ public class NightscoutFollowService extends ForegroundService {
             if (lastBg != null) {
                 lastBgTime = lastBg.timestamp;
             }
-            if (lastBg == null || JoH.msSince(lastBg.timestamp) > SAMPLE_PERIOD) {
+            if (lastBg == null || JoH.msSince(lastBg.timestamp) > connectPeriod()) {
                 if (JoH.ratelimit("last-ns-follow-poll", 5)) {
                     Inevitable.task("NS-Follow-Work", 200, () -> {
                         NightscoutFollow.work(true);
@@ -130,7 +135,7 @@ public class NightscoutFollowService extends ForegroundService {
         final long last = lastBg != null ? lastBg.timestamp : 0;
 
         final long grace = Constants.SECOND_IN_MS * 10;
-        final long next = Anticipate.next(JoH.tsl(), last, SAMPLE_PERIOD, grace) + grace;
+        final long next = Anticipate.next(JoH.tsl(), last, connectPeriod(), grace) + grace;
         wakeup_time = next;
         UserError.Log.d(TAG, "Anticipate next: " + JoH.dateTimeText(next) + "  last: " + JoH.dateTimeText(last));
 
@@ -161,10 +166,10 @@ public class NightscoutFollowService extends ForegroundService {
         Highlight ageOfLastBgPollHighlight = Highlight.NORMAL;
         if (bgReceiveDelay > 0) {
             ageOfBgLastPoll = JoH.niceTimeScalar(bgReceiveDelay);
-            if (bgReceiveDelay - lag > SAMPLE_PERIOD / 2) {
+            if (bgReceiveDelay - lag > connectPeriod() / 2) {
                 ageOfLastBgPollHighlight = Highlight.BAD;
             }
-            if (bgReceiveDelay - lag > SAMPLE_PERIOD * 2) {
+            if (bgReceiveDelay - lag > connectPeriod() * 2) {
                 ageOfLastBgPollHighlight = Highlight.CRITICAL;
             }
         }
@@ -175,7 +180,7 @@ public class NightscoutFollowService extends ForegroundService {
         if (lastBg != null) {
             long age = JoH.msSince(lastBg.timestamp);
             ageLastBg = JoH.niceTimeScalar(age);
-            if (age > SAMPLE_PERIOD + hightlightGrace + lag) {
+            if (age > connectPeriod() + hightlightGrace + lag) {
                 bgAgeHighlight = Highlight.BAD;
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/Session.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/Session.java
@@ -1,6 +1,7 @@
 package com.eveningoutpost.dexdrip.cgm.nsfollow;
 
 import com.eveningoutpost.dexdrip.cgm.nsfollow.messages.Entry;
+import com.eveningoutpost.dexdrip.cgm.nsfollow.messages.Profile;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.utils.NightscoutUrl;
 
 import java.util.List;
@@ -20,12 +21,14 @@ public class Session {
     public NightscoutUrl url;
     public BaseCallback<List<Entry>> entriesCallback;
     public BaseCallback<ResponseBody> treatmentsCallback;
+    public BaseCallback<List<Profile>> profilesCallback;
 
 
     // most recent set of entries
     public List<Entry> entries;
     // most recent treatments raw json
     public ResponseBody treatments;
+    public Profile currentProfile;
 
 
     // populate session data from a response object which could be any supported type
@@ -35,6 +38,11 @@ public class Session {
 
             if (!someList.isEmpty() && someList.get(0) instanceof Entry) {
                 entries = (List<Entry>)object;
+            }
+            if (!someList.isEmpty() && someList.get(0) instanceof Profile) {
+                List<Profile> list = (List<Profile>)object;
+                list.sort(Profile::compare);
+                currentProfile = list.get(0);
             }
 
         } else if (object instanceof ResponseBody) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/BasalProfileEntry.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/BasalProfileEntry.java
@@ -1,0 +1,20 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow.messages;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.Locale;
+
+public class BasalProfileEntry {
+    @Expose
+    public String time; // 01:00 etc.
+    @Expose
+    public int timeAsSeconds;
+    @Expose
+    public double value;
+
+    public BasalProfileEntry(int timeAsSeconds, double value) {
+        this.timeAsSeconds = timeAsSeconds;
+        this.value = value;
+        this.time = String.format((Locale) null, "%02d:00", timeAsSeconds / 3600);
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/Profile.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/Profile.java
@@ -24,7 +24,7 @@ public class Profile extends BaseMessage {
     }
 
     public List<Double> getDefaultBasalProfile() {
-        SingleProfile singleProfile = store.get("defaultProfile");
+        SingleProfile singleProfile = store.get(defaultProfile);
 
         if (singleProfile == null) {
             return new ArrayList<>();
@@ -33,8 +33,6 @@ public class Profile extends BaseMessage {
         ArrayList<BasalProfileEntry> profileFromNS = singleProfile.basal;
 
         int oneHourAsSeconds = 3600;
-
-        int size = profileFromNS.size();
 
         for (int i = 0; profileFromNS.size() >= i + 1; i++) {
             int nextIndex = i + 1;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/Profile.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/Profile.java
@@ -1,0 +1,60 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow.messages;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Profile extends BaseMessage {
+    @Expose
+    public String _id;
+    @Expose
+    public String defaultProfile;
+    @Expose
+    public String startDate; // ISO date time
+    @Expose
+    public String created_at; // ISO date time
+    @Expose
+    public HashMap<String, SingleProfile> store;
+
+    public static int compare(Profile a, Profile b) {
+        return b.startDate.compareTo(a.startDate);
+    }
+
+    public List<Double> getDefaultBasalProfile() {
+        SingleProfile singleProfile = store.get("defaultProfile");
+
+        if (singleProfile == null) {
+            return new ArrayList<>();
+        }
+
+        ArrayList<BasalProfileEntry> profileFromNS = singleProfile.basal;
+
+        int oneHourAsSeconds = 3600;
+
+        int size = profileFromNS.size();
+
+        for (int i = 0; profileFromNS.size() >= i + 1; i++) {
+            int nextIndex = i + 1;
+
+            if (profileFromNS.size() <= nextIndex) {
+                break;
+            }
+
+            BasalProfileEntry profileEntry = profileFromNS.get(i);
+            BasalProfileEntry nextProfileEntry = profileFromNS.get(i + 1);
+
+            int nextTimeAsSeconds = profileEntry.timeAsSeconds + oneHourAsSeconds;
+
+            if (nextProfileEntry.timeAsSeconds > nextTimeAsSeconds) {
+                profileFromNS.add(nextIndex, new BasalProfileEntry(nextTimeAsSeconds, profileEntry.value));
+            }
+        }
+
+        return profileFromNS.stream().map(x -> x.value)
+                .collect(Collectors.toList());
+    }
+}
+

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/SingleProfile.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/SingleProfile.java
@@ -1,0 +1,10 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow.messages;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.ArrayList;
+
+public class SingleProfile {
+    @Expose
+    public ArrayList<BasalProfileEntry> basal;
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/BasalProfile.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/BasalProfile.java
@@ -9,6 +9,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -33,6 +35,56 @@ public class BasalProfile {
 
     public static List<Float> load(final String ref) {
         return JsonStringToFloatList(Pref.getString(getPrefix(ref), ""));
+    }
+
+
+    static int getHourOfTheDay(long timestamp) {
+        Calendar calendar = Calendar.getInstance();
+
+        calendar.setTimeInMillis(timestamp);
+
+        return calendar.get(Calendar.HOUR_OF_DAY);
+    }
+
+    static int getDifferenceInFullDays(long timestampA, long timestampB) {
+        Calendar calendarA = Calendar.getInstance();
+        Calendar calendarB = Calendar.getInstance();
+
+        calendarA.setTimeInMillis(timestampA);
+        calendarB.setTimeInMillis(timestampB);
+
+        return calendarB.get(Calendar.DAY_OF_YEAR) - calendarA.get(Calendar.DAY_OF_YEAR) + 1;
+    }
+
+    public static List<BasalProfileEntryTimed> loadForTime(final String ref, long startTime, long endTime) {
+        final List<Float> profile = load(ref);
+
+        int startHour = getHourOfTheDay(startTime);
+        int endHour = getHourOfTheDay(endTime);
+
+        int fullDays = getDifferenceInFullDays(startTime, endTime);
+
+        List<Float> profileForAllDays = new ArrayList<>();
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(startTime);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+        for (int i = 0; i < fullDays; i++) {
+            profileForAllDays.addAll(profile);
+        }
+
+        List<Float> sublist = profileForAllDays.subList(startHour, profileForAllDays.size() - 24 + endHour + 1);
+        List<BasalProfileEntryTimed> timed = new ArrayList<>();
+
+        sublist.forEach(entry -> {
+            timed.add(new BasalProfileEntryTimed(entry, calendar.getTimeInMillis()));
+            calendar.add(Calendar.HOUR_OF_DAY, 1);
+        });
+
+        return timed;
     }
 
     public static String getActiveRateName() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/BasalProfile.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/BasalProfile.java
@@ -56,28 +56,28 @@ public class BasalProfile {
         return calendarB.get(Calendar.DAY_OF_YEAR) - calendarA.get(Calendar.DAY_OF_YEAR) + 1;
     }
 
-    public static List<BasalProfileEntryTimed> loadForTime(final String ref, long startTime, long endTime) {
+    public static List<BasalProfileEntryTimed> loadForTimeSpan(final String ref, long startTime, long endTime) {
         final List<Float> profile = load(ref);
-
-        int startHour = getHourOfTheDay(startTime);
-        int endHour = getHourOfTheDay(endTime);
 
         int fullDays = getDifferenceInFullDays(startTime, endTime);
 
         List<Float> profileForAllDays = new ArrayList<>();
+
+        for (int i = 0; i < fullDays; i++) {
+            profileForAllDays.addAll(profile);
+        }
+
+        int startHour = getHourOfTheDay(startTime);
+        int endHour = getHourOfTheDay(endTime);
+
+        List<Float> sublist = profileForAllDays.subList(startHour, profileForAllDays.size() - 24 + endHour);
+        List<BasalProfileEntryTimed> timed = new ArrayList<>();
 
         Calendar calendar = Calendar.getInstance();
         calendar.setTimeInMillis(startTime);
         calendar.set(Calendar.MINUTE, 0);
         calendar.set(Calendar.SECOND, 0);
         calendar.set(Calendar.MILLISECOND, 0);
-
-        for (int i = 0; i < fullDays; i++) {
-            profileForAllDays.addAll(profile);
-        }
-
-        List<Float> sublist = profileForAllDays.subList(startHour, profileForAllDays.size() - 24 + endHour + 1);
-        List<BasalProfileEntryTimed> timed = new ArrayList<>();
 
         sublist.forEach(entry -> {
             timed.add(new BasalProfileEntryTimed(entry, calendar.getTimeInMillis()));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/BasalProfileEntryTimed.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/BasalProfileEntryTimed.java
@@ -1,0 +1,11 @@
+package com.eveningoutpost.dexdrip.profileeditor;
+
+public class BasalProfileEntryTimed {
+    public Float absolute = null;
+    public Long timestamp = null;
+
+    BasalProfileEntryTimed(Float absolute, Long timestamp) {
+        this.absolute = absolute;
+        this.timestamp = timestamp;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -34,6 +34,8 @@ import com.eveningoutpost.dexdrip.models.StepCounter;
 import com.eveningoutpost.dexdrip.models.Treatments;
 import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.R;
+import com.eveningoutpost.dexdrip.profileeditor.BasalProfile;
+import com.eveningoutpost.dexdrip.profileeditor.BasalProfileEntryTimed;
 import com.eveningoutpost.dexdrip.services.ActivityRecognizedService;
 import com.eveningoutpost.dexdrip.calibrations.CalibrationAbstract;
 import com.eveningoutpost.dexdrip.calibrations.PluggableCalibration;
@@ -340,13 +342,14 @@ public class BgGraphBuilder {
             final float yscale = doMgdl ? (float) Constants.MMOLL_TO_MGDL : 1f;
 
             final List<APStatus> aplist = APStatus.latestForGraph(2000, loaded_start, loaded_end);
+            final List<BasalProfileEntryTimed> profile = BasalProfile.loadForTime(BasalProfile.getActiveRateName(), loaded_start, loaded_end);
 
             if (aplist.size() > 0) {
 
                 // divider line
 
                 final Line dividerLine = new Line();
-                dividerLine.setTag("tbr"); // not quite true
+                dividerLine.setTag("basal rate");
                 dividerLine.setHasPoints(false);
                 dividerLine.setHasLines(true);
                 dividerLine.setStrokeWidth(1);
@@ -356,24 +359,47 @@ public class BgGraphBuilder {
                 dividerLine.setHasPoints(false);
 
                 final float one_hundred_percent = (100 * yscale) / 100f;
-                final List<PointValue> divider_points = new ArrayList<>(2);
-                divider_points.add(new HPointValue(loaded_start / FUZZER, one_hundred_percent));
+                final float one_hundred_percent_as_absolute = profile.stream().map(x -> x.absolute).max(Float::compareTo).orElse(one_hundred_percent);
+                final List<PointValue> divider_points = new ArrayList<>(profile.size());
+
+                float last_absolute = -1;
+                float last_ypos = -1;
+                int count = profile.size();
+
+                for (BasalProfileEntryTimed item : profile) {
+                    if (--count == 0 || (item.absolute != last_absolute)) {
+                        if (last_ypos != -1) {
+                            divider_points.add(new HPointValue((double) item.timestamp / FUZZER, last_ypos));
+                        }
+
+                        final float this_ypos = (Math.min(item.absolute, 5 * one_hundred_percent_as_absolute) * yscale) / one_hundred_percent_as_absolute; // capped at 500%
+                        divider_points.add(new HPointValue((double) item.timestamp / FUZZER, this_ypos));
+
+                        last_absolute = item.absolute;
+                        last_ypos = this_ypos;
+                    }
+                }
+
+                if (last_ypos != -1) {
+                    divider_points.add(new HPointValue((double) (profile.get(profile.size() - 1).timestamp + 60 * 60 + 1000) / FUZZER, last_ypos));
+                }
+
                 dividerLine.setPointRadius(0);
-                divider_points.add(new HPointValue(loaded_end / FUZZER, one_hundred_percent));
                 dividerLine.setValues(divider_points);
+
                 basalLines.add(dividerLine);
 
                 final List<PointValue> points = new ArrayList<>(aplist.size());
 
-                int last_percent = -1;
+                double last_basal_absolute = -1;
+                count = aplist.size();
 
-                int count = aplist.size();
                 for (APStatus item : aplist) {
-                    if (--count == 0 || (item.basal_percent != last_percent)) {
-                        final float this_ypos = (Math.min(item.basal_percent, 500) * yscale) / 100f; // capped at 500%
+                    if (--count == 0 || (item.basal_absolute != last_basal_absolute)) {
+                        final double this_ypos = (Math.min(item.basal_absolute, 5 * one_hundred_percent_as_absolute) * yscale) / one_hundred_percent_as_absolute; // capped at 500%
                         points.add(new HPointValue((double) item.timestamp / FUZZER, this_ypos));
 
-                        last_percent = item.basal_percent;
+                        last_basal_absolute = item.basal_absolute;
                     }
                 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -342,7 +342,7 @@ public class BgGraphBuilder {
             final float yscale = doMgdl ? (float) Constants.MMOLL_TO_MGDL : 1f;
 
             final List<APStatus> aplist = APStatus.latestForGraph(2000, loaded_start, loaded_end);
-            final List<BasalProfileEntryTimed> profile = BasalProfile.loadForTime(BasalProfile.getActiveRateName(), loaded_start, loaded_end);
+            final List<BasalProfileEntryTimed> profile = BasalProfile.loadForTimeSpan(BasalProfile.getActiveRateName(), loaded_start, loaded_end);
 
             if (aplist.size() > 0) {
 
@@ -381,7 +381,7 @@ public class BgGraphBuilder {
                 }
 
                 if (last_ypos != -1) {
-                    divider_points.add(new HPointValue((double) (profile.get(profile.size() - 1).timestamp + 60 * 60 + 1000) / FUZZER, last_ypos));
+                    divider_points.add(new HPointValue((double) Calendar.getInstance().getTimeInMillis() / FUZZER, last_ypos));
                 }
 
                 dividerLine.setPointRadius(0);
@@ -392,6 +392,7 @@ public class BgGraphBuilder {
                 final List<PointValue> points = new ArrayList<>(aplist.size());
 
                 double last_basal_absolute = -1;
+                double last_basal_ypos = -1;
                 count = aplist.size();
 
                 for (APStatus item : aplist) {
@@ -400,7 +401,12 @@ public class BgGraphBuilder {
                         points.add(new HPointValue((double) item.timestamp / FUZZER, this_ypos));
 
                         last_basal_absolute = item.basal_absolute;
+                        last_basal_ypos = this_ypos;
                     }
+                }
+
+                if (last_basal_ypos != -1) {
+                    points.add(new HPointValue((double) Calendar.getInstance().getTimeInMillis() / FUZZER, last_basal_ypos));
                 }
 
                 final Line line = new Line(points);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutBasalRate.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutBasalRate.java
@@ -1,0 +1,186 @@
+package com.eveningoutpost.dexdrip.utilitymodels;
+
+import com.eveningoutpost.dexdrip.NewDataObserver;
+import com.eveningoutpost.dexdrip.models.APStatus;
+import com.eveningoutpost.dexdrip.models.DateUtil;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.models.UserError;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+public class NightscoutBasalRate {
+    private static final boolean d = true;
+    private static final String TAG = "NightscoutBasalRate";
+    private static final int requiredSegments = 24;
+    private static final int minimumProfileBRDuration = 10000;
+
+    private static ArrayList<APStatusEntry> statusEntries = new ArrayList<>();
+    private static List<Double> profile = new ArrayList<>();
+
+    public static void setTreatments(final String response) throws Exception {
+        final JSONArray jsonArray = new JSONArray(response);
+
+        for (int i = 0; i < jsonArray.length(); i++) {
+            final JSONObject tr = (JSONObject) jsonArray.get(i);
+            final String etype = tr.has("eventType") ? tr.getString("eventType") : "<null>";
+
+            if (!etype.equals("Temp Basal")) {
+                continue;
+            }
+
+            Double absolute = null;
+            Long durationInMilliseconds = null;
+
+            try {
+                absolute = tr.has("absolute") ? tr.getDouble("absolute") : null;
+            } catch (JSONException e) {
+                UserError.Log.e(TAG, "Could not parse absolute: " + tr.get("absolute"));
+            }
+
+            try {
+                durationInMilliseconds = tr.has("durationInMilliseconds") ? tr.getLong("durationInMilliseconds") : null;
+            } catch (JSONException e) {
+                UserError.Log.e(TAG, "Could not parse durationInMilliseconds: " + tr.get("durationInMilliseconds"));
+            }
+
+            if (absolute != null && durationInMilliseconds != null) {
+                final long timestamp = DateUtil.tolerantFromISODateString(tr.getString("created_at")).getTime();
+
+                if (d) {
+                    UserError.Log.ueh(TAG, "New Treatment from Nightscout: Temp Basal: " + absolute + " Event type: " + etype + " timestamp: " + JoH.dateTimeText(timestamp));
+                }
+
+                statusEntries.add(new APStatusEntry(absolute, timestamp, durationInMilliseconds, false));
+            }
+        }
+
+        tryProcessBasalRate();
+    }
+
+    public static void setProfile(List<Double> loadedProfile) {
+        profile = loadedProfile;
+
+        tryProcessBasalRate();
+    }
+
+    public static void tryProcessBasalRate() {
+        if (statusEntries.isEmpty() || profile.isEmpty()) {
+            if (d) {
+                UserError.Log.ueh(TAG, "Trying to process Nightscout basal rate, but:" + (statusEntries.isEmpty() ? " - treatments are still empty" : "") + (profile.isEmpty() ? " - profile is still empty" : ""));
+            }
+            return;
+        }
+
+        long nowInMilliseconds = System.currentTimeMillis();
+
+        if (d) {
+            UserError.Log.ueh(TAG, "Process Nightscout basal rate with " + statusEntries.size() + " new tbr entries and " + profile.size() + " profile segments.");
+        }
+
+        statusEntries.sort(APStatusEntry::compare);
+
+        for (int i = 0; statusEntries.size() >= i + 1; i++) {
+            int nextIndex = i + 1;
+
+            boolean hasNext = nextIndex < statusEntries.size();
+
+            APStatusEntry currentEntry = statusEntries.get(i);
+            APStatusEntry nextEntry = hasNext ? statusEntries.get(nextIndex) : null;
+
+            long currentEntryFinishTimestamp = currentEntry.timestamp + currentEntry.durationInMilliseconds;
+
+            if (currentEntryFinishTimestamp < nowInMilliseconds && (nextEntry == null || nextEntry.timestamp > currentEntryFinishTimestamp)) {
+                APStatusEntry nextSegment = getNextSegment(
+                    currentEntryFinishTimestamp,
+                    profile,
+                    Math.min(nowInMilliseconds, nextEntry != null ? nextEntry.timestamp : Long.MAX_VALUE)
+                );
+
+                if (nextSegment.durationInMilliseconds < minimumProfileBRDuration) {
+                    continue;
+                }
+
+                if (d) {
+                    UserError.Log.ueh(TAG, "Adding next profile segment: " + nextSegment.absolute + "U, timestamp: " + JoH.dateTimeText(nextSegment.timestamp) + ", duration: " + nextSegment.durationInMilliseconds + "ms");
+                }
+
+                statusEntries.add(nextIndex, nextSegment);
+            }
+        }
+
+        // TODO: Should not be needed
+        statusEntries.sort(APStatusEntry::compare);
+
+        statusEntries.forEach(entry -> {
+            APStatus.createEfficientRecord(entry.timestamp, entry.absolute);
+            NewDataObserver.newExternalStatus(false);
+        });
+
+        statusEntries = new ArrayList<>();
+        profile = new ArrayList<>();
+    }
+
+    static APStatusEntry getNextSegment(long lastFinishTimestamp, List<Double> profile, long nextTimestamp) {
+        int hour = getHourOfTheDay(lastFinishTimestamp);
+        double absolute = profile.get(hour);
+        long finishTimestamp = getHourFinishTimestamp(lastFinishTimestamp, nextTimestamp);
+
+        long duration = finishTimestamp - lastFinishTimestamp;
+
+        return new APStatusEntry(absolute, lastFinishTimestamp, duration, true);
+    }
+
+    static int getHourOfTheDay(long timestamp) {
+        Calendar calendar = Calendar.getInstance();
+
+        calendar.setTimeInMillis(timestamp);
+
+        return calendar.get(Calendar.HOUR_OF_DAY);
+    }
+
+    static long getHourFinishTimestamp(long timestamp, long nextTimestamp) {
+        Calendar calendar = Calendar.getInstance();
+
+        calendar.setTimeInMillis(timestamp);
+        calendar.add(Calendar.HOUR, 1);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        calendar.add(Calendar.MILLISECOND, -1);
+
+        return Math.min(calendar.getTimeInMillis(), nextTimestamp);
+    }
+}
+
+class APStatusEntry {
+    double absolute;
+    long timestamp;
+    // For debugging
+    long durationInMilliseconds;
+    String timestampText;
+    String timestampEndText;
+    boolean isProfile;
+    boolean isTBR;
+
+    public APStatusEntry(double absolute, long timestamp, long durationInMilliseconds, boolean isProfile) {
+        this.absolute = absolute;
+        this.timestamp = timestamp;
+        this.durationInMilliseconds = durationInMilliseconds;
+
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault());
+
+        this.timestampText = df.format(new Date(timestamp));
+        this.timestampEndText = df.format(new Date(timestamp + durationInMilliseconds));
+        this.isProfile = isProfile;
+        this.isTBR = !isProfile;
+    }
+
+    public static int compare(APStatusEntry a, APStatusEntry b) {
+        return (int) (a.timestamp - b.timestamp);
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutBasalRate.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutBasalRate.java
@@ -14,7 +14,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 public class NightscoutBasalRate {
-    private static final boolean d = true;
+    private static final boolean d = false;
     private static final String TAG = "NightscoutBasalRate";
     private static final int requiredSegments = 24;
     private static final int minimumProfileBRDuration = 10000;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutBasalRate.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutBasalRate.java
@@ -51,8 +51,18 @@ public class NightscoutBasalRate {
             if (absolute != null && durationInMilliseconds != null) {
                 final long timestamp = DateUtil.tolerantFromISODateString(tr.getString("created_at")).getTime();
 
+                APStatus lastAPStatus = APStatus.last();
+
+                if (lastAPStatus != null && timestamp < lastAPStatus.timestamp) {
+                    if (d) {
+
+                        UserError.Log.ueh(TAG, "APStatus exists: - value: " + lastAPStatus.basal_absolute + " - timestamp: " + JoH.dateTimeText(lastAPStatus.timestamp) + " Omitting: - value: " + absolute + " - timestamp: " + JoH.dateTimeText(timestamp));
+                    }
+                    continue;
+                }
+
                 if (d) {
-                    UserError.Log.ueh(TAG, "New Treatment from Nightscout: Temp Basal: " + absolute + " Event type: " + etype + " timestamp: " + JoH.dateTimeText(timestamp));
+                    UserError.Log.ueh(TAG, "New Temp Basal from Nightscout: - value: " + absolute + " - timestamp: " + JoH.dateTimeText(timestamp));
                 }
 
                 statusEntries.add(new APStatusEntry(absolute, timestamp, durationInMilliseconds, false));
@@ -112,9 +122,6 @@ public class NightscoutBasalRate {
                 statusEntries.add(nextIndex, nextSegment);
             }
         }
-
-        // TODO: Should not be needed
-        statusEntries.sort(APStatusEntry::compare);
 
         statusEntries.forEach(entry -> {
             APStatus.createEfficientRecord(entry.timestamp, entry.absolute);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1340,8 +1340,10 @@
     <string name="summary_nsfollow_download_treatments">Also download treatments from Nightscout as follower</string>
     <string name="title_nsfollow_download_treatments">Download Treatments</string>
     <string name="title_nsfollow_lag">Nightscout Follow delay</string>
-    <string name="summary_nsfollow_download_profile">Also download basal profile from Nightscout as follower</string>
-    <string name="title_nsfollow_download_profile">Download Basal Profile</string>
+    <string name="summary_nsfollow_download_basalrate">Download profile and TBR from Nightscout as follower (use with "Show Basal TBR" to see graph)</string>
+    <string name="title_nsfollow_download_basalrate">Download Basal Profile</string>
+    <string name="summary_nsfollow_download_per_minute">Download data from Nightscout every minute. Otherwise loads every 5 minutes.</string>
+    <string name="title_nsfollow_download_per_minute">Connect more frequently</string>
     <!-- Maybe we can use them later?
     <string name="title_clfollow_user">CareLink Username</string>
     <string name="summary_clfollow_user">CareLink login username</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1340,6 +1340,8 @@
     <string name="summary_nsfollow_download_treatments">Also download treatments from Nightscout as follower</string>
     <string name="title_nsfollow_download_treatments">Download Treatments</string>
     <string name="title_nsfollow_lag">Nightscout Follow delay</string>
+    <string name="summary_nsfollow_download_profile">Also download basal profile from Nightscout as follower</string>
+    <string name="title_nsfollow_download_profile">Download Basal Profile</string>
     <!-- Maybe we can use them later?
     <string name="title_clfollow_user">CareLink Username</string>
     <string name="summary_clfollow_user">CareLink login username</string>

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -196,7 +196,7 @@
             android:key="nsfollow_download_treatments_screen"
             android:title="@string/title_nsfollow_download_treatments">
             <CheckBoxPreference
-                android:defaultValue="true"
+                android:defaultValue="false"
                 android:key="nsfollow_download_treatments"
                 android:summary="@string/summary_nsfollow_download_treatments"
                 android:title="@string/title_nsfollow_download_treatments" />
@@ -208,9 +208,14 @@
                 android:title="@string/title_cloud_storage_api_download_from_xdrip" />
             <CheckBoxPreference
                 android:defaultValue="true"
-                android:key="nsfollow_download_profile"
-                android:summary="@string/summary_nsfollow_download_profile"
-                android:title="@string/title_nsfollow_download_profile" />
+                android:key="nsfollow_download_basalrate"
+                android:summary="@string/summary_nsfollow_download_basalrate"
+                android:title="@string/title_nsfollow_download_basalrate" />
+            <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="nsfollow_download_per_minute"
+                    android:summary="@string/summary_nsfollow_download_per_minute"
+                    android:title="@string/title_nsfollow_download_per_minute" />
         </PreferenceScreen>
         <ListPreference
             android:defaultValue="0"

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -196,7 +196,7 @@
             android:key="nsfollow_download_treatments_screen"
             android:title="@string/title_nsfollow_download_treatments">
             <CheckBoxPreference
-                android:defaultValue="false"
+                android:defaultValue="true"
                 android:key="nsfollow_download_treatments"
                 android:summary="@string/summary_nsfollow_download_treatments"
                 android:title="@string/title_nsfollow_download_treatments" />
@@ -206,6 +206,11 @@
                 android:key="cloud_storage_api_skip_download_from_xdrip"
                 android:summary="@string/summary_cloud_storage_api_download_from_xdrip"
                 android:title="@string/title_cloud_storage_api_download_from_xdrip" />
+            <CheckBoxPreference
+                android:defaultValue="true"
+                android:key="nsfollow_download_profile"
+                android:summary="@string/summary_nsfollow_download_profile"
+                android:title="@string/title_nsfollow_download_profile" />
         </PreferenceScreen>
         <ListPreference
             android:defaultValue="0"


### PR DESCRIPTION
This is a proposal of handling "Temp Basal" eventType entries from Nightscout.

I'm not Java-native, so NightscoutTreatment class might me the wrong place for it. Yet it's working fine as this class processes treatments anyway.

WIP - as we don't have NS profile yet. I plan to add support for it once I have the gist of how BasalProfile is working. For now there's a 0.15U base hardcoded.

I tested it on Nightscout follower flow. I have yet to test it when xDrip pushes data to Nightscout and loads treatments from it while AAPS loads profile.

![Screenshot_20240728_014342_xDrip+](https://github.com/user-attachments/assets/09b78ca5-4cf9-4e22-9d50-6dcb14369226)

I believe this PR will fix:
- https://github.com/NightscoutFoundation/xDrip/issues/895
- https://github.com/NightscoutFoundation/xDrip/issues/1593 - adds an ability to send temp basal vie aaps -> nightscout -> xdrip
