### PR TITLE
Persistent High Alert threshold fix

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/evaluators/PersistentHigh.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/evaluators/PersistentHigh.java
@@ -25,6 +25,7 @@ import java.util.List;
 import static com.eveningoutpost.dexdrip.models.JoH.msSince;
 import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalar;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
+import static com.eveningoutpost.dexdrip.utils.RangeVerification.defaultCorrection;
 import static com.eveningoutpost.dexdrip.utils.RangeVerification.verifyRange;
 
 public class PersistentHigh {
@@ -35,8 +36,9 @@ public class PersistentHigh {
 
     public static boolean checkForPersistentHigh() {
 
-        final double verifiedThreshold = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString("persistent_high_threshold_verified", "170"))); // Fetch the secondary threshold setting from preferences
+        defaultCorrection("persistent_high_threshold"); // Correct the defaults if needed.
         verifyRange("persistent_high_threshold"); // Verify the custom threshold and update the secondary setting when needed
+        final double verifiedThreshold = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString("persistent_high_threshold_verified", "170"))); // Fetch the secondary threshold setting from preferences
 
         if (!Pref.getBoolean("high_value_is_persistent_high_threshold", true)) { // If the user has chosen not to use the High Value as the threshold
             persistentHighThreshold = verifiedThreshold; // Set the threshold to the verified value of what the user has entered.

--- a/app/src/main/java/com/eveningoutpost/dexdrip/evaluators/PersistentHigh.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/evaluators/PersistentHigh.java
@@ -25,6 +25,7 @@ import java.util.List;
 import static com.eveningoutpost.dexdrip.models.JoH.msSince;
 import static com.eveningoutpost.dexdrip.models.JoH.niceTimeScalar;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
+import static com.eveningoutpost.dexdrip.utils.RangeVerification.verifyRange;
 
 public class PersistentHigh {
 
@@ -34,8 +35,11 @@ public class PersistentHigh {
 
     public static boolean checkForPersistentHigh() {
 
+        final double verifiedThreshold = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString("persistent_high_threshold_verified", "170"))); // Fetch the secondary threshold setting from preferences
+        verifyRange("persistent_high_threshold"); // Verify the custom threshold and update the secondary setting when needed
+
         if (!Pref.getBoolean("high_value_is_persistent_high_threshold", true)) { // If the user has chosen not to use the High Value as the threshold
-            persistentHighThreshold = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString("persistent_high_threshold", "170"))); // Set the threshold to the value chosen by the user
+            persistentHighThreshold = verifiedThreshold; // Set the threshold to the verified value of what the user has entered.
         }
 
         // skip if not enabled

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
@@ -61,6 +61,7 @@ public class Constants {
     public static final int ZXING_CAM_REQ_CODE = 49374;
     public static final int ZXING_FILE_REQ_CODE = 49375; // This is created by just incrementing the existing camera scan code from the zxing package
     public static final int SENSORY_EXPIRY_NOTIFICATION_ID = 2003;
+    public static final int OUT_OF_RANGE_GLUCOSE_ENTRY_ID = 2004; // The verifyRange method shows a notification with this ID if the entered value is out of range.
 
 
     // increments from this start number

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1,6 +1,7 @@
 package com.eveningoutpost.dexdrip.utils;
 
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
+import static com.eveningoutpost.dexdrip.utils.RangeVerification.defaultCorrection;
 import static com.eveningoutpost.dexdrip.utils.RangeVerification.verifyRange;
 import static com.eveningoutpost.dexdrip.xdrip.gs;
 
@@ -758,6 +759,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             if (isNumeric(stringValue)) {
                 final boolean domgdl = Pref.getString("units", "mgdl").equals("mgdl"); // Identify which unit is chosen
                 preference.setSummary(stringValue + "  " + (domgdl ? "mg/dl" : "mmol/l")); // Set the summary to show the value followed by the chosen unit
+                defaultCorrection(preference.getKey()); // Correct defaults if needed
                 verifyRange(preference.getKey()); // Reject the entered value if out of range
                 return true;
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -751,7 +751,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
     };
 
     private static Preference.OnPreferenceChangeListener sBindNumericUnitizedPreferenceSummaryToValueListener = new Preference.OnPreferenceChangeListener() { // This listener adds glucose unit in addition to the value to the summary
-        // It also verifies the value entered and reject it if outside the expected range.
+        // It also verifies the value entered and rejects it if outside the expected range.
         @Override
         public boolean onPreferenceChange(Preference preference, Object value) {
             String stringValue = value.toString();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/RangeVerification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/RangeVerification.java
@@ -22,62 +22,80 @@ import lombok.val;
 
 public class RangeVerification {
     private static final String TAG = RangeVerification.class.getSimpleName();
-    // We may some day parameterize the following two.
     private static double MIN = 40; // The smallest blood glucose value xDrip accepts as an input
     private static double MAX = 400; // The greatest blood glucose value xDrip accepts as an input
-    private static boolean doMgdl;
-    private static String msg = "";
-    private static String unit = "";
+
     public static boolean verifyRange(String prefKey) {
 
-        doMgdl = (Pref.getString("units", "mgdl").compareTo("mgdl") == 0); // True if we are using mg/dL - False if we are using mmol/L
-        final Double valueUiMgdl = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString(prefKey, ""))); // The value entered by the user shown in mg/dL
+        boolean doMgdl = (Pref.getString("units", "mgdl").compareTo("mgdl") == 0); // True if we are using mg/dL - False if we are using mmol/L
+        double valueUiMgdl = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString(prefKey, ""))); // The value entered by the user shown in mg/dL
         final String prefVerifiedKey = prefKey + "_verified"; // The key for the shadow setting representing the verified value
-        final Double valueVerMgdl = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString(prefVerifiedKey, ""))); // Verified entered value in mg/dL
+        double valueVerMgdl = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString(prefVerifiedKey, ""))); // Verified entered value in mg/dL
 
-        msg = "Value needs to be between " + unitsConvert2Disp(doMgdl, MIN) + " and " + unitsConvert2Disp(doMgdl, MAX); // Toast and notification content
-        unit = "mmol/l";
+        String unit = "mmol/l";
         if (doMgdl) { // Correct the unit if needed
             unit = "mg/dl";
         }
-        final String msgLongLow = "Value entered is less than " + unitsConvert2Disp(doMgdl, MIN) + " " + unit + " and cannot be accepted";
-        final String msgLongHigh = "Value entered is greater than " + unitsConvert2Disp(doMgdl, MAX) + " " + unit + " and cannot be accepted";
+        final String msg = "Value needs to be between " + unitsConvert2Disp(doMgdl, MIN) + " and " + unitsConvert2Disp(doMgdl, MAX); // Toast and notification content
+        final String msgLongLow = prefKey + " value entered is less than " + unitsConvert2Disp(doMgdl, MIN) + " " + unit + " and cannot be accepted"; // Log content
+        final String msgLongHigh = prefKey + " value entered is greater than " + unitsConvert2Disp(doMgdl, MAX) + " " + unit + " and cannot be accepted"; // Log content
 
         if (valueUiMgdl < MIN) { // The value entered is less than the allowed minimum
-            if (doMgdl) { // We are using mg/dL
-                Pref.setString(prefKey, Long.toString(Math.round(valueVerMgdl))); // Correct the UI setting
-            } else { // We are using mmol/L
-                Pref.setString(prefKey, JoH.qs(Math.round(valueVerMgdl * Constants.MGDL_TO_MMOLL), 1)); // Correct the UI setting
-            }
-            JoH.static_toast_long(msg);
-            issueNotification(prefKey); // Unfortunately, the toast message comes up with a delay of a few seconds.  For that reason, a silent notification is also added.
+            undoChange(prefKey, msg); // Restore the setting to the value of its shadow.
             UserError.Log.e(TAG, msgLongLow);
             return false;
         } else if (valueUiMgdl > MAX) { // The value entered is greater than the allowed maximum
-            if (doMgdl) { // We are using mg/dL
-                Pref.setString(prefKey, Long.toString(Math.round(valueVerMgdl))); // Correct the UI setting
-            } else { // We are using mmol/L
-                Pref.setString(prefKey, JoH.qs(Math.round(valueVerMgdl * Constants.MGDL_TO_MMOLL), 1)); // Correct the UI setting
-            }
-            JoH.static_toast_long(msg);
-            issueNotification(prefKey); // Unfortunately, the toast message comes up with a delay of a few seconds.  For that reason, a silent notification is also added.
+            undoChange(prefKey, msg); // Restore the setting to the value of its shadow.
             UserError.Log.e(TAG, msgLongHigh);
             return false;
-
         } else { // The value entered is in range.
-            if (abs(valueUiMgdl - valueVerMgdl) > 0.01) { // Ignore values too close to the current value.
-                if (doMgdl) { // We are using mg/dL
-                    Pref.setString(prefVerifiedKey, Long.toString(Math.round(valueUiMgdl))); // Update the verified setting
-                } else { // We are using mmol/L
-                    Pref.setString(prefVerifiedKey, JoH.qs(Math.round(valueUiMgdl * Constants.MGDL_TO_MMOLL), 1)); // Update the verified setting
-                }
+            if (abs(valueUiMgdl - valueVerMgdl) > 0.01) { // Ignore submitted values too close to the current value.
+                approveChange(prefKey); // Update the shadow setting to the submitted value by the user
+                UserError.Log.d(TAG, "Approving " + prefKey + " submission");
             }
             return true;
         }
     }
 
-    private static void issueNotification(String title) { // Show a silent notification
+    public static void defaultCorrection(String prefKey) {
+        value2Large4mmol(prefKey); // Correct the default value if needed.
+        String shadowPrefKey = prefKey + "_verified"; // Shadow setting key
+        value2Large4mmol(shadowPrefKey); // Correct the default shadow value if needed.
+    }
+
+    private static void value2Large4mmol(String prefKey) { // The 35/36 correction mechanism is only triggered when the user changes units.
+        // But, the defaults are always in mg/dL.  If the unit is mmol/L, and the user updates from an older version of xDrip,
+        // the default value of the new setting will be in mg/dL and will never be corrected unless the user changes units back and forth.
+        // This method corrects the default value if needed even if the user does not change units.
+        boolean doMgdl = (Pref.getString("units", "mgdl").compareTo("mgdl") == 0);
+        if (!doMgdl) { // If we are using the mmol/L unit
+            double value = JoH.tolerantParseDouble(Pref.getString(prefKey, ""));
+            if (value > 35) { // If the value is greater than 35, it means the value corresponds to the mg/dL unit.
+                Pref.setString(prefKey, JoH.qs(value * Constants.MGDL_TO_MMOLL, 1)); // Convert the value from mg/dL to mmol/L
+                UserError.Log.d(TAG, "Converting " + prefKey + " to mmom/l " + value);
+            }
+        }
+    }
+
+    private static void undoChange(String prefKey, String msg) { // Restore the setting to the value of the shadow setting
+        String shadowKey = prefKey + "_verified"; // The key of the shadow setting
+        String old = Pref.getString(shadowKey, ""); // Shadow setting
+        Pref.setString(prefKey, old); // Restore the setting to the value of its shadow.
+        JoH.static_toast_long(msg);
+        rejectionNotification(prefKey, msg); // Unfortunately, the toast message comes up with a delay of a few seconds if there is an active session.
+        // If there is no active session, the toast will come up only when the user opens settings.
+        // For that reason, a silent notification is also shown to provide more detail and serve as a reminder.
+    }
+
+    private static void approveChange(String prefKey) { // Update the shadow setting to the new value entered by the user.
+        String shadowKey = prefKey + "_verified"; // The key of the shadow setting
+        String submission = Pref.getString(prefKey, ""); // Submitted setting
+        Pref.setString(shadowKey, submission); // Update the shadow setting
+    }
+
+    private static void rejectionNotification(String title, String msg) { // Show a silent notification
         val notificationId = OUT_OF_RANGE_GLUCOSE_ENTRY_ID; // Notification ID
         showNotification(title, msg, null, notificationId, null, false, false, null, null, null, true);
     }
 }
+

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/RangeVerification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/RangeVerification.java
@@ -1,0 +1,86 @@
+package com.eveningoutpost.dexdrip.utils;
+
+import static com.eveningoutpost.dexdrip.EditAlertActivity.unitsConvert2Disp;
+import static com.eveningoutpost.dexdrip.models.JoH.showNotification;
+import static com.eveningoutpost.dexdrip.utilitymodels.Constants.OUT_OF_RANGE_GLUCOSE_ENTRY_ID;
+import static com.eveningoutpost.dexdrip.utilitymodels.Constants.SENSORY_EXPIRY_NOTIFICATION_ID;
+import static java.lang.Math.abs;
+
+import android.preference.PreferenceScreen;
+
+import com.eveningoutpost.dexdrip.Home;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.models.UserError;
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+
+import lombok.val;
+
+/**
+ * Navid200
+ * <p>
+ * Utility for verifying that the glucose value entered is in the expected range.
+ * If it is not, the setting is corrected back to what it was and the user is notified by a log, a toast and a notification.
+ */
+
+public class RangeVerification {
+    private static final String TAG = RangeVerification.class.getSimpleName();
+    // We may some day parameterize the following two.
+    private static double MIN = 40; // The smallest blood glucose value xDrip accepts as an input
+    private static double MAX = 400; // The greatest blood glucose value xDrip accepts as an input
+    private static boolean doMgdl;
+    private static String msg = "";
+    private static String unit = "";
+    public static boolean verifyRange(String prefKey) {
+
+        doMgdl = (Pref.getString("units", "mgdl").compareTo("mgdl") == 0); // True if we are using mg/dL - False if we are using mmol/L
+        final Double valueUiMgdl = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString(prefKey, ""))); // The value entered by the user shown in mg/dL
+        final String prefVerifiedKey = prefKey + "_verified"; // The key for the shadow setting representing the verified value
+        final Double valueVerMgdl = Home.convertToMgDlIfMmol(JoH.tolerantParseDouble(Pref.getString(prefVerifiedKey, ""))); // Verified entered value in mg/dL
+
+        msg = "Value needs to be between " + unitsConvert2Disp(doMgdl, MIN) + " and " + unitsConvert2Disp(doMgdl, MAX); // Toast and notification content
+        unit = "mmol/l";
+        if (doMgdl) { // Correct the unit if needed
+            unit = "mg/dl";
+        }
+        final String msgLongLow = "Value entered is less than " + unitsConvert2Disp(doMgdl, MIN) + " " + unit + " and cannot be accepted";
+        final String msgLongHigh = "Value entered is greater than " + unitsConvert2Disp(doMgdl, MAX) + " " + unit + " and cannot be accepted";
+
+        if (valueUiMgdl < MIN) { // The value entered is less than the allowed minimum
+            if (doMgdl) { // We are using mg/dL
+                Pref.setString(prefKey, Long.toString(Math.round(valueVerMgdl))); // Correct the UI setting
+            } else { // We are using mmol/L
+                Pref.setString(prefKey, JoH.qs(Math.round(valueVerMgdl * Constants.MGDL_TO_MMOLL), 1)); // Correct the UI setting
+            }
+            JoH.static_toast_long(msg);
+            issueNotification(prefKey); // Unfortunately, the toast message comes up with a delay of a few seconds.  For that reason, a silent notification is also added.
+            UserError.Log.e(TAG, msgLongLow);
+            return false;
+        } else if (valueUiMgdl > MAX) { // The value entered is greater than the allowed maximum
+            if (doMgdl) { // We are using mg/dL
+                Pref.setString(prefKey, Long.toString(Math.round(valueVerMgdl))); // Correct the UI setting
+            } else { // We are using mmol/L
+                Pref.setString(prefKey, JoH.qs(Math.round(valueVerMgdl * Constants.MGDL_TO_MMOLL), 1)); // Correct the UI setting
+            }
+            JoH.static_toast_long(msg);
+            issueNotification(prefKey); // Unfortunately, the toast message comes up with a delay of a few seconds.  For that reason, a silent notification is also added.
+            UserError.Log.e(TAG, msgLongHigh);
+            return false;
+
+        } else { // The value entered is in range.
+            if (abs(valueUiMgdl - valueVerMgdl) > 0.01) { // Ignore values too close to the current value.
+                if (doMgdl) { // We are using mg/dL
+                    Pref.setString(prefVerifiedKey, Long.toString(Math.round(valueUiMgdl))); // Update the verified setting
+                } else { // We are using mmol/L
+                    Pref.setString(prefVerifiedKey, JoH.qs(Math.round(valueUiMgdl * Constants.MGDL_TO_MMOLL), 1)); // Update the verified setting
+                }
+            }
+            return true;
+        }
+    }
+
+    private static void issueNotification(String title) { // Show a silent notification
+        val notificationId = OUT_OF_RANGE_GLUCOSE_ENTRY_ID; // Notification ID
+        showNotification(title, msg, null, notificationId, null, false, false, null, null, null, true);
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/RangeVerification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/RangeVerification.java
@@ -3,10 +3,7 @@ package com.eveningoutpost.dexdrip.utils;
 import static com.eveningoutpost.dexdrip.EditAlertActivity.unitsConvert2Disp;
 import static com.eveningoutpost.dexdrip.models.JoH.showNotification;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.OUT_OF_RANGE_GLUCOSE_ENTRY_ID;
-import static com.eveningoutpost.dexdrip.utilitymodels.Constants.SENSORY_EXPIRY_NOTIFICATION_ID;
 import static java.lang.Math.abs;
-
-import android.preference.PreferenceScreen;
 
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.models.JoH;

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -313,6 +313,13 @@
                         android:inputType="numberDecimal"
                         android:key="persistent_high_threshold"
                         android:title="@string/title_persistent_high_threshold" />
+                    <!-- The following item must be set to be invisible.
+                      It is used as a memory containing the verified version of the threshold.
+                      Its key must be identical to that of the setting it shadows with the suffix _verified
+                      Its default value must be set to match that of the main variable it shadows.  -->
+                    <EditTextPreference
+                        android:defaultValue="170"
+                        android:key="persistent_high_threshold_verified" />
                     <EditTextPreference
                         android:defaultValue="60"
                         android:dependency="persistent_high_alert_enabled"


### PR DESCRIPTION
I forgot to include verification for the threshold range.  This PR adds that.  
  
We wait for the threshold to be changed to trigger a listener.  Then, we fix it if the value is out of range.
This means that in the meantime, the alert could be using an incorrect threshold.  
Also, if the app crashes just after a new threshold is added but before verification, it will never be corrected.

To avoid those, I have added a second preference.  The alert only uses the second setting.  This effectively isolates the alert from transitionary changes the UI setting may experience.  
  
There is no before/after because there is no change to how the user interface looks.  The new setting is invisible.    
  
I wish I knew a way to accomplish these simple objectives with a PR much smaller than this.  
I am open to suggestions.  

I have intentionally left everything in English.  After this is used and tested and verified, I will open a PR and add all the new text to strings so that they can be translated.

Thanks