### PR TITLE
AOD bottom center setting fix

### DIFF
--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -558,7 +558,7 @@
                     android:title="@string/title_aod_use_center" />
                 <CheckBoxPreference
                     android:defaultValue="true"
-                    android:key="aod_use_top_center_bottom"
+                    android:key="aod_use_center_bottom"
                     android:summary="@string/summary_aod_use_center_bottom"
                     android:title="@string/title_aod_use_center_bottom" />
                 <CheckBoxPreference


### PR DESCRIPTION
I have tested this for each one of the 5 sections and they all seems to be working fine.
Testing our latest Nightly as is with bottom center selected only, I can see that the readings moves to all regions.
After this PR it does not and stays where it should.

The following screenshot is meant to help with the review.
![Screenshot 2025-01-10 161428](https://github.com/user-attachments/assets/282e24cf-05e1-437a-9b4c-cb210fd36528)
 