### PR TITLE
Classic status page session start fix

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/MicroStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/MicroStatus.java
@@ -12,5 +12,6 @@ public interface MicroStatus {
 
     boolean xmitterBattery();
 
+    boolean sessionStartTime(); // Show session start time on the classic status page only when true (not G7)
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/MicroStatusImpl.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/MicroStatusImpl.java
@@ -35,6 +35,11 @@ public class MicroStatusImpl extends BaseObservable implements MicroStatus {
     }
 
     @Override
+    public boolean sessionStartTime() { // This is false only if we are using G7
+        return !getBestCollectorHardwareName().equals("G7");
+    }
+
+    @Override
     public boolean xmitterBattery() {
         return DexCollectionType.usesClassicTransmitterBattery();
     }

--- a/app/src/main/res/layout/activity_system_status.xml
+++ b/app/src/main/res/layout/activity_system_status.xml
@@ -129,7 +129,7 @@
 
             <LinearLayout
                 android:id="@+id/layout_sensor"
-                app:showIfTrue="@{ms.bluetooth()}"
+                app:showIfTrue="@{ms.sessionStartTime()}"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"


### PR DESCRIPTION
I removed session start time from the classic status page for G7 here: https://github.com/NightscoutFoundation/xDrip/pull/3531 

But, it is affecting other devices: https://github.com/NightscoutFoundation/xDrip/issues/3749  

This PR changes the logic used to determine if the start time should be shown or not.  It focuses on G7.  It shows it always except for G7.  This should address the problem we are facing now.  

Fixes: https://github.com/NightscoutFoundation/xDrip/issues/3749 