### PR TITLE
Decimal separator fix for Edit Alert

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -499,7 +499,7 @@ public class EditAlertActivity extends ActivityWithMenu {
         buttonSave.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 // Check that values are ok.
-                double threshold = parseDouble(alertThreshold.getText().toString());
+                double threshold = JoH.tolerantParseDouble(alertThreshold.getText().toString());
                 if(Double.isNaN(threshold))
                     return;
 


### PR DESCRIPTION
This is an alternative approach with respect to: https://github.com/NightscoutFoundation/xDrip/pull/2998  

I have used tolerantParseDouble().  
In the following table you can see the behaviors before and after.
Please pay attention at the very end to the fractional part, which is dropped before but, is preserved after.  

| Before | After |  
| ------- | ------ |  
| https://github.com/user-attachments/assets/db8b902d-00de-4221-b43a-c728c86db490 | https://github.com/user-attachments/assets/a7c622e9-d6be-48e0-b217-77efedba744a |  
  
