### PR TITLE
Sync battery level on status page

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/RollCall.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/RollCall.java
@@ -296,7 +296,7 @@ public class RollCall {
         for (Map.Entry entry : indexed.entrySet()) {
             final RollCall rc = (RollCall) entry.getValue();
             // TODO refactor with stringbuilder
-            lf.add(new StatusItem(rc.role + (desert_sync ? rc.getRemoteWifiIndicate(our_wifi_ssid) : "") + (engineering ? ("\n" + JoH.niceTimeSince(rc.last_seen) + " ago") : ""), rc.bestName() + (desert_sync ? rc.getRemoteIpStatus() : "") + (engineering && rc.batteryValid() ? ("\n" + rc.battery + "%") : "") + (engineering && rc.bridgeBatteryValid() ? (" " + rc.bridge_battery+"%") : "")));
+            lf.add(new StatusItem(rc.role + (desert_sync ? rc.getRemoteWifiIndicate(our_wifi_ssid) : "") + (engineering ? ("\n" + JoH.niceTimeSince(rc.last_seen) + " ago") : ""), rc.bestName() + (desert_sync ? rc.getRemoteIpStatus() : "") + (rc.batteryValid() ? ("\n" + rc.battery + "%") : "") + (engineering && rc.bridgeBatteryValid() ? (" " + rc.bridge_battery+"%") : "")));
         }
 
         Collections.sort(lf, new Comparator<StatusItem>() {


### PR DESCRIPTION
Show master battery level on the follower status page with no need to enable engineering mode:

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20241208-184034](https://github.com/user-attachments/assets/86fccd61-385e-4b39-8b96-53448d299ba4) | ![Screenshot_20241208-185109](https://github.com/user-attachments/assets/ea77348b-9436-4aa8-bcf3-840c8dfa932f) |  
<br/>  
  
---  
  
**Please note**  
This has an unintended ramification:
The battery levels of all followers will also be shown on the status page of the master.  
If this is unacceptable, we will need to complicate the code to only show this on the followers but not on the master.
I hope this is not a problem.  
