### PR TITLE
Sensor expiry alert resolution increased to 1 decimal point

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
@@ -3,6 +3,7 @@ package com.eveningoutpost.dexdrip.alert;
 import static com.eveningoutpost.dexdrip.models.JoH.cancelNotification;
 import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalar;
 import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalarNatural;
+import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalarNaturalp1;
 import static com.eveningoutpost.dexdrip.models.JoH.showNotification;
 import static com.eveningoutpost.dexdrip.models.JoH.tsl;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.SENSORY_EXPIRY_NOTIFICATION_ID;
@@ -41,7 +42,7 @@ public class SensorExpiry extends BaseAlert {
 
     @Override
     public boolean activate() {
-        val expiry = niceTimeScalarNatural(SensorDays.get().getRemainingSensorPeriodInMs());
+        val expiry = niceTimeScalarNaturalp1(SensorDays.get().getRemainingSensorPeriodInMs());
         val notificationId = SENSORY_EXPIRY_NOTIFICATION_ID;
         cancelNotification(notificationId);
         val expireMsg = String.format("Sensor will expire in %s", expiry); // TODO i18n and format string

--- a/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
@@ -3,7 +3,6 @@ package com.eveningoutpost.dexdrip.alert;
 import static com.eveningoutpost.dexdrip.models.JoH.cancelNotification;
 import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalar;
 import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalarNatural;
-import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalarNaturalp1;
 import static com.eveningoutpost.dexdrip.models.JoH.showNotification;
 import static com.eveningoutpost.dexdrip.models.JoH.tsl;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.SENSORY_EXPIRY_NOTIFICATION_ID;
@@ -42,7 +41,7 @@ public class SensorExpiry extends BaseAlert {
 
     @Override
     public boolean activate() {
-        val expiry = niceTimeScalarNaturalp1(SensorDays.get().getRemainingSensorPeriodInMs());
+        val expiry = niceTimeScalarNatural(SensorDays.get().getRemainingSensorPeriodInMs(), 1);
         val notificationId = SENSORY_EXPIRY_NOTIFICATION_ID;
         cancelNotification(notificationId);
         val expireMsg = String.format("Sensor will expire in %s", expiry); // TODO i18n and format string

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
@@ -809,7 +809,7 @@ public class JoH {
     }
 
 
-    public static String niceTimeScalarNatural(long t) {
+    public static String niceTimeScalarNatural(long t) { // Shows the integer part only
         if (t > 3000000) t = t + 10000; // round up by 10 seconds if nearly an hour
         if ((t > Constants.DAY_IN_MS) && (t < Constants.WEEK_IN_MS * 2)) {
             final SimpleDateFormat df = new SimpleDateFormat("EEEE", Locale.getDefault());
@@ -817,6 +817,17 @@ public class JoH {
             return ((t > Constants.WEEK_IN_MS) ? "next " : "") + day;
         } else {
             return niceTimeScalar(t);
+        }
+    }
+
+    public static String niceTimeScalarNaturalp1(long t) { // Rounds down to 1 decimal point.
+        if (t > 3000000) t = t + 10000; // round up by 10 seconds if nearly an hour
+        if ((t > Constants.DAY_IN_MS) && (t < Constants.WEEK_IN_MS * 2)) {
+            final SimpleDateFormat df = new SimpleDateFormat("EEEE", Locale.getDefault());
+            final String day = df.format(new Date(JoH.tsl() + t));
+            return ((t > Constants.WEEK_IN_MS) ? "next " : "") + day;
+        } else {
+            return niceTimeScalar(t, 1);
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
@@ -809,25 +809,18 @@ public class JoH {
     }
 
 
-    public static String niceTimeScalarNatural(long t) { // Shows the integer part only
-        if (t > 3000000) t = t + 10000; // round up by 10 seconds if nearly an hour
-        if ((t > Constants.DAY_IN_MS) && (t < Constants.WEEK_IN_MS * 2)) {
-            final SimpleDateFormat df = new SimpleDateFormat("EEEE", Locale.getDefault());
-            final String day = df.format(new Date(JoH.tsl() + t));
-            return ((t > Constants.WEEK_IN_MS) ? "next " : "") + day;
-        } else {
-            return niceTimeScalar(t);
-        }
+    public static String niceTimeScalarNatural(long t) { // Shows the integer part only when less than 1 day.
+        return niceTimeScalarNatural(t, 0);
     }
 
-    public static String niceTimeScalarNaturalp1(long t) { // Rounds down to 1 decimal point.
+    public static String niceTimeScalarNatural(long t, int h_digits) { // Rounds down to the defined number of decimal points when less than 1 day.
         if (t > 3000000) t = t + 10000; // round up by 10 seconds if nearly an hour
         if ((t > Constants.DAY_IN_MS) && (t < Constants.WEEK_IN_MS * 2)) {
             final SimpleDateFormat df = new SimpleDateFormat("EEEE", Locale.getDefault());
             final String day = df.format(new Date(JoH.tsl() + t));
             return ((t > Constants.WEEK_IN_MS) ? "next " : "") + day;
         } else {
-            return niceTimeScalar(t, 1);
+            return niceTimeScalar(t, h_digits);
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/3569
Sensor expiry alert shows "Sensor will expire in 1 hour" even if 1.99 hours are still l eft to expiry as shown here: https://github.com/NightscoutFoundation/xDrip/issues/3569.  
  
I can speculate that the intent was for the alert to show 24 hours left and 12 hours left, and 6 hours left and 2 hours left.
But, because we want this to be a silent alert, we have made it wait for the screen to be unlocked or the charger to be disconnected.

As a result, when 2 hours are left to expiry, the alert does not trigger.  it triggers when the user unlocks the phone after that time.
But, the format chosen can only show integer values.

The 24-hour value shows 23 hours are left.
The 12 hour alert shows 11 hours are left.
It is really bad when the 2-hour alert shows 1 hour left.  
  
This PR rounds down the value to 1 decimal point instead of dropping the fractional part completely.  
  
---  
  
**Not tested yet**  
I have tested a fictitious case and verified functionality.
However, I will test this in real action in 10 days with a G7.  
  
Please let me know if I have overlooked anything.  