### PR TITLE
Raw-related Calibration logs shown only when raw is available

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Calibration.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 
 import static com.eveningoutpost.dexdrip.models.BgReading.isDataSuitableForDoubleCalibration;
 import static com.eveningoutpost.dexdrip.calibrations.PluggableCalibration.newFingerStickData;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getDexCollectionType;
 
 
 class DexParameters extends SlopeParameters {
@@ -639,7 +640,7 @@ public class Calibration extends Model {
                     } else {
                         Log.d(TAG, "Follower mode or note so not processing calibration deeply");
                     }
-                } else {
+                } else if (SensorSanity.isRawCapable(getDexCollectionType())) { // Only if the sensor can provide raw values
                     final String msg = "Sensor data fails sanity test - Cannot Calibrate! raw:" + bgReading.raw_data;
                     UserError.Log.e(TAG, msg);
                     JoH.static_toast_long(msg);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/SensorSanity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/SensorSanity.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip.models;
 
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getDexCollectionType;
+
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
@@ -25,12 +27,16 @@ public class SensorSanity {
 
     private static final String TAG = "SensorSanity";
 
+    public static boolean isRawCapable(DexCollectionType type) { // This is true only if the sensor can provide raw values
+        return (DexCollectionType.hasDexcomRaw(type) || DexCollectionType.hasLibre(type) || type == DexCollectionType.Medtrum);
+    }
+
     public static boolean isRawValueSane(double raw_value) {
-        return isRawValueSane(raw_value, DexCollectionType.getDexCollectionType(), false);
+        return isRawValueSane(raw_value, getDexCollectionType(), false);
     }
 
     public static boolean isRawValueSane(double raw_value, boolean hard) {
-        return isRawValueSane(raw_value, DexCollectionType.getDexCollectionType(), hard);
+        return isRawValueSane(raw_value, getDexCollectionType(), hard);
     }
 
     public static boolean isRawValueSane(double raw_value, DexCollectionType type) {
@@ -71,7 +77,7 @@ public class SensorSanity {
             else if (raw_value > DEXCOM_MAX_RAW) state = false;
         }
 
-        if (!state) {
+        if (!state && isRawCapable(type)) {
             if (JoH.ratelimit("sanity-failure", 20)) {
                 final String msg = "Sensor Raw Data Sanity Failure: " + raw_value;
                 UserError.Log.e(TAG, msg);


### PR DESCRIPTION
When using a G7, calibrations will produce logs shown below:
![456976494_8064313687021924_1436055729562293458_n](https://github.com/user-attachments/assets/755b46ef-b249-48df-9aa8-bb24c5e5dfac)
  
But, G7 does not send raw values.  Therefore, the first two logs do not provide any information to the user and confuse them as posted in facebook.  

This PR gates those two logs and allows them only if the sensor is raw capable.  The following screenshot shows the logs after a calibration after this PR.  
![Screenshot_20240826-121210](https://github.com/user-attachments/assets/5eabac02-96a3-463e-9026-c1f358b51436)
  
<br/>  
  
The third log should ideally be replaced by calibration accepted by transmitter.  
But, that can be a different PR.