### PR TITLE
Retire sensor location setting

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NewSensorLocation.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NewSensorLocation.java
@@ -116,7 +116,7 @@ public class NewSensorLocation extends ActivityWithMenu {
 
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
 
-                prefs.edit().putBoolean("store_sensor_location", !DontAskAgain.isChecked()).apply();
+            //    prefs.edit().putBoolean("store_sensor_location", !DontAskAgain.isChecked()).apply();
 
                 Intent intent = new Intent(getApplicationContext(), Home.class);
                 startActivity(intent);
@@ -129,7 +129,7 @@ public class NewSensorLocation extends ActivityWithMenu {
 
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
 
-                prefs.edit().putBoolean("store_sensor_location", !DontAskAgain.isChecked()).apply();
+            //    prefs.edit().putBoolean("store_sensor_location", !DontAskAgain.isChecked()).apply();
 
                 Intent intent = new Intent(getApplicationContext(), Home.class);
                 startActivity(intent);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
@@ -224,11 +224,7 @@ public class StartNewSensor extends ActivityWithMenu {
         startSensorForTime(startTime);
 
         Intent intent;
-        if (Pref.getBoolean("store_sensor_location", false) && Experience.gotData()) {
-            intent = new Intent(getApplicationContext(), NewSensorLocation.class);
-        } else {
-            intent = new Intent(getApplicationContext(), Home.class);
-        }
+        intent = new Intent(getApplicationContext(), Home.class);
 
         startActivity(intent);
         finish();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -157,6 +157,7 @@ public class IdempotentMigrations {
         Pref.setBoolean("run_ble_scan_constantly", false);
         Pref.setBoolean("run_G5_ble_tasks_on_uithread", false);
         Pref.setBoolean("ob1_initiate_bonding_flag", true);
+        Pref.setBoolean("store_sensor_location", false);
     }
     private static void legacySettingsMoveLanguageFromNoToNb() {
         // Check if the user's language preference is set to "no"

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1618,15 +1618,6 @@
                     android:title="@string/title_NOT_FOR_PRODUCTION_USE" />
 
             </PreferenceScreen>
-            <PreferenceCategory
-                android:key="community_help_category"
-                android:title="@string/help_the_community">
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="store_sensor_location"
-                    android:summary="@string/help_the_developers_improve_the_algorithm"
-                    android:title="@string/store_sensor_location_to_help" />
-            </PreferenceCategory>
         </PreferenceScreen>
 
     </PreferenceCategory>


### PR DESCRIPTION
I could be wrong.  If I'm not, we are not going to improve calibration schemes.  We can fix bugs.  But, I don't think we have a use for where users place their sensors.
But, there could be users who keep submitting that data.
If I am right and we are not going to need the data, we might as well remove the setting.

This PR removes the sensor location setting and disables it to be sure going back in time will not break anything.

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20241217-221630](https://github.com/user-attachments/assets/1831e5fa-8472-4ce8-95f5-4e2793ce8022) | ![Screenshot_20241217-221815](https://github.com/user-attachments/assets/120ff47f-4e50-42c4-b660-79299b684af9) |  
  
