### PR TITLE
Daily intent service no charging requirement

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/jobs/DailyJob.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/jobs/DailyJob.java
@@ -37,7 +37,8 @@ public class DailyJob extends Job {
             new JobRequest.Builder(TAG)
                     .setPeriodic(Constants.DAY_IN_MS, Constants.HOUR_IN_MS * 12)
                     .setRequiresDeviceIdle(true)
-                    .setRequiresCharging(true)
+//                    .setRequiresCharging(true) // If the battery level is not low, we should run even if it is not being charged.
+                    .setRequiresBatteryNotLow(true)
                     .setRequiredNetworkType(JobRequest.NetworkType.UNMETERED)
                     .setUpdateCurrent(true)
                     .build()


### PR DESCRIPTION
Please see: https://github.com/NightscoutFoundation/xDrip/discussions/3815  

I don't believe we have an issue if the daily intent service does not run daily as long as it runs at least once a week.

But, I have a concern about the requirements.  We currently have a requirement of the phone being in the process of being charged.  
What if the battery level is extremely low?  Wouldn't it be a bad idea to run then even if it was being charged?

This PR replaces the requirement of being charged with a requirement of the battery level not being low.  
<br/>  
  
---  
  
**Tests**  
In progress