### PR TITLE
Do not assign a y position to notes

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -3519,7 +3519,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
 
             if (treatment_text.length() > 0) {
                 // display snackbar of the snackbar
-                final View.OnClickListener mOnClickListener = v -> Home.startHomeWithExtra(xdrip.getAppContext(), Home.CREATE_TREATMENT_NOTE, Long.toString(timestamp), Double.toString(position));
+                final View.OnClickListener mOnClickListener = v -> Home.startHomeWithExtra(xdrip.getAppContext(), Home.CREATE_TREATMENT_NOTE, Long.toString(timestamp), "-1"); // Let's not enter a y position to avoid having to worry about BG units
                 Home.snackBar(R.string.add_note, getString(R.string.added) + ":    " + treatment_text, mOnClickListener, mActivity);
             }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -2370,7 +2370,7 @@ public class BgGraphBuilder {
                     final View.OnClickListener mOnClickListener = new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {
-                            Home.startHomeWithExtra(xdrip.getAppContext(), Home.CREATE_TREATMENT_NOTE, time.toString(), Double.toString(ypos));
+                            Home.startHomeWithExtra(xdrip.getAppContext(), Home.CREATE_TREATMENT_NOTE, time.toString(), "-1"); // Let's not enter a y position to avoid having to worry about the BG units
                         }
                     };
                     Home.snackBar(R.string.add_note, message, mOnClickListener, callerActivity);


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/1299  
<br/>  
  
---  
  
**Recreate the problem**  
Install the latest Nightly (https://github.com/NightscoutFoundation/xDrip/releases/tag/2024.08.07).  
Disable predictive simulations.  
Set the BG units to mmol/L.
Enter an insulin treatment.
Tap on it and add a note.  You should see something like this.  
![Screenshot_20240812-175734](https://github.com/user-attachments/assets/8b54318d-c531-44b4-a059-c0a7ae86bdd9)
  
Change the BG unit setting to mg/dL.  Now, you will see something like this.  
![Screenshot_20240812-180000](https://github.com/user-attachments/assets/e4725b3f-4889-483e-8903-9698b7872880)
  
You can see the y axis range has been expanded to very low values.  Now, delete the treatment.  You will see the scale going back to normal as shown below.
![Screenshot_20240812-180204](https://github.com/user-attachments/assets/f645260b-1055-4ce7-aa92-e93e8988c424)  
 
Enter a treatment again.  Add a note to it.  You should see something like this:  
![Screenshot_20240812-180331](https://github.com/user-attachments/assets/fb536958-8255-4aef-b9c9-bfdafbe54e77)  
Change the BG unit to mmol/L.  You will see this:  
![Screenshot_20240812-180522](https://github.com/user-attachments/assets/7dda3a63-b3d1-4036-99e6-366031ac8f7f)  
You can see that the y axis range is now unreasonably extended on the positive side.  
 <br/>  
  
---   
  
**After this PR**  
The note will not have a y position value applied to them.  
Let's repeat the second test.  This is what you will see after entering a treatment and adding a note to it.  
![Screenshot_20240812-181019](https://github.com/user-attachments/assets/459c7e7b-761c-4a1e-a7a3-1d9d8c52f6cc)  
Now, if you change the BG unit, you will see this.  
![Screenshot_20240812-181152](https://github.com/user-attachments/assets/0a28f225-38b9-4050-8d4e-f136980514a6)  
You can see that the y axis range remains reasonable.