### PR TITLE
Silent upload chunk logs

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/UploadChunk.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/UploadChunk.java
@@ -53,7 +53,7 @@ public class UploadChunk implements NamedSliderProcessor {
 
     public static String get(final long start, final long end) {
 
-        UserError.Log.uel(TAG, "Syncing data between: " + dateTimeText(start) + " -> " + dateTimeText(end));
+        UserError.Log.d(TAG, "Syncing data between: " + dateTimeText(start) + " -> " + dateTimeText(end));
         if (end <= start) {
             UserError.Log.e(TAG, "End is <= start: " + dateTimeText(start) + " " + dateTimeText(end));
             return null;


### PR DESCRIPTION
Makes the upload logs silent.  There are too many of them:  
  
![Screenshot_20241030-114336](https://github.com/user-attachments/assets/688d6d5b-8957-4bb6-ba71-51512098812a)
