### PR TITLE
No more confusing BG codes

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -2190,29 +2190,8 @@ public class BgGraphBuilder {
                 df.setMinimumFractionDigits(1);
                 return df.format(mmolConvert(value));
             }
-        } else if (value > 12) {
-            return "LOW";
         } else {
-            switch ((int) value) {
-                case 0:
-                    return "??0";
-                case 1:
-                    return "?SN";
-                case 2:
-                    return "??2";
-                case 3:
-                    return "?NA";
-                case 5:
-                    return "?NC";
-                case 6:
-                    return "?CD";
-                case 9:
-                    return "?AD";
-                case 12:
-                    return "?RF";
-                default:
-                    return "???";
-            }
+            return "LOW";
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Unitized.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Unitized.java
@@ -73,29 +73,8 @@ public class Unitized {
                 df.setMinimumFractionDigits(1);
                 return df.format(mmolConvert(value));
             }
-        } else if (value > 12) {
-            return "LOW";
         } else {
-            switch ((int) value) {
-                case 0:
-                    return "??0";
-                case 1:
-                    return "?SN";
-                case 2:
-                    return "??2";
-                case 3:
-                    return "?NA";
-                case 5:
-                    return "?NC";
-                case 6:
-                    return "?CD";
-                case 9:
-                    return "?AD";
-                case 12:
-                    return "?RF";
-                default:
-                    return "???";
-            }
+            return "LOW";
         }
     }
 


### PR DESCRIPTION
These codes were added a very long time ago.
https://github.com/StephenBlackWasAlreadyTaken/xDrip/blob/bd43dad2b9cf25d9e6af13813acbaf262f5893c2/app/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Constants.java#L132-L141  
The oldest existing record I can find is from almost 10 years ago.  But, they may have even been added before then.  

A lot has changed since then.  Are we sure any devices today send such low values as codes?  
So, we show a value of 13 as LOW, but a value of 12 as ?RF.
Neither 12 nor 13mg/dL makes any sense.  Both are unreasonable values for blood glucose.  

But, questions about them have come up over the years.  And there is no answer as to what they mean.  Therefore, they are confusing.

This PR removes the codes and shows LOW instead.