### PR TITLE
Time unit symbols for the Dex status page last connected

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
@@ -754,26 +754,29 @@ public class JoH {
     }
 
     // temporary
-    public static String niceTimeScalar(long t) {
+    public static String niceTimeScalar(long t) { // If forceSym is not entered as a parameter, a value of false will be assumed for it.
+        return niceTimeScalar(t, false); // The method will use translations, instead of symbols, if forceSym is set to false.
+    }
+        public static String niceTimeScalar(long t, boolean forceSym) { // Symbols will be used if forceSym is true, regardless of the chosen language
         String unit = xdrip.getAppContext().getString(R.string.unit_second);
         t = t / 1000;
-        if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_seconds);
+        if (t != 1) unit = forceSym? "s" : xdrip.getAppContext().getString(R.string.unit_seconds);
         if (t > 59) {
-            unit = xdrip.getAppContext().getString(R.string.unit_minute);
+            unit = forceSym? "min" : xdrip.getAppContext().getString(R.string.unit_minute);
             t = t / 60;
-            if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_minutes);
+            if (t != 1) unit = forceSym? "min" : xdrip.getAppContext().getString(R.string.unit_minutes);
             if (t > 59) {
-                unit = xdrip.getAppContext().getString(R.string.unit_hour);
+                unit = forceSym? "h" : xdrip.getAppContext().getString(R.string.unit_hour);
                 t = t / 60;
-                if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_hours);
+                if (t != 1) unit = forceSym? "h" : xdrip.getAppContext().getString(R.string.unit_hours);
                 if (t > 24) {
-                    unit = xdrip.getAppContext().getString(R.string.unit_day);
+                    unit = forceSym? "d" : xdrip.getAppContext().getString(R.string.unit_day);
                     t = t / 24;
-                    if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_days);
+                    if (t != 1) unit = forceSym? "d" : xdrip.getAppContext().getString(R.string.unit_days);
                     if (t > 28) {
-                        unit = xdrip.getAppContext().getString(R.string.unit_week);
+                        unit = forceSym? "wk" : xdrip.getAppContext().getString(R.string.unit_week);
                         t = t / 7;
-                        if (t != 1) unit = xdrip.getAppContext().getString(R.string.unit_weeks);
+                        if (t != 1) unit = forceSym? "wk" : xdrip.getAppContext().getString(R.string.unit_weeks);
                     }
                 }
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -2175,7 +2175,9 @@ public class Ob1G5CollectionService extends G5BaseService {
         }
 
         if (static_last_connected > 0) {
-            l.add(new StatusItem("Last Connected", niceTimeScalar(msSince(static_last_connected)) + " ago"));
+            l.add(new StatusItem("Last Connected", niceTimeScalar(msSince(static_last_connected), true) + " ago")); // Time symbols are used to avoid translations.
+            // This parameter is extremely important when troubleshooting connectivity.  Let's use symbols for this parameter on this page so that those helping won't have to
+            // translate back to English or other languages, which could possibly cause errors.
         }
 
         if ((!lastState.startsWith("Service Stopped")) && (!lastState.startsWith("Not running")))


### PR DESCRIPTION
Please let's use time unit symbols on the status page for last connected at least.  
Then, I won't have to keep using a translator to find out if the translated unit is seconds or minutes.
  
The following table shows what the status page looks like before and after this PR when last connected is 2 minutes ago.  

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20241216-114044](https://github.com/user-attachments/assets/4e9f9619-3b59-4618-aeb4-c2805d30942a) | ![Screenshot_20241216-114517](https://github.com/user-attachments/assets/d9a92641-6e62-4440-9d71-a08968bb343c) |  
  
The following image shows what the seconds symbol will look like after this PR:
![Screenshot_20241216-114328](https://github.com/user-attachments/assets/0c414f46-5a7a-4736-9cf8-25cf2cb85001)

