### PR TITLE
Some new translation keys

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -775,6 +775,8 @@
     <string name="glucose_meters">Glucose Meters</string>
     <string name="glucose_meter_options">Options for wireless glucose meters</string>
     <string name="auto_connect_to_meter">Automatically connect and retrieve data from a standard\'s compliant glucose meter like the Contour Next One</string>
+    <string name="summary_use_nfc_meter">Download glucose records from NFC meter when xDrip is open</string>
+    <string name="title_use_nfc_meter">Use NFC Meter</string>
     <string name="use_bluetooth_meter">Use Bluetooth Meter</string>
     <string name="scan_for_bluetooth_meter">Scan for Bluetooth Meter</string>
     <string name="meter_connect_sound">Enable this to play sound effects when the meter connects, disconnects or syncs data</string>
@@ -1243,6 +1245,12 @@
     <string name="title_tidepool_window_latency">Data Age Mins</string>
     <string name="summary_tidepool_dev_servers">If enabled, uploads will go to https://int-app.tidepool.org instead of the regular https://app.tidepool.org/</string>
     <string name="title_tidepool_dev_servers">Use Integration (test) servers</string>
+    <string name="summary_tidepool_upload_when_chargeonly">Upload data only when charging</string>
+    <string name="title_tidepool_upload_when_chargeonly">Only when charging</string>
+    <string name="summary_tidepool_upload_only_wifi">Upload data only when connected to an unmetered network like Wifi</string>
+    <string name="title_tidepool_upload_only_wifi">Only on Wifi</string>
+    <string name="summary_tidepool_upload_no_treatment">Upload only CGM data to avoid duplicates with manual pump upload</string>
+    <string name="title_tidepool_upload_no_treatment">Don\'t upload treatments</string>
     <string name="title_tidepool">Tidepool</string>
     <string name="show_help">Show Help</string>
     <string name="load_save_settings_on_sdcard">Load / Save Settings</string>
@@ -1325,6 +1333,8 @@
     <string name="summary_lefun_send_alarms">Send notifications to the band for glucose alarms</string>
     <string name="title_lefun_send_alarms">Send Alarms</string>
     <string name="title_lefun_option_shake_snoozes">Shake to Snooze</string>
+    <string name="summary_lefun_send_calls">Send call notifications to the band</string>
+    <string name="title_lefun_send_calls">Send Calls</string>
     <string name="title_lefun_screens_features">Lefun Screens / Features</string>
     <string name="title_features">Features</string>
     <string name="title_lefun_feature_lift_to_wak">Lift to Wake</string>
@@ -1392,6 +1402,8 @@
     <string name="title_ob1_g5_fallback_to_xdrip">Fallback to xDrip</string>
     <string name="summary_ob1_minimize_scanning">Use heuristics to minimize Bluetooth scanning + save power</string>
     <string name="title_ob1_minimize_scanning">Minimize Scanning</string>
+    <string name="summary_ob1_avoid_scanning">Avoid scanning as much as possible (reduces battery usage further)</string>
+    <string name="title_ob1_avoid_scanning">Avoid Scanning</string>
     <string name="summary_using_g6">I am using a G6, G7, Dexcom 1 or One+ Sensor</string>
     <string name="title_using_g6">G6/G7/Dex1/One+ Support</string>
     <string name="summary_ob1_g5_allow_resetbond">OB1 collector can unbond if it thinks the encryption has failed. If you get problems with it unpairing then disable this option. If you then totally lose connection, make sure this is enabled.</string>
@@ -1914,6 +1926,8 @@
     <string name="audio_focus_lower_volume_of_other_apps">Lower volume of other apps</string>
     <string name="audio_focus_pause_other_apps_playing_audio">Pause other apps playing audio</string>
     <string name="audio_focus_pause_all_other_sounds">Pause all other sounds</string>
+    <string name="wake_up_screen">Wake Screen</string>
+    <string name="wake_up_screen_summary">Wake up screen during alerts. Might unlock devices that don\'t have screen lock enabled.</string>
     <string name="use_camera_light">Use Camera Light</string>
     <string name="use_camera_light_summary">Flash camera light during alerts when connected to a charger</string>
     <string name="g7_should_start_automatically">G7 should start automatically</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -515,8 +515,8 @@
                 android:defaultValue="false"
                 android:dependency="lefun_enabled"
                 android:key="lefun_option_call_notifications"
-                android:summary="Send call notifications to the band (Android 6+)"
-                android:title="Send Calls" />
+                android:summary="@string/summary_lefun_send_calls"
+                android:title="@string/title_lefun_send_calls" />
 
             <PreferenceScreen android:title="@string/title_lefun_screens_features"
                 android:key="lefun_features">

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -383,8 +383,8 @@
                     android:dependency="ob1_minimize_scanning"
                     android:enabled="true"
                     android:key="ob1_avoid_scanning"
-                    android:summary="Avoid scanning as much as possible (reduces battery usage further)"
-                    android:title="Avoid Scanning" />
+                    android:summary="@string/summary_ob1_avoid_scanning"
+                    android:title="@string/title_ob1_avoid_scanning" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="using_g6"

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -298,18 +298,18 @@
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="tidepool_only_while_charging"
-                    android:summary="Upload data only when charging"
-                    android:title="Only when charging" />
+                    android:summary="@string/summary_tidepool_upload_when_chargeonly"
+                    android:title="@string/title_tidepool_upload_when_chargeonly" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="tidepool_only_while_unmetered"
-                    android:summary="Upload data only when connected to an unmetered network like Wifi"
-                    android:title="Only on Wifi" />
+                    android:summary="@string/summary_tidepool_upload_only_wifi"
+                    android:title="@string/title_tidepool_upload_only_wifi" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="tidepool_no_treatments"
-                    android:summary="Upload only CGM data to avoid duplicates with manual pump upload"
-                    android:title="Don't upload treatments" />
+                    android:summary="@string/summary_tidepool_upload_no_treatment"
+                    android:title="@string/title_tidepool_upload_no_treatment" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="tidepool_new_auth"
@@ -362,10 +362,10 @@
             <SwitchPreference
                 android:defaultValue="false"
                 android:key="nfc_meter_enabled"
-                android:summary="Download glucose records from NFC meter when xDrip is open"
+                android:summary="@string/summary_use_nfc_meter"
                 android:switchTextOff="@string/short_off_text_for_switches"
                 android:switchTextOn="@string/short_on_text_for_switches"
-                android:title="Use NFC Meter" />
+                android:title="@string/title_use_nfc_meter" />
             <SwitchPreference
                 android:defaultValue="false"
                 android:key="bluetooth_meter_enabled"

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -74,10 +74,10 @@
                 <SwitchPreference
                     android:defaultValue="false"
                     android:key="wake_phone_during_alerts"
-                    android:summary="Wake up screen during alerts. Might unlock devices that don't have screen lock enabled."
+                    android:summary="@string/wake_up_screen_summary"
                     android:switchTextOff="@string/short_off_text_for_switches"
                     android:switchTextOn="@string/short_on_text_for_switches"
-                    android:title="Wake Screen" />
+                    android:title="@string/wake_up_screen" />
 
                 <SwitchPreference
                     android:defaultValue="false"


### PR DESCRIPTION
I looked at the screenshots here:  https://github.com/NightscoutFoundation/xDrip/discussions/3715

And have taken the ones I thought would make sense to translate.  I have left a few that I was not sure about.

I have not made any change to the original English text except one.  There was Android 6 + in one.  I deleted that portion since we have now retired Android 6.

Please let me know what you think.  Thanks  
  
---  
  
The following images mark all the text that this PR moves to strings.  
![Screenshot_20241107-165154](https://github.com/user-attachments/assets/f8a31a27-167f-42df-b2aa-d04ab889dcdb)  ![Screenshot_20241107-165247](https://github.com/user-attachments/assets/eb4172b7-17e2-4892-8b2a-09377dcfe94b) ![Screenshot_20241107-165406](https://github.com/user-attachments/assets/d368c844-058c-408f-8ebf-6245cc2c95af) ![Screenshot_20241107-170041](https://github.com/user-attachments/assets/87ae661d-7975-48cc-9d46-8bcf312e8cec) ![Screenshot_20241107-170139](https://github.com/user-attachments/assets/1f9ea6b6-78de-4bad-80a1-48364258d01f)
