### PR TITLE
Persistent High Alert Threshold range

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -194,8 +194,8 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
     private void refreshFragments() {
         refreshFragments(null);
     }
-    private static final double MIN_GLUCOSE_INPUT = 40; // The smallest acceptable input glucose value in mg/dL
-    private static final double MAX_GLUCOSE_INPUT = 400; // The largest acceptable input glucose value in mg/dL
+    public static final double MIN_GLUCOSE_INPUT = 40; // The smallest acceptable input glucose value in mg/dL
+    public static final double MAX_GLUCOSE_INPUT = 400; // The largest acceptable input glucose value in mg/dL
 
     private void refreshFragments(final String jumpTo) {
         this.preferenceFragment = new AllPrefsFragment(jumpTo);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip.utils;
 
+import static com.eveningoutpost.dexdrip.EditAlertActivity.unitsConvert2Disp;
+import static com.eveningoutpost.dexdrip.models.JoH.tolerantParseDouble;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
 import static com.eveningoutpost.dexdrip.xdrip.gs;
 
@@ -192,6 +194,8 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
     private void refreshFragments() {
         refreshFragments(null);
     }
+    private static final double MIN_GLUCOSE_INPUT = 40; // The smallest acceptable input glucose value in mg/dL
+    private static final double MAX_GLUCOSE_INPUT = 400; // The largest acceptable input glucose value in mg/dL
 
     private void refreshFragments(final String jumpTo) {
         this.preferenceFragment = new AllPrefsFragment(jumpTo);
@@ -749,16 +753,21 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
         }
     };
 
-    private static Preference.OnPreferenceChangeListener sBindNumericUnitizedPreferenceSummaryToValueListener = new Preference.OnPreferenceChangeListener() { // This listener adds glucose unit in addition to the value to the summary
+    private static Preference.OnPreferenceChangeListener sBindNumericUnitizedPreferenceSummaryToValueListener = new Preference.OnPreferenceChangeListener() { // This listener adds glucose unit in addition to the value to the summary and rejects out-of-range inputs
         @Override
         public boolean onPreferenceChange(Preference preference, Object value) {
             String stringValue = value.toString();
             if (isNumeric(stringValue)) {
                 final boolean domgdl = Pref.getString("units", "mgdl").equals("mgdl"); // Identify which unit is chosen
+                double submissionMgdl = domgdl ? tolerantParseDouble(stringValue) : tolerantParseDouble(stringValue) * Constants.MMOLL_TO_MGDL;
+                if (submissionMgdl > MAX_GLUCOSE_INPUT || submissionMgdl < MIN_GLUCOSE_INPUT) {
+                    JoH.static_toast_long(xdrip.gs(R.string.the_value_must_be_between_min_and_max, unitsConvert2Disp(domgdl, MIN_GLUCOSE_INPUT), unitsConvert2Disp(domgdl, MAX_GLUCOSE_INPUT)));
+                    return false; // Reject input if out of range
+                }
                 preference.setSummary(stringValue + "  " + (domgdl ? "mg/dl" : "mmol/l")); // Set the summary to show the value followed by the chosen unit
-                return true;
+                return true; // Accept input as it is numeric and in range
             }
-            return false;
+            return false; // Reject input if not numeric
         }
     };
     private static Preference.OnPreferenceChangeListener sBindPreferenceTitleAppendToValueListenerUpdateChannel = new Preference.OnPreferenceChangeListener() {
@@ -1009,7 +1018,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                         .getString(preference.getKey(), ""));
     }
 
-    private static void bindPreferenceSummaryToUnitizedValueAndEnsureNumeric(Preference preference) { // Use this to show the value as well as the corresponding glucose unit as the summary
+    private static void bindPreferenceSummaryToUnitizedValueAndEnsureNumeric(Preference preference) { // Use this to show the value as well as the corresponding glucose unit as the summary, and reject out-of-range inputs
         preference.setOnPreferenceChangeListener(sBindNumericUnitizedPreferenceSummaryToValueListener);
         sBindNumericUnitizedPreferenceSummaryToValueListener.onPreferenceChange(preference,
                 PreferenceManager

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,6 +243,7 @@
     <string name="persistent_high_alert">Persistent High Alert</string>
     <string name="persistent_high_alert_enable">Enable</string>
     <string name="title_persistent_high_threshold">Threshold</string>
+    <string name="the_value_must_be_between_min_and_max">The value must be between %1$s and %2$s</string>
     <string name="forecasted_low_alert">Forecasted Low Alert</string>
     <string name="extrapolate_data_to_try_to_predict_lows">Extrapolate data to try to predict lows</string>
     <string name="alarm_at_forecasted_low_mins">Alarm at Forecasted Low mins</string>


### PR DESCRIPTION
This PR only imposes a range on the persistent high alert threshold.  

I will address the other requirements in another PR to make this one independent and easier to review.  

The following images show the toast message shown when the input is out of range, for the two units, and is rejected.

 
![Screenshot_20241109-214259](https://github.com/user-attachments/assets/1d3eec41-fec9-47cd-88d7-cc72e3a8fd77) ![Screenshot_20241109-214346](https://github.com/user-attachments/assets/017cd127-b9ab-4e55-8b07-dd24fc5daeca)

