### PR TITLE
Persistent High threshold fix

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip.utilitymodels;
 
+import static com.eveningoutpost.dexdrip.utils.Preferences.handleUnitsChange;
+
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -60,6 +62,9 @@ public class IdempotentMigrations {
         IncompatibleApps.notifyAboutIncompatibleApps();
         CompatibleApps.notifyAboutCompatibleApps();
         legacySettingsMoveLanguageFromNoToNb();
+        if (!Pref.getString("units", "mgdl").equals("mgdl")) { // Only if the selected unit is mmol/L
+            handleUnitsChange(null, "mmol", null); // Trigger the correction of values (defaults) if needed
+        }
 
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -761,7 +761,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 final boolean domgdl = Pref.getString("units", "mgdl").equals("mgdl"); // Identify which unit is chosen
                 double submissionMgdl = domgdl ? tolerantParseDouble(stringValue) : tolerantParseDouble(stringValue) * Constants.MMOLL_TO_MGDL;
                 if (submissionMgdl > MAX_GLUCOSE_INPUT || submissionMgdl < MIN_GLUCOSE_INPUT) {
-                    JoH.static_toast_long(xdrip.gs(R.string.the_value_must_be_between_min_and_max,unitsConvert2Disp(domgdl, MIN_GLUCOSE_INPUT), unitsConvert2Disp(domgdl, MAX_GLUCOSE_INPUT)));
+                    JoH.static_toast_long(xdrip.gs(R.string.the_value_must_be_between_min_and_max, unitsConvert2Disp(domgdl, MIN_GLUCOSE_INPUT), unitsConvert2Disp(domgdl, MAX_GLUCOSE_INPUT)));
                     return false; // Reject input if out of range
                 }
                 preference.setSummary(stringValue + "  " + (domgdl ? "mg/dl" : "mmol/l")); // Set the summary to show the value followed by the chosen unit

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,6 +243,7 @@
     <string name="persistent_high_alert">Persistent High Alert</string>
     <string name="persistent_high_alert_enable">Enable</string>
     <string name="title_persistent_high_threshold">Threshold</string>
+    <string name="the_value_must_be_between_min_and_max">The value must be between %1$s and %2$s</string>
     <string name="forecasted_low_alert">Forecasted Low Alert</string>
     <string name="extrapolate_data_to_try_to_predict_lows">Extrapolate data to try to predict lows</string>
     <string name="alarm_at_forecasted_low_mins">Alarm at Forecasted Low mins</string>


### PR DESCRIPTION
This PR fixes two issues I caused adding Persistent High threshold (https://github.com/NightscoutFoundation/xDrip/pull/3704).

1- You can enter any value as persistent high threshold.
This PR rejects all values that are outside the 40-400 mg/dL range.

2- If xDrip is already installed and mmol/L is selected and xDrip is updated to our latest Nightly (2024.10.11), the threshold will be set to 170 mmol/L.
The user will need to change units to mg/dL and back to mmol/L to correct that to 9.4 mmol/L.
This PR does the correction automatically.