### PR TITLE
Dex Share cleanup

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1901,13 +1901,13 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 }
             }
 
-
-            if (!engineering_mode) {
-                try {
-                    ((PreferenceScreen) findPreference("dexcom_server_upload_screen")).removePreference(findPreference("share_test_key"));
-                } catch (Exception e) {
-                    //
-                }
+            // Hide receiver serial number settings
+            // Hiding a setting without deleting it makes it invisible to the user while it can still define the setting value.
+            try {
+                ((PreferenceScreen) findPreference("dexcom_server_upload_screen")).removePreference(findPreference("share_test_key"));
+                ((PreferenceScreen) findPreference("dexcom_server_upload_screen")).removePreference(findPreference("share_key"));
+            } catch (Exception e) {
+                //
             }
 
             //if (engineering_mode) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,8 +312,8 @@
     <string name="use_excessive_wakelocks">Use Excessive Wakelocks</string>
     <string name="speak_readings">Speak Readings</string>
     <string name="extra_status_line">Extra Status Line</string>
-    <string name="dexcom_share_server_upload">Dexcom Share Server Upload</string>
-    <string name="upload_data_to_dex_servers">Upload data to Dexcoms Servers so you can use your data with Dexcoms apps</string>
+    <string name="dexcom_share_server_upload">Dex Share</string>
+    <string name="upload_data_to_dex_servers">Upload data to Dex Share Servers</string>
     <string name="manage_followers">Manage Followers</string>
     <string name="manage_existing_followers">Manage your existing followers and invite new ones.</string>
     <string name="invite_follower">Invite a Follower</string>
@@ -759,15 +759,15 @@
     <string name="influxdb_database_name">InfluxDB database name</string>
     <string name="user">User</string>
     <string name="password">Password</string>
-    <string name="upload_to_dexcom">Enable this to upload to Dexcom\'s servers</string>
-    <string name="upload_to_dexcom_share">Upload BG values as Dexcom Share</string>
+    <string name="upload_to_dexcom">Enable this to upload to Dex Share servers</string>
+    <string name="upload_to_dexcom_share">Upload BG values to Dex Share</string>
     <string name="accounts_outside_usa">Disabled = Your account and follower apps are from outside the USA</string>
     <string name="accounts_inside_usa">Enabled = Your account and follower apps are from the USA</string>
-    <string name="usa_based_account">Dexcom USA based account</string>
-    <string name="dexcom_login">Your login for Dexcom\'s Website</string>
-    <string name="dexcom_user">Dexcom Account Login</string>
-    <string name="dexcom_login_password">Your password for Dexcom\'s Website</string>
-    <string name="dexcom_password">Dexcom Account Password</string>
+    <string name="usa_based_account">Dex USA based account</string>
+    <string name="dexcom_login">Your login for Dex share</string>
+    <string name="dexcom_user">Dex Account Login</string>
+    <string name="dexcom_login_password">Your password for Dex share</string>
+    <string name="dexcom_password">Dex Account Password</string>
     <string name="dexcom_receiver_serial">10-Character Dexcom Receiver serial number</string>
     <string name="dexcom_test_mode_serial">10-Character Test Mode serial number</string>
     <string name="glucose_meters">Glucose Meters</string>

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -259,16 +259,6 @@
                     android:key="share_test_key"
                     android:shouldDisableView="true"
                     android:title="@string/dexcom_test_mode_serial" />
-                <Preference
-                    android:dependency="share_upload"
-                    android:summary="@string/manage_existing_followers"
-                    android:key="manage_dexcom_share_followers"
-                    android:title="@string/manage_followers">
-                    <intent
-                        android:action="android.intent.action.MAIN"
-                        android:targetClass="com.eveningoutpost.dexdrip.FollowerManagementActivity"
-                        android:targetPackage="@string/local_target_package" />
-                </Preference>
             </PreferenceScreen>
             <PreferenceScreen
                 android:key="tidepool_upload_screen"


### PR DESCRIPTION
This PR makes the following changes.

1- Removes the ability to edit the test mode RX serial number.
This setting is available under engineering mode only.  After this PR, it will not be available even in engineering mode.    
  
2- Removes the Dexcom receiver serial number setting from the Dex share menu.
This setting should not be changed and as such has no purpose any longer. 
  
3- Removes the option to manage followers from the Dex share menu.
This option has no purpose as it is not possible to manage followers from xDrip any longer.  
  
4- Strings have been updated.
Users often misunderstand Dex share with Clarity.  xDrip cannot upload to Clarity.  Many users see the current Dex share setting and because it is not clearly identified, they expect it to upload to Clarity.  
There may be a copyright on the word Dexcom.  It has been replaced with Dex.

Before and After are shown below.

![1](https://github.com/user-attachments/assets/1ef8ef97-c50b-42f4-a6f0-b269b21235bd)
  
![2](https://github.com/user-attachments/assets/31f37d7c-1832-4d94-82e7-fe57ac85f2b4)


This is tested and ready for review.