### PR TITLE
Statistics Customization 1

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -10,6 +10,7 @@ import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
 
 import com.eveningoutpost.dexdrip.databinding.StatsGeneralBinding;
+import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -28,6 +29,7 @@ import java.util.List;
  * Created by adrian on 30/06/15.
  */
 public class FirstPageFragment extends Fragment {
+    private final static String TAG = FirstPageFragment.class.getSimpleName();
 
     private View myView;
 
@@ -55,23 +57,46 @@ public class FirstPageFragment extends Fragment {
 
     public class ViewStats { // Linking to stats_general layout
         public boolean viewAbsolutes() { // Show absolute numbers
-            return Pref.getBoolean("show_statistics_absolutes", true);
+            return Pref.getBoolean("show_statistics_absolutes", false);
         }
 
         public boolean viewMedianBG() { // Show BG median
-            return Pref.getBoolean("show_statistics_median", true);
+            return Pref.getBoolean("show_statistics_median", false);
         }
 
         public boolean viewA1C() { // Show estimated A1C
-            return Pref.getBoolean("show_statistics_a1cestimate", true);
+            return Pref.getBoolean("show_statistics_a1cestimate", false);
         }
 
         public boolean viewRelSD() { // Show relative standard deviation
-            return Pref.getBoolean("show_statistics_relsd", true);
+            return Pref.getBoolean("show_statistics_relsd", false);
         }
 
         public boolean viewGviLine() { // Show the GVI line, including GVI and PGS
-            return Pref.getBoolean("show_statistics_gvi", true) || Pref.getBoolean("show_statistics_pgs", true);
+            return Pref.getBoolean("show_statistics_gvi", false) || Pref.getBoolean("show_statistics_pgs", false);
+        }
+    }
+
+    public static void defineDefaults () { // This is where the defaults are defined.
+        defineDefault("show_statistics_absolutes", true); // Show absolute values
+        defineDefault("show_statistics_median", true); // Show median by default
+        defineDefault("show_statistics_a1cestimate", true); // Show estimated A1C
+        defineDefault("show_statistics_relsd", true); // Show relative standard deviation
+        defineDefault("show_statistics_pgs", true); // Show PGS
+        defineDefault("show_statistics_gvi", true); // Show GVI
+    }
+
+    public static void defineDefault (String pref, Boolean def) {
+        if (!Pref.isPreferenceSet(pref)) { // If the value (of pref) has never been changed
+            try {
+                if (!def) { // If the default is false
+                    // There is no need to take any action if the default is false
+                } else if (def) { // If the default is true
+                    Pref.setBoolean(pref, true); // Enable the setting
+                }
+            } catch (Exception e) {
+                UserError.Log.wtf(TAG, "incorrect arguments");
+            }
         }
     }
 
@@ -216,11 +241,11 @@ public class FirstPageFragment extends Fragment {
                 Log.d("DrawStats", "NormalReadingspct=" + normalReadingspct + " glucoseMean=" + glucoseMean + " tirMultiplier=" + tirMultiplier + " PGS=" + PGS);
                 TextView gviView = (TextView) localView.findViewById(R.id.textView_gvi);
                 DecimalFormat df = new DecimalFormat("#.00");
-                if (Pref.getBoolean("show_statistics_pgs", true) && Pref.getBoolean("show_statistics_gvi", true)) { // Show both GVI and PGS
+                if (Pref.getBoolean("show_statistics_pgs", false) && Pref.getBoolean("show_statistics_gvi", true)) { // Show both GVI and PGS
                     updateText(localView, gviView, "GVI:  " +  df.format(gvi) + "    PGS:  " + df.format(PGS));
                 } else if (Pref.getBoolean("show_statistics_gvi", true)) { // Show only GVI
                     updateText(localView, gviView, "GVI:  " + df.format(gvi));
-                } else if (Pref.getBoolean("show_statistics_pgs", true)) { // Show only PGS
+                } else if (Pref.getBoolean("show_statistics_pgs", false)) { // Show only PGS
                     updateText(localView, gviView, "PGS:  " + df.format(PGS));
                 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -68,6 +68,10 @@ public class FirstPageFragment extends Fragment {
             return Pref.getBoolean("show_statistics_a1cestimate", false);
         }
 
+        public boolean viewSD() { // Show standard deviation
+            return Pref.getBoolean("show_statistics_sd", false);
+        }
+
         public boolean viewRelSD() { // Show relative standard deviation
             return Pref.getBoolean("show_statistics_relsd", false);
         }
@@ -81,6 +85,7 @@ public class FirstPageFragment extends Fragment {
         defineDefault("show_statistics_absolutes", true); // Show absolute values
         defineDefault("show_statistics_median", true); // Show median by default
         defineDefault("show_statistics_a1cestimate", true); // Show estimated A1C
+        defineDefault("show_statistics_sd", true); // Show standard deviation
         defineDefault("show_statistics_relsd", true); // Show relative standard deviation
         defineDefault("show_statistics_pgs", true); // Show PGS
         defineDefault("show_statistics_gvi", true); // Show GVI

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/FirstPageFragment.java
@@ -1,16 +1,15 @@
 package com.eveningoutpost.dexdrip.stats;
 
-import static android.app.PendingIntent.getActivity;
-
-
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
 
+import com.eveningoutpost.dexdrip.databinding.StatsGeneralBinding;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -19,6 +18,7 @@ import android.widget.TextView;
 
 import com.eveningoutpost.dexdrip.importedlibraries.dexcom.Dex_Constants;
 import com.eveningoutpost.dexdrip.R;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -36,8 +36,9 @@ public class FirstPageFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         Log.d("DrawStats", "FirstPageFragment onCreateView");
 
-        myView = inflater.inflate(
-                R.layout.stats_general, container, false);
+        StatsGeneralBinding binding = DataBindingUtil.inflate(inflater, R.layout.stats_general, container, false);
+        myView = binding.getRoot();
+        binding.setStatsview(new ViewStats());
 
         myView.setTag(0);
 
@@ -50,6 +51,28 @@ public class FirstPageFragment extends Fragment {
     @Override
     public View getView() {
         return myView;
+    }
+
+    public class ViewStats { // Linking to stats_general layout
+        public boolean viewAbsolutes() { // Show absolute numbers
+            return Pref.getBoolean("show_statistics_absolutes", true);
+        }
+
+        public boolean viewMedianBG() { // Show BG median
+            return Pref.getBoolean("show_statistics_median", true);
+        }
+
+        public boolean viewA1C() { // Show estimated A1C
+            return Pref.getBoolean("show_statistics_a1cestimate", true);
+        }
+
+        public boolean viewRelSD() { // Show relative standard deviation
+            return Pref.getBoolean("show_statistics_relsd", true);
+        }
+
+        public boolean viewGviLine() { // Show the GVI line, including GVI and PGS
+            return Pref.getBoolean("show_statistics_gvi", true) || Pref.getBoolean("show_statistics_pgs", true);
+        }
     }
 
     private class CalculationThread extends Thread {
@@ -75,7 +98,7 @@ public class FirstPageFragment extends Fragment {
                 return;
             }
 
-            //Ranges
+            // Ranges
             long aboveRange = DBSearchUtil.noReadingsAboveRange(context);
             long belowRange = DBSearchUtil.noReadingsBelowRange(context);
             long inRange = DBSearchUtil.noReadingsInRange(context);
@@ -96,7 +119,7 @@ public class FirstPageFragment extends Fragment {
             double stats_high = Double.parseDouble(settings.getString("highValue", "170"));
             double stats_low = Double.parseDouble(settings.getString("lowValue", "70"));
             TextView rangeView = (TextView) localView.findViewById(R.id.textView_stats_range_set);
-            //update stats_high/low
+            // update stats_high/low
             if (!mgdl) {
                 updateText(localView, rangeView, (Math.round(stats_low * 10) / 10d) + " - " + (Math.round(stats_high * 10) / 10d) + " mmol/l");
             } else {
@@ -127,14 +150,14 @@ public class FirstPageFragment extends Fragment {
                 }
 
                 TextView meanView = (TextView) localView.findViewById(R.id.textView_mean);
-                //update mean
+                // update mean
                 if (mgdl) {
                     updateText(localView, meanView, (Math.round(mean * 10) / 10d) + " mg/dl");
                 } else {
                     updateText(localView, meanView, (Math.round(mean * Dex_Constants.MG_DL_TO_MMOL_L * 100) / 100d) + " mmol/l");
 
                 }
-                //update A1c
+                // update A1c
                 TextView a1cView = (TextView) localView.findViewById(R.id.textView_a1c);
                 int a1c_ifcc = (int) Math.round(((mean + 46.7) / 28.7 - 2.15) * 10.929);
                 double a1c_dcct = Math.round(10 * (mean + 46.7) / 28.7) / 10d;
@@ -156,7 +179,7 @@ public class FirstPageFragment extends Fragment {
                 updateText(localView, coefficientOfVariation, Math.round(1000d*stdev/mean)/10d + "%");
 
 
-                //calculate BGI / PGS
+                // calculate GVI / PGS
                 // https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/report_plugins/glucosedistribution.js#L150
                 List<BgReadingStats> bgListByTime = DBSearchUtil.getFilteredReadingsWithFallback(false);
 
@@ -193,7 +216,13 @@ public class FirstPageFragment extends Fragment {
                 Log.d("DrawStats", "NormalReadingspct=" + normalReadingspct + " glucoseMean=" + glucoseMean + " tirMultiplier=" + tirMultiplier + " PGS=" + PGS);
                 TextView gviView = (TextView) localView.findViewById(R.id.textView_gvi);
                 DecimalFormat df = new DecimalFormat("#.00");
-                updateText(localView, gviView,  df.format(gvi) + "  PGS:  " + df.format(PGS));
+                if (Pref.getBoolean("show_statistics_pgs", true) && Pref.getBoolean("show_statistics_gvi", true)) { // Show both GVI and PGS
+                    updateText(localView, gviView, "GVI:  " +  df.format(gvi) + "    PGS:  " + df.format(PGS));
+                } else if (Pref.getBoolean("show_statistics_gvi", true)) { // Show only GVI
+                    updateText(localView, gviView, "GVI:  " + df.format(gvi));
+                } else if (Pref.getBoolean("show_statistics_pgs", true)) { // Show only PGS
+                    updateText(localView, gviView, "PGS:  " + df.format(PGS));
+                }
 
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
@@ -68,6 +68,7 @@ public class StatsActivity extends ActivityWithMenu {
     MenuItem menuItem6;
     MenuItem menuItem7;
     MenuItem menuItem8;
+    MenuItem menuItem9;
     private View decorView;
     private String stateString;
     private final static int MY_PERMISSIONS_REQUEST_STORAGE_SCREENSHOT = 106;
@@ -76,6 +77,7 @@ public class StatsActivity extends ActivityWithMenu {
     public static final String SHOW_STATISTICS_Absolutes = "show_statistics_absolutes";
     public static final String SHOW_STATISTICS_Median_BG = "show_statistics_median";
     public static final String SHOW_STATISTICS_A1C = "show_statistics_a1cestimate";
+    public static final String SHOW_STATISTICS_SD = "show_statistics_sd";
     public static final String SHOW_STATISTICS_Rel_SD = "show_statistics_relsd";
     public static final String SHOW_STATISTICS_GVI = "show_statistics_gvi";
     public static final String SHOW_STATISTICS_PGS = "show_statistics_pgs";
@@ -280,9 +282,10 @@ public class StatsActivity extends ActivityWithMenu {
         menuItem3 = menu.findItem(R.id.action_show_absolutes);
         menuItem4 = menu.findItem(R.id.action_show_median);
         menuItem5 = menu.findItem(R.id.action_show_a1cestimate);
-        menuItem6 = menu.findItem(R.id.action_show_relsd);
-        menuItem7 = menu.findItem(R.id.action_show_gvi);
-        menuItem8 = menu.findItem(R.id.action_show_pgs);
+        menuItem6 = menu.findItem(R.id.action_show_sd);
+        menuItem7 = menu.findItem(R.id.action_show_relsd);
+        menuItem8 = menu.findItem(R.id.action_show_gvi);
+        menuItem9 = menu.findItem(R.id.action_show_pgs);
 
         updateMenuChecked();
 
@@ -303,9 +306,10 @@ public class StatsActivity extends ActivityWithMenu {
         menuItem3.setChecked(Pref.getBoolean(SHOW_STATISTICS_Absolutes, false));
         menuItem4.setChecked(Pref.getBoolean(SHOW_STATISTICS_Median_BG, false));
         menuItem5.setChecked(Pref.getBoolean(SHOW_STATISTICS_A1C, false));
-        menuItem6.setChecked(Pref.getBoolean(SHOW_STATISTICS_Rel_SD, false));
-        menuItem7.setChecked(Pref.getBoolean(SHOW_STATISTICS_GVI, false));
-        menuItem8.setChecked(Pref.getBoolean(SHOW_STATISTICS_PGS, false));
+        menuItem6.setChecked(Pref.getBoolean(SHOW_STATISTICS_SD, false));
+        menuItem7.setChecked(Pref.getBoolean(SHOW_STATISTICS_Rel_SD, false));
+        menuItem8.setChecked(Pref.getBoolean(SHOW_STATISTICS_GVI, false));
+        menuItem9.setChecked(Pref.getBoolean(SHOW_STATISTICS_PGS, false));
     }
 
     private void evaluateColors(boolean recreate) {
@@ -353,6 +357,13 @@ public class StatsActivity extends ActivityWithMenu {
     public void toggleStatisticsShowA1C(MenuItem m) // Toggle visibility of estimated A1C
     {
         Pref.toggleBoolean(SHOW_STATISTICS_A1C);
+        evaluateColors(true);
+        updateMenuChecked();
+    }
+
+    public void toggleStatisticsShowSD(MenuItem m) // Toggle visibility of standard deviation
+    {
+        Pref.toggleBoolean(SHOW_STATISTICS_SD);
         evaluateColors(true);
         updateMenuChecked();
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
@@ -300,12 +300,12 @@ public class StatsActivity extends ActivityWithMenu {
     private void updateMenuChecked() {
         menuItem.setChecked(Pref.getBoolean(SHOW_STATISTICS_FULL_SCREEN, false));
         menuItem2.setChecked(Pref.getBoolean(SHOW_STATISTICS_PRINT_COLOR, false));
-        menuItem3.setChecked(Pref.getBoolean(SHOW_STATISTICS_Absolutes, true));
-        menuItem4.setChecked(Pref.getBoolean(SHOW_STATISTICS_Median_BG, true));
-        menuItem5.setChecked(Pref.getBoolean(SHOW_STATISTICS_A1C, true));
-        menuItem6.setChecked(Pref.getBoolean(SHOW_STATISTICS_Rel_SD, true));
-        menuItem7.setChecked(Pref.getBoolean(SHOW_STATISTICS_GVI, true));
-        menuItem8.setChecked(Pref.getBoolean(SHOW_STATISTICS_PGS, true));
+        menuItem3.setChecked(Pref.getBoolean(SHOW_STATISTICS_Absolutes, false));
+        menuItem4.setChecked(Pref.getBoolean(SHOW_STATISTICS_Median_BG, false));
+        menuItem5.setChecked(Pref.getBoolean(SHOW_STATISTICS_A1C, false));
+        menuItem6.setChecked(Pref.getBoolean(SHOW_STATISTICS_Rel_SD, false));
+        menuItem7.setChecked(Pref.getBoolean(SHOW_STATISTICS_GVI, false));
+        menuItem8.setChecked(Pref.getBoolean(SHOW_STATISTICS_PGS, false));
     }
 
     private void evaluateColors(boolean recreate) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
@@ -62,11 +62,23 @@ public class StatsActivity extends ActivityWithMenu {
     private Button button90d;
     MenuItem menuItem;
     MenuItem menuItem2;
+    MenuItem menuItem3;
+    MenuItem menuItem4;
+    MenuItem menuItem5;
+    MenuItem menuItem6;
+    MenuItem menuItem7;
+    MenuItem menuItem8;
     private View decorView;
     private String stateString;
     private final static int MY_PERMISSIONS_REQUEST_STORAGE_SCREENSHOT = 106;
     private static final String SHOW_STATISTICS_FULL_SCREEN = "show_statistics_full_screen";
     public static final String SHOW_STATISTICS_PRINT_COLOR = "show_statistics_print_color";
+    public static final String SHOW_STATISTICS_Absolutes = "show_statistics_absolutes";
+    public static final String SHOW_STATISTICS_Median_BG = "show_statistics_median";
+    public static final String SHOW_STATISTICS_A1C = "show_statistics_a1cestimate";
+    public static final String SHOW_STATISTICS_Rel_SD = "show_statistics_relsd";
+    public static final String SHOW_STATISTICS_GVI = "show_statistics_gvi";
+    public static final String SHOW_STATISTICS_PGS = "show_statistics_pgs";
     private static final String TAG = "Statistics";
 
     @Override
@@ -265,6 +277,12 @@ public class StatsActivity extends ActivityWithMenu {
 
         menuItem = menu.findItem(R.id.action_toggle_fullscreen);
         menuItem2 = menu.findItem(R.id.action_toggle_printing);
+        menuItem3 = menu.findItem(R.id.action_show_absolutes);
+        menuItem4 = menu.findItem(R.id.action_show_median);
+        menuItem5 = menu.findItem(R.id.action_show_a1cestimate);
+        menuItem6 = menu.findItem(R.id.action_show_relsd);
+        menuItem7 = menu.findItem(R.id.action_show_gvi);
+        menuItem8 = menu.findItem(R.id.action_show_pgs);
 
         updateMenuChecked();
 
@@ -282,6 +300,12 @@ public class StatsActivity extends ActivityWithMenu {
     private void updateMenuChecked() {
         menuItem.setChecked(Pref.getBoolean(SHOW_STATISTICS_FULL_SCREEN, false));
         menuItem2.setChecked(Pref.getBoolean(SHOW_STATISTICS_PRINT_COLOR, false));
+        menuItem3.setChecked(Pref.getBoolean(SHOW_STATISTICS_Absolutes, true));
+        menuItem4.setChecked(Pref.getBoolean(SHOW_STATISTICS_Median_BG, true));
+        menuItem5.setChecked(Pref.getBoolean(SHOW_STATISTICS_A1C, true));
+        menuItem6.setChecked(Pref.getBoolean(SHOW_STATISTICS_Rel_SD, true));
+        menuItem7.setChecked(Pref.getBoolean(SHOW_STATISTICS_GVI, true));
+        menuItem8.setChecked(Pref.getBoolean(SHOW_STATISTICS_PGS, true));
     }
 
     private void evaluateColors(boolean recreate) {
@@ -311,6 +335,49 @@ public class StatsActivity extends ActivityWithMenu {
         evaluateColors(true);
         updateMenuChecked();
     }
+
+    public void toggleStatisticsShowAbsolutes(MenuItem m) // Toggle visibility of absolute numbers
+    {
+        Pref.toggleBoolean(SHOW_STATISTICS_Absolutes);
+        evaluateColors(true);
+        updateMenuChecked();
+    }
+
+    public void toggleStatisticsShowMedianBG(MenuItem m) // Toggle visibility of absolute numbers
+    {
+        Pref.toggleBoolean(SHOW_STATISTICS_Median_BG);
+        evaluateColors(true);
+        updateMenuChecked();
+    }
+
+    public void toggleStatisticsShowA1C(MenuItem m) // Toggle visibility of estimated A1C
+    {
+        Pref.toggleBoolean(SHOW_STATISTICS_A1C);
+        evaluateColors(true);
+        updateMenuChecked();
+    }
+
+    public void toggleStatisticsShowRelSD(MenuItem m) // Toggle visibility of estimated A1C
+    {
+        Pref.toggleBoolean(SHOW_STATISTICS_Rel_SD);
+        evaluateColors(true);
+        updateMenuChecked();
+    }
+
+    public void toggleStatisticsShowGVI(MenuItem m) // Toggle visibility of PGS
+    {
+        Pref.toggleBoolean(SHOW_STATISTICS_GVI);
+        evaluateColors(true);
+        updateMenuChecked();
+    }
+
+    public void toggleStatisticsShowPGS(MenuItem m) // Toggle visibility of PGS
+    {
+        Pref.toggleBoolean(SHOW_STATISTICS_PGS);
+        evaluateColors(true);
+        updateMenuChecked();
+    }
+
     public void statisticsDisableFullScreen(View v)
     {
         toggleStatisticsFullScreenMode(null);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
@@ -343,7 +343,7 @@ public class StatsActivity extends ActivityWithMenu {
         updateMenuChecked();
     }
 
-    public void toggleStatisticsShowMedianBG(MenuItem m) // Toggle visibility of absolute numbers
+    public void toggleStatisticsShowMedianBG(MenuItem m) // Toggle visibility of median
     {
         Pref.toggleBoolean(SHOW_STATISTICS_Median_BG);
         evaluateColors(true);
@@ -357,14 +357,14 @@ public class StatsActivity extends ActivityWithMenu {
         updateMenuChecked();
     }
 
-    public void toggleStatisticsShowRelSD(MenuItem m) // Toggle visibility of estimated A1C
+    public void toggleStatisticsShowRelSD(MenuItem m) // Toggle visibility of relative standard deviation
     {
         Pref.toggleBoolean(SHOW_STATISTICS_Rel_SD);
         evaluateColors(true);
         updateMenuChecked();
     }
 
-    public void toggleStatisticsShowGVI(MenuItem m) // Toggle visibility of PGS
+    public void toggleStatisticsShowGVI(MenuItem m) // Toggle visibility of GVI
     {
         Pref.toggleBoolean(SHOW_STATISTICS_GVI);
         evaluateColors(true);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -20,6 +20,7 @@ import com.eveningoutpost.dexdrip.models.Prediction;
 import com.eveningoutpost.dexdrip.models.UserNotification;
 import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.SnoozeActivity;
+import com.eveningoutpost.dexdrip.stats.FirstPageFragment;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -60,6 +61,7 @@ public class IdempotentMigrations {
         IncompatibleApps.notifyAboutIncompatibleApps();
         CompatibleApps.notifyAboutCompatibleApps();
         legacySettingsMoveLanguageFromNoToNb();
+        FirstPageFragment.defineDefaults(); // Define the statistics page visibility defaults.
 
     }
 

--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -197,6 +197,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="left"
+                    app:showIfTrue="@{statsview.viewSD}"
                     android:orientation="horizontal"
                     android:padding="5dp">
 

--- a/app/src/main/res/layout/stats_general.xml
+++ b/app/src/main/res/layout/stats_general.xml
@@ -1,270 +1,275 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ScrollView
-        android:id="@+id/scrollView5"
+    <data>
+        <variable
+            name="statsview"
+            type="com.eveningoutpost.dexdrip.stats.FirstPageFragment.ViewStats"/>
+    </data>
+
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <LinearLayout
+        <ScrollView
+            android:id="@+id/scrollView5"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center_horizontal"
-            android:orientation="vertical">
+            android:layout_height="match_parent">
 
             <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center_horizontal"
+                android:orientation="vertical">
 
-                <TextView
-                    android:id="@+id/textView4"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="@string/range_in_high_low"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    android:layout_gravity="left"
+                    android:orientation="horizontal"
+                    android:padding="5dp">
 
-                <TextView
-                    android:id="@+id/textView_ranges_percent"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="--%/--%/--%"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/textView4"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="@string/range_in_high_low"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
+                    <TextView
+                        android:id="@+id/textView_ranges_percent"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="--%/--%/--%"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
+                </LinearLayout>
 
-                <TextView
-                    android:id="@+id/textView20"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="0dp"
-                    android:text="@string/stats_range_settings"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    android:layout_gravity="left"
+                    android:orientation="horizontal"
+                    android:padding="5dp">
 
-                <TextView
-                    android:id="@+id/textView_stats_range_set"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text=": ---"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/textView20"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="0dp"
+                        android:text="@string/stats_range_settings"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
+                    <TextView
+                        android:id="@+id/textView_stats_range_set"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text=": ---"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
+                </LinearLayout>
 
-                <TextView
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="@string/absolute_s"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    app:showIfTrue="@{statsview.viewAbsolutes}"
+                    android:layout_gravity="left"
+                    android:orientation="horizontal"
+                    android:padding="5dp">
 
-                <TextView
-                    android:id="@+id/textView_ranges_absolute"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="--/--/--"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="@string/absolute_s"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
+                    <TextView
+                        android:id="@+id/textView_ranges_absolute"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="--/--/--"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
+                </LinearLayout>
 
-                <TextView
-                    android:id="@+id/textView11"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="@string/median_bg"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    android:layout_gravity="left"
+                    app:showIfTrue="@{statsview.viewMedianBG}"
+                    android:orientation="horizontal"
+                    android:padding="5dp">
 
-                <TextView
-                    android:id="@+id/textView_median"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="---"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/textView11"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="@string/median_bg"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
+                    <TextView
+                        android:id="@+id/textView_median"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="---"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
+                </LinearLayout>
 
-                <TextView
-                    android:id="@+id/textView13"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="@string/mean_bg"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    android:layout_gravity="left"
+                    android:orientation="horizontal"
+                    android:padding="5dp">
 
-                <TextView
-                    android:id="@+id/textView_mean"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="---"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/textView13"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="@string/mean_bg"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
+                    <TextView
+                        android:id="@+id/textView_mean"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="---"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
+                </LinearLayout>
 
-                <TextView
-                    android:id="@+id/textView14"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="@string/hba1c_est"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    android:layout_gravity="left"
+                    app:showIfTrue="@{statsview.viewA1C}"
+                    android:orientation="horizontal"
+                    android:padding="5dp">
 
-                <TextView
-                    android:id="@+id/textView_a1c"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="2"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="-- mmol/mol\n--%"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/textView14"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="@string/hba1c_est"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
+                    <TextView
+                        android:id="@+id/textView_a1c"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="2"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="-- mmol/mol\n--%"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
+                </LinearLayout>
 
-                <TextView
-                    android:id="@+id/textView17"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="@string/stddev"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    android:layout_gravity="left"
+                    android:orientation="horizontal"
+                    android:padding="5dp">
 
-                <TextView
-                    android:id="@+id/textView_stdev"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="---"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/textView17"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="@string/stddev"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
+                    <TextView
+                        android:id="@+id/textView_stdev"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="---"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
+                </LinearLayout>
 
-                <TextView
-                    android:id="@+id/textView18"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="@string/relative_sd_cv"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    android:layout_gravity="left"
+                    app:showIfTrue="@{statsview.viewRelSD}"
+                    android:orientation="horizontal"
+                    android:padding="5dp">
 
-                <TextView
-                    android:id="@+id/textView_coefficient_of_variation"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="--%"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/textView18"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="@string/relative_sd_cv"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="left"
-                android:orientation="horizontal"
-                android:padding="5dp">
+                    <TextView
+                        android:id="@+id/textView_coefficient_of_variation"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="--%"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
+                </LinearLayout>
 
-                <TextView
-                    android:id="@+id/textView19"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="GVI:"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    android:layout_gravity="left"
+                    android:orientation="horizontal"
+                    android:padding="5dp"
+                    app:showIfTrue="@{statsview.viewGviLine}">
 
-                <TextView
-                    android:id="@+id/textView_gvi"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:text="--"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    <TextView
+                        android:id="@+id/textView_gvi"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="--"
+                        android:textAppearance="?android:attr/textAppearanceLarge" />
+                </LinearLayout>
             </LinearLayout>
-        </LinearLayout>
-    </ScrollView>
+        </ScrollView>
 
-</RelativeLayout>
+    </RelativeLayout>
+</layout>

--- a/app/src/main/res/menu/menu_statistics.xml
+++ b/app/src/main/res/menu/menu_statistics.xml
@@ -25,7 +25,7 @@
     <item
         android:id="@+id/statistics_settings"
         android:orderInCategory="1"
-        android:title="Visibility"
+        android:title="Parameters"
         android:visible="true">
         <menu>
             <group
@@ -44,6 +44,10 @@
                     android:id="@+id/action_show_a1cestimate"
                     android:onClick="toggleStatisticsShowA1C"
                     android:title="Estimated A1C" />
+                <item
+                    android:id="@+id/action_show_sd"
+                    android:onClick="toggleStatisticsShowSD"
+                    android:title="Standard Deviation" />
                 <item
                     android:id="@+id/action_show_relsd"
                     android:onClick="toggleStatisticsShowRelSD"

--- a/app/src/main/res/menu/menu_statistics.xml
+++ b/app/src/main/res/menu/menu_statistics.xml
@@ -1,65 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:id="@+id/action_toggle_fullscreen"
-        android:title="@string/title_full_screen_mode"
+    <item
+        android:id="@+id/action_toggle_fullscreen"
+        android:checkable="true"
         android:onClick="toggleStatisticsFullScreenMode"
-        android:checkable="true"
         android:orderInCategory="1"
-        android:visible="true"/>
-    <item android:id="@+id/action_toggle_printing"
-        android:title="@string/title_colors_for_printing"
+        android:title="@string/title_full_screen_mode"
+        android:visible="true" />
+    <item
+        android:id="@+id/action_toggle_printing"
+        android:checkable="true"
         android:onClick="toggleStatisticsPrintingMode"
-        android:checkable="true"
         android:orderInCategory="1"
-        android:visible="true"/>
-    <item android:id="@+id/share_this_screen"
-        android:title="@string/title_share_save_this_screen"
-        android:onClick="statisticsShare"
+        android:title="@string/title_colors_for_printing"
+        android:visible="true" />
+    <item
+        android:id="@+id/share_this_screen"
         android:checkable="false"
+        android:onClick="statisticsShare"
         android:orderInCategory="1"
-        android:visible="true"/>
-    <item android:id="@+id/statistics_settings"
-        android:title="Include"
+        android:title="@string/title_share_save_this_screen"
+        android:visible="true" />
+    <item
+        android:id="@+id/statistics_settings"
         android:orderInCategory="1"
-        android:visible="true" >
+        android:title="Visibility"
+        android:visible="true">
         <menu>
-            <item
-                android:id="@+id/action_show_absolutes"
-                android:title="Absolutes #s"
-                android:onClick="toggleStatisticsShowAbsolutes"
-                android:checkable="true"
-                android:visible="true" />
-            <item
-                android:id="@+id/action_show_median"
-                android:title="Median BG"
-                android:onClick="toggleStatisticsShowMedianBG"
-                android:checkable="true"
-                android:visible="true" />
-            <item
-                android:id="@+id/action_show_a1cestimate"
-                android:title="Estimated A1C"
-                android:onClick="toggleStatisticsShowA1C"
-                android:checkable="true"
-                android:visible="true" />
-            <item
-                android:id="@+id/action_show_relsd"
-                android:title="Relative SD"
-                android:onClick="toggleStatisticsShowRelSD"
-                android:checkable="true"
-                android:visible="true" />
-            <item
-                android:id="@+id/action_show_gvi"
-                android:title="GVI"
-                android:onClick="toggleStatisticsShowGVI"
-                android:checkable="true"
-                android:visible="true" />
-            <item
-                android:id="@+id/action_show_pgs"
-                android:title="PGS"
-                android:onClick="toggleStatisticsShowPGS"
-                android:checkable="true"
-                android:visible="true" />
+            <group
+                android:id="@+id/visibility_settings"
+                android:checkableBehavior="all"
+                android:visible="true">
+                <item
+                    android:id="@+id/action_show_absolutes"
+                    android:onClick="toggleStatisticsShowAbsolutes"
+                    android:title="Absolutes #s" />
+                <item
+                    android:id="@+id/action_show_median"
+                    android:onClick="toggleStatisticsShowMedianBG"
+                    android:title="Median BG" />
+                <item
+                    android:id="@+id/action_show_a1cestimate"
+                    android:onClick="toggleStatisticsShowA1C"
+                    android:title="Estimated A1C" />
+                <item
+                    android:id="@+id/action_show_relsd"
+                    android:onClick="toggleStatisticsShowRelSD"
+                    android:title="Relative SD" />
+                <item
+                    android:id="@+id/action_show_gvi"
+                    android:onClick="toggleStatisticsShowGVI"
+                    android:title="GVI" />
+                <item
+                    android:id="@+id/action_show_pgs"
+                    android:onClick="toggleStatisticsShowPGS"
+                    android:title="PGS" />
+            </group>
         </menu>
     </item>
 

--- a/app/src/main/res/menu/menu_statistics.xml
+++ b/app/src/main/res/menu/menu_statistics.xml
@@ -19,5 +19,48 @@
         android:checkable="false"
         android:orderInCategory="1"
         android:visible="true"/>
+    <item android:id="@+id/statistics_settings"
+        android:title="Include"
+        android:orderInCategory="1"
+        android:visible="true" >
+        <menu>
+            <item
+                android:id="@+id/action_show_absolutes"
+                android:title="Absolutes #s"
+                android:onClick="toggleStatisticsShowAbsolutes"
+                android:checkable="true"
+                android:visible="true" />
+            <item
+                android:id="@+id/action_show_median"
+                android:title="Median BG"
+                android:onClick="toggleStatisticsShowMedianBG"
+                android:checkable="true"
+                android:visible="true" />
+            <item
+                android:id="@+id/action_show_a1cestimate"
+                android:title="Estimated A1C"
+                android:onClick="toggleStatisticsShowA1C"
+                android:checkable="true"
+                android:visible="true" />
+            <item
+                android:id="@+id/action_show_relsd"
+                android:title="Relative SD"
+                android:onClick="toggleStatisticsShowRelSD"
+                android:checkable="true"
+                android:visible="true" />
+            <item
+                android:id="@+id/action_show_gvi"
+                android:title="GVI"
+                android:onClick="toggleStatisticsShowGVI"
+                android:checkable="true"
+                android:visible="true" />
+            <item
+                android:id="@+id/action_show_pgs"
+                android:title="PGS"
+                android:onClick="toggleStatisticsShowPGS"
+                android:checkable="true"
+                android:visible="true" />
+        </menu>
+    </item>
 
 </menu>


### PR DESCRIPTION
This allows you to choose which items you would like to see on the statistics distribution page.
After this PR, you will only be able to remove some of the existing items.
If this is approved, we already have an open PR for adding capture rate.  I will work on that to add that to the menu and give credit to the person opening that PR.
Later, I would also like to add very high and very low.

Changing the pie chart to a bar chart as you requested will come later.

I chose using a simple menu so that after closing the menu, you will still be on the statistics page instead of going to the main screen.

I have avoided adding any strings so that we can make sure we are happy with English before any translation work starts.

So, why do we need this?
This is not a bug fix.  I think it can be useful.  The distribution page is already very cluttered and we have an open PR to add yet one more item to it.  This will allow one to remove what they don't need to clean up the page as they wish.

Please let me know what you think.