### PR TITLE
Hide Nightscout base URL

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1144,7 +1144,6 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             bindPreferenceSummaryToValue(findPreference("cloud_storage_mongodb_uri"));
             bindPreferenceSummaryToValue(findPreference("cloud_storage_mongodb_collection"));
             bindPreferenceSummaryToValue(findPreference("cloud_storage_mongodb_device_status_collection"));
-            bindPreferenceSummaryToValue(findPreference("cloud_storage_api_base"));
 
             addPreferencesFromResource(R.xml.pref_advanced_settings);
             addPreferencesFromResource(R.xml.xdrip_plus_prefs);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="pref_title_api_enabled">Enabled</string>
     <string name="pref_summary_api_enabled">The REST API is the standard way to connect to Nightscout</string>
     <string name="pref_title_api_url">Base URL</string>
+    <string name="pref_summary_api_url">Format: https://password@hostname/api/v1/</string>
     <string name="pref_dialog_api_url">Enter Base API URL</string>
     <string name="pref_message_api_url">This only the base URL, the uploader will automatically append /entries for the POST.  API_SECRET on the server should match yourpassphrase in this setting.</string>
     <string name="pref_default_api_url">https://yourpassphrase@{YOUR-SITE}.azurewebsites.net/api/v1/</string>

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -58,7 +58,8 @@
                     android:dialogTitle="@string/pref_dialog_api_url"
                     android:inputType="textUri"
                     android:key="cloud_storage_api_base"
-                    android:title="@string/pref_title_api_url" />
+                    android:title="@string/pref_title_api_url"
+                    android:summary="@string/pref_summary_api_url"/>
 
                 <PreferenceScreen
                     android:key="download_treatments_screen"


### PR DESCRIPTION
Users often post a screenshot of their Nightscout settings page in forums revealing their API_SECRET and hostname.

This PR changes the base URL summary from the real URL to the expected format as a guide to the user.
The user can still see their base URL by tapping on the setting.  
  
The following shows my settings page with the base URLs covered as  before and what this PR will do as after.
  
| Before | After |  
| ------- | ------ |  
| ![Screenshot_20241216-201236](https://github.com/user-attachments/assets/77f3f9bf-2956-4c7e-9275-76546e273896) | ![Screenshot_20241216-201321](https://github.com/user-attachments/assets/b2440458-3527-4369-8168-a11a8fcb6728) |  
  