### PR TITLE
Add Cubot to the wake workaround list

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/BuggySamsung.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/BuggySamsung.java
@@ -71,7 +71,8 @@ public class BuggySamsung {
                 || Build.MANUFACTURER.toLowerCase().contains("xiaomi")
                 || Build.MANUFACTURER.toLowerCase().contains("oneplus")    // experimental test
                 || Build.MANUFACTURER.toLowerCase().contains("oppo")      // experimental test
-                || Build.MANUFACTURER.toLowerCase().contains("huawei");      // experimental test
+                || Build.MANUFACTURER.toLowerCase().contains("huawei")      // experimental test
+                || Build.MANUFACTURER.toLowerCase().contains("cubot");
     }
 
 }


### PR DESCRIPTION
Should we add this manufacturer to the list that can benefit from wake workaround?  
That's what this PR does.
Over the years, one of the phones that has been reported as having connectivity problems has been this.