### PR TITLE
Hidden xDrip Sync Key

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1767,7 +1767,6 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             if (this.prefs.getString("custom_sync_key", "").equals("")) {
                 this.prefs.edit().putString("custom_sync_key", CipherUtils.getRandomHexKey()).apply();
             }
-            bindPreferenceSummaryToValue(findPreference("custom_sync_key")); // still needed?
 
             bindPreferenceSummaryToValue(findPreference("xplus_insulin_dia"));
             bindPreferenceSummaryToValue(findPreference("xplus_liver_sensitivity"));


### PR DESCRIPTION
xDrip currently shows the xDrip Sync key as the summary of the sync key on the settings page.
It gets captured in screenshots and posted in forums.

This PR removes the key from the summary on the settings page.
The user can still see the key by tapping on the setting.

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20241101-194031](https://github.com/user-attachments/assets/95db8be6-d2a0-4f73-b0b7-bbee6dc6ff1c) | ![Screenshot_20241101-194404](https://github.com/user-attachments/assets/564f2be7-d415-4481-825e-77b18d9b37fd) |  
| ![Screenshot_20241101-194055](https://github.com/user-attachments/assets/a0543aaf-4650-4750-9a81-10fec6309c89) | ![Screenshot_20241101-194423](https://github.com/user-attachments/assets/38262697-c6f0-45c2-a3a5-cc590aad3098) |  





 xDrip sync key hidden on the settings page.