### PR TITLE
Stop an expired sensor

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/CalibrationState.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/CalibrationState.java
@@ -109,6 +109,10 @@ public enum CalibrationState {
         return !stopped.contains(this);
     }
 
+    public boolean sensorStopped() {
+        return stopped.contains(this);
+    }
+
     public boolean sensorFailed() {
         return failed.contains(this);
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -1018,7 +1018,6 @@ public class Ob1G5StateMachine {
         }
 
         // TODO check firmware version
-        stopExpiredSession(); // Stop the internal session if the sensor has expired.
         if (glucose.calibrationState().readyForBackfill() && !parent.getBatteryStatusNow) {
             backFillIfNeeded(parent, connection);
         }
@@ -1629,13 +1628,6 @@ public class Ob1G5StateMachine {
         }
     }
 
-    private static void stopExpiredSession() { // This stops the internal sensor if G7 has expired
-        if (Sensor.isActive()) { // If there is an active internal session
-            if (CalibrationState.Stopped.sensorStopped()) { // If the calibration state is "Stopped".
-                Sensor.stopSensor(); // Stop the internal session.
-            }
-        }
-    }
 
     private static void processSensorRxMessage(SensorRxMessage sensorRx) {
         if (sensorRx == null) return;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -1018,6 +1018,7 @@ public class Ob1G5StateMachine {
         }
 
         // TODO check firmware version
+        stopExpiredSession(); // Stop the internal session if the sensor has expired.
         if (glucose.calibrationState().readyForBackfill() && !parent.getBatteryStatusNow) {
             backFillIfNeeded(parent, connection);
         }
@@ -1628,6 +1629,13 @@ public class Ob1G5StateMachine {
         }
     }
 
+    private static void stopExpiredSession() { // This stops the internal sensor if G7 has expired
+        if (Sensor.isActive()) { // If there is an active internal session
+            if (CalibrationState.Stopped.sensorStopped()) { // If the calibration state is "Stopped".
+                Sensor.stopSensor(); // Stop the internal session.
+            }
+        }
+    }
 
     private static void processSensorRxMessage(SensorRxMessage sensorRx) {
         if (sensorRx == null) return;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -960,6 +960,10 @@ public class Ob1G5CollectionService extends G5BaseService {
 
     private synchronized void prepareToWakeup() {
         if (JoH.ratelimit("g5-wakeup-timer", 5)) {
+            if (Sensor.isActive() && CalibrationState.Stopped.sensorStopped()) { // If the calibration state is "Stopped" while there is an active internal session.
+                UserError.Log.e(TAG, "Stopping internal session because there is no active session on the device ");
+                Sensor.stopSensor(); // Stop the internal session.
+            }
             final long when = DexSyncKeeper.anticipate(transmitterID);
             if (when > 0) {
                 final long when_offset = when - tsl();


### PR DESCRIPTION
After a G7 expires, we don't stop the internal session.
When xDrip connects to the next sensor, it thinks that there is an active internal session.  Therefore, it requests a full backfill causing a backfill overlap.

When we stop a G6, we also stop the internal session.  After that, when we connect to a G7, xDrip starts a new session and takes into account the last readings and avoid a backfill overlap.

This PR will avoid a backfill overlap for G7 to G7 as well.  
<br/>  
   
---  
  
**Testing**  
Unfortunately, I can test this in 10 days I hope.  I will update then.

However, I will be able to test G6 to G7 before then to make sure nothing is negatively affected there.  I will add this test's results in a day or two.