### PR TITLE
Enable Use xDrip Cloud by default

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cloud/jamcm/Pusher.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cloud/jamcm/Pusher.java
@@ -121,7 +121,7 @@ public class Pusher {
     }
 
     public static boolean enabled() {
-        return Pref.getBoolean("use_xdrip_cloud_sync", false);
+        return Pref.getBoolean("use_xdrip_cloud_sync", true);
     }
 
     public static boolean connected() {

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -860,7 +860,7 @@
                 android:summary="@string/summary_plus_accept_follower_actions"
                 android:title="@string/title_plus_accept_follower_actions" />
             <SwitchPreference
-                android:defaultValue="false"
+                android:defaultValue="true"
                 android:key="use_xdrip_cloud_sync"
                 android:summary="@string/summary_plus_xdrip_cloud"
                 android:switchTextOff="@string/short_off_text_for_switches"


### PR DESCRIPTION
This PR enables `Use xDrip Cloud` by default.  
<br/>  
<br/>  
  
![Screenshot 2024-11-03 204243](https://github.com/user-attachments/assets/76b11c89-2907-466d-b89d-acd6ac617e1f)
