### PR TITLE
CareLinkFollower - v11 data endpoint outside US

### DIFF
--- a/app/proguard-debug.pro
+++ b/app/proguard-debug.pro
@@ -59,3 +59,12 @@
 -keep class com.newrelic.** { *; }
 -dontwarn com.newrelic.**
 -keepattributes Exceptions, Signature, InnerClasses, LineNumberTable, SourceFile, EnclosingMethod
+
+-keep class com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.*
+-keep class com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.*
+-keep class com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.** { *; }
+-keep class com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.** { *; }
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -150,3 +150,10 @@
 -keepattributes Exceptions, Signature, InnerClasses, LineNumberTable
 
 -keep class com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.*
+-keep class com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.*
+-keep class com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.** { *; }
+-keep class com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.** { *; }
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkDataProcessor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/CareLinkDataProcessor.java
@@ -73,7 +73,7 @@ public class CareLinkDataProcessor {
             filteredSgList = new ArrayList<>();
             for (SensorGlucose sg : recentData.sgs) {
                 //SG DateTime is null (sensor expired?)
-                if (sg != null && sg.datetimeAsDate != null) {
+                if (sg != null && sg.getDate() != null) {
                     filteredSgList.add(sg);
                 }
             }
@@ -84,31 +84,31 @@ public class CareLinkDataProcessor {
                 sensor.save();
 
                 // place in order of oldest first
-                Collections.sort(filteredSgList, (o1, o2) -> o1.datetimeAsDate.compareTo(o2.datetimeAsDate));
+                Collections.sort(filteredSgList, (o1, o2) -> o1.getDate().compareTo(o2.getDate()));
 
                 for (final SensorGlucose sg : filteredSgList) {
 
                     //Not EPOCH 0 (warmup?)
-                    if (sg.datetimeAsDate.getTime() > 1) {
+                    if (sg.getDate().getTime() > 1) {
 
                         //Not in the future
-                        if (sg.datetimeAsDate.getTime() < new Date().getTime() + 300_000) {
+                        if (sg.getDate().getTime() < new Date().getTime() + 300_000) {
 
                             //Not 0 SG (not calibrated?)
                             if (sg.sg > 0) {
 
                                 //newer than last BG
-                                if (sg.datetimeAsDate.getTime() > lastBgTimestamp) {
+                                if (sg.getDate().getTime() > lastBgTimestamp) {
 
-                                    if (sg.datetimeAsDate.getTime() > 0) {
+                                    if (sg.getDate().getTime() > 0) {
 
                                         //New entry
-                                        if (BgReading.getForPreciseTimestamp(sg.datetimeAsDate.getTime(), 10_000) == null) {
+                                        if (BgReading.getForPreciseTimestamp(sg.getDate().getTime(), 10_000) == null) {
                                             UserError.Log.d(TAG, "NEW NEW NEW New entry: " + sg.toS());
 
                                             if (live) {
                                                 final BgReading bg = new BgReading();
-                                                bg.timestamp = sg.datetimeAsDate.getTime();
+                                                bg.timestamp = sg.getDate().getTime();
                                                 bg.calculated_value = (double) sg.sg;
                                                 bg.raw_data = SPECIAL_FOLLOWER_PLACEHOLDER;
                                                 bg.filtered_data = (double) sg.sg;
@@ -149,14 +149,14 @@ public class CareLinkDataProcessor {
             //Filter markers
             filteredMarkerList = new ArrayList<>();
             for (Marker marker : recentData.markers) {
-                if (marker != null && marker.type != null && marker.dateTime != null) {
+                if (marker != null && marker.type != null && marker.getDate() != null) {
                     filteredMarkerList.add(marker);
                 }
             }
 
             if (filteredMarkerList.size() > 0) {
                 //sort markers by time
-                Collections.sort(filteredMarkerList, (o1, o2) -> o1.dateTime.compareTo(o2.dateTime));
+                Collections.sort(filteredMarkerList, (o1, o2) -> o1.getDate().compareTo(o2.getDate()));
 
                 //process markers one-by-one
                 for (Marker marker : filteredMarkerList) {
@@ -164,10 +164,10 @@ public class CareLinkDataProcessor {
                     //FINGER BG
                     if (marker.isBloodGlucose() && Pref.getBooleanDefaultFalse("clfollow_download_finger_bgs")) {
                         //check required values
-                        if (marker.value != null && !marker.value.equals(0)) {
+                        if (marker.getBloodGlucose() != null && !marker.getBloodGlucose().equals(0)) {
                             //new blood test
-                            if (BloodTest.getForPreciseTimestamp(marker.dateTime.getTime(), 10000) == null) {
-                                BloodTest.create(marker.dateTime.getTime(), marker.value, SOURCE_CARELINK_FOLLOW);
+                            if (BloodTest.getForPreciseTimestamp(marker.getDate().getTime(), 10000) == null) {
+                                BloodTest.create(marker.getDate().getTime(), marker.getBloodGlucose(), SOURCE_CARELINK_FOLLOW);
                             }
                         }
 
@@ -186,15 +186,15 @@ public class CareLinkDataProcessor {
                             //Insulin
                             if (marker.type.equals(Marker.MARKER_TYPE_INSULIN)) {
                                 carbs = 0;
-                                if (marker.deliveredExtendedAmount != null && marker.deliveredFastAmount != null) {
-                                    insulin = marker.deliveredExtendedAmount + marker.deliveredFastAmount;
+                                if (marker.getInsulinAmount() != null) {
+                                    insulin = marker.getInsulinAmount();
                                 }
                                 //SKIP if insulin = 0
                                 if (insulin == 0) continue;
                                 //Carbs
                             } else if (marker.type.equals(Marker.MARKER_TYPE_MEAL)) {
-                                if (marker.amount != null) {
-                                    carbs = marker.amount;
+                                if (marker.getCarbAmount() != null) {
+                                    carbs = marker.getCarbAmount();
                                 }
                                 insulin = 0;
                                 //SKIP if carbs = 0
@@ -202,8 +202,8 @@ public class CareLinkDataProcessor {
                             }
 
                             //new Treatment
-                            if (newTreatment(carbs, insulin, marker.dateTime.getTime())) {
-                                t = Treatments.create(carbs, insulin, marker.dateTime.getTime());
+                            if (newTreatment(carbs, insulin, marker.getDate().getTime())) {
+                                t = Treatments.create(carbs, insulin, marker.getDate().getTime());
                                 if (t != null) {
                                     t.enteredBy = SOURCE_CARELINK_FOLLOW;
                                     t.save();
@@ -222,7 +222,7 @@ public class CareLinkDataProcessor {
         //PUMP INFO (Pump Status)
         if (recentData.isNGP()) {
             PumpStatus.setReservoir(recentData.reservoirRemainingUnits);
-            PumpStatus.setBattery(recentData.medicalDeviceBatteryLevelPercent);
+            PumpStatus.setBattery(recentData.getDeviceBatteryLevel());
             if (recentData.activeInsulin != null)
                 PumpStatus.setBolusIoB(recentData.activeInsulin.amount);
             PumpStatus.syncUpdate();
@@ -246,13 +246,13 @@ public class CareLinkDataProcessor {
                 //Active Notifications
                 if (recentData.notificationHistory.activeNotifications != null) {
                     for (ActiveNotification activeNotification : recentData.notificationHistory.activeNotifications) {
-                        addNotification(activeNotification.dateTime, recentData.getDeviceFamily(), activeNotification.messageId, activeNotification.faultId);
+                        addNotification(activeNotification.dateTime, recentData.getDeviceFamily(), activeNotification.getMessageId(), activeNotification.faultId);
                     }
                 }
                 //Cleared Notifications
                 if (recentData.notificationHistory.clearedNotifications != null) {
                     for (ClearedNotification clearedNotification : recentData.notificationHistory.clearedNotifications) {
-                        addNotification(clearedNotification.triggeredDateTime, recentData.getDeviceFamily(), clearedNotification.messageId, clearedNotification.faultId);
+                        addNotification(clearedNotification.triggeredDateTime, recentData.getDeviceFamily(), clearedNotification.getMessageId(), clearedNotification.faultId);
                     }
                 }
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -8,6 +8,7 @@ import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.ActiveNotification;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.ClearedNotification;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.CountrySettings;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.DataUpload;
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.DisplayMessage;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.Marker;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.MonitorData;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.Profile;
@@ -53,6 +54,9 @@ public class CareLinkClient {
     protected String carelinkCountry;
     protected static final String CARELINK_CONNECT_SERVER_EU = "carelink.minimed.eu";
     protected static final String CARELINK_CONNECT_SERVER_US = "carelink.minimed.com";
+    protected static final String CARELINK_CLOUD_SERVER_EU = "clcloud.minimed.eu";
+    protected static final String CARELINK_CLOUD_SERVER_US = "clcloud.minimed.com";
+    protected static final String API_PATH_DISPLAY_MESSAGE = "connect/carepartner/v11/display/message";
     protected static final String CARELINK_LANGUAGE_EN = "en";
     protected static final String CARELINK_AUTH_TOKEN_COOKIE_NAME = "auth_tmp_token";
     protected static final String CARELINK_TOKEN_VALIDTO_COOKIE_NAME = "c_token_valid_to";
@@ -197,6 +201,12 @@ public class CareLinkClient {
             return CARELINK_CONNECT_SERVER_EU;
     }
 
+    protected String cloudServer() {
+        if (this.carelinkCountry.equals("us"))
+            return CARELINK_CLOUD_SERVER_US;
+        else
+            return CARELINK_CLOUD_SERVER_EU;
+    }
 
     //Wrapper for common request of recent data (last 24 hours)
     public RecentData getRecentData() {
@@ -619,10 +629,14 @@ public class CareLinkClient {
     // Periodic data from CareLink Cloud
     public RecentData getConnectDisplayMessage(String username, String role, String patientUsername, String endpointUrl) {
 
-        RequestBody requestBody = null;
-        Gson gson = null;
-        JsonObject userJson = null;
+        RequestBody requestBody;
+        Gson gson;
+        JsonObject userJson;
         RecentData recentData = null;
+        DisplayMessage displayMessage;
+        boolean useNewEndpoint;
+        HttpUrl newEndpointUrl;
+
 
         // Build user json for request
         userJson = new JsonObject();
@@ -635,10 +649,33 @@ public class CareLinkClient {
 
         requestBody = RequestBody.create(MediaType.get("application/json; charset=utf-8"), gson.toJson(userJson));
 
+        //use new v11 endpoint outside US
+        useNewEndpoint = !this.carelinkCountry.equals("us") ? true : false;
+
+        //new endpoint url
+        newEndpointUrl = new HttpUrl.Builder()
+                .scheme("https")
+                .host(this.cloudServer())
+                .addPathSegments(API_PATH_DISPLAY_MESSAGE)
+                .build();
+
+        //get data and correct time
         try {
-            recentData = this.getData(HttpUrl.parse(endpointUrl), requestBody, RecentData.class);
-            if (recentData != null)
-                correctTimeInRecentData(recentData);
+            //Use old data format for old endpoint
+            if (!useNewEndpoint) {
+                recentData = this.getData(HttpUrl.parse(endpointUrl), requestBody, RecentData.class);
+                if (recentData != null) {
+                    correctTimeInRecentData(recentData);
+                }
+            }
+            //Use new data format outside US
+            else {
+                displayMessage = this.getData(newEndpointUrl, requestBody, DisplayMessage.class);
+                if (displayMessage != null && displayMessage.patientData != null) {
+                    correctTimeInDisplayMessage(displayMessage);
+                    recentData = displayMessage.patientData;
+                }
+            }
         } catch (Exception e) {
             lastErrorMessage = e.getClass().getSimpleName() + ":" + e.getMessage();
         }
@@ -668,6 +705,11 @@ public class CareLinkClient {
     }
 
     // General data request for API calls
+
+    protected <T> T getData(String host, String path, RequestBody requestBody, Class<T> dataClass) {
+           return  this.getData(new HttpUrl.Builder().scheme("https").host(host).addPathSegments(path).build(), requestBody, dataClass);
+    }
+
     protected <T> T getData(HttpUrl url, RequestBody requestBody, Class<T> dataClass) {
 
         Request.Builder requestBuilder = null;
@@ -771,6 +813,65 @@ public class CareLinkClient {
                 requestBuilder.addHeader("Content-Type", "application/x-www-form-urlencoded");
                 break;
         }
+
+    }
+
+    protected void correctTimeInDisplayMessage(DisplayMessage displayMessage) {
+
+        boolean timezoneMissing = false;
+        String offsetString = null;
+        RecentData recentData = null;
+
+        recentData = displayMessage.patientData;
+
+        //time data is available to check and correct time if needed
+        if (recentData.lastConduitDateTime != null && recentData.lastConduitDateTime.getTime() > 1
+                && recentData.lastConduitUpdateServerDateTime  > 1) {
+
+            //Correct times if server <> device > 26 mins => possibly different time zones
+            int diffInHour = (int) Math.round(((recentData.lastConduitUpdateServerDateTime - recentData.lastConduitDateTime.getTime()) / 3600000D));
+            if (diffInHour != 0 && diffInHour < 26) {
+
+                recentData.lastConduitDateTime = shiftDateByHours(recentData.lastConduitDateTime, diffInHour);
+
+                //Sensor glucose
+                if (recentData.sgs != null) {
+                    for (SensorGlucose sg : recentData.sgs) {
+                        if(sg.timestamp != null)
+                            sg.timestamp = shiftDateByHours(sg.timestamp, diffInHour);
+                    }
+                }
+
+                //Markers
+                if (recentData.markers != null) {
+                    for (Marker marker : recentData.markers) {
+                        if(marker.timestamp != null)
+                            marker.timestamp = shiftDateByHours(marker.timestamp, diffInHour);
+                    }
+                }
+                //Notifications
+                if (recentData.notificationHistory != null) {
+                    if (recentData.notificationHistory.clearedNotifications != null) {
+                        for (ClearedNotification notification : recentData.notificationHistory.clearedNotifications) {
+                            if(notification.dateTime != null) {
+                                notification.dateTime = shiftDateByHours(notification.dateTime, diffInHour);
+                                notification.triggeredDateTime = shiftDateByHours(notification.triggeredDateTime, diffInHour);
+                            }
+                        }
+                    }
+                    if (recentData.notificationHistory.activeNotifications != null) {
+                        for (ActiveNotification notification : recentData.notificationHistory.activeNotifications) {
+                            if(notification.dateTime != null)
+                                notification.dateTime = shiftDateByHours(notification.dateTime, diffInHour);
+                        }
+                    }
+                }
+
+            }
+
+        }
+
+        displayMessage.patientData = recentData;
 
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/ActiveInsulin.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/ActiveInsulin.java
@@ -1,5 +1,8 @@
 package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
 
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.CareLinkJsonAdapter;
+import com.google.gson.annotations.JsonAdapter;
+
 import java.util.Date;
 
 /**
@@ -8,6 +11,7 @@ import java.util.Date;
 public class ActiveInsulin {
 
     public Integer code;
+    @JsonAdapter(CareLinkJsonAdapter.class)
     public Date datetime;
     public long version;
     public Double amount;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/ActiveNotification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/ActiveNotification.java
@@ -1,18 +1,15 @@
 package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
 
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.CareLinkJsonAdapter;
+import com.google.gson.annotations.JsonAdapter;
+
 import java.util.Date;
 
-public class ActiveNotification {
+public class ActiveNotification extends Notification {
 
     public String GUID;
-    public Date dateTime;
-    public String type;
-    public int faultId;
-    public int instanceId;
-    public String messageId;
-    public String pumpDeliverySuspendState;
-    public String pnpId;
-    public int relativeOffset;
+
     public Boolean alertSilenced;
+
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Alarm.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Alarm.java
@@ -1,5 +1,8 @@
 package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
 
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.CareLinkJsonAdapter;
+import com.google.gson.annotations.JsonAdapter;
+
 import java.util.Date;
 
 /**
@@ -12,6 +15,7 @@ public class Alarm {
     }
 
     public int code;
+    //@JsonAdapter(CareLinkJsonAdapter.class)
     public String datetime;
     public Date datetimeAsDate;
     public String type;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/ClearedNotification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/ClearedNotification.java
@@ -1,18 +1,15 @@
 package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
 
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.CareLinkJsonAdapter;
+import com.google.gson.annotations.JsonAdapter;
+
 import java.util.Date;
 
-public class ClearedNotification {
+public class ClearedNotification extends Notification {
 
     public String referenceGUID;
-    public Date dateTime;
-    public String type;
-    public int faultId;
-    public int instanceId;
-    public String messageId;
-    public String pumpDeliverySuspendState;
-    public String pnpId;
-    public int relativeOffset;
+
+    @JsonAdapter(CareLinkJsonAdapter.class)
     public Date triggeredDateTime;
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/DisplayMessage.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/DisplayMessage.java
@@ -1,0 +1,8 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
+
+public class DisplayMessage {
+
+    public DisplayMessageMetadata metadata;
+    public RecentData patientData;
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/DisplayMessageMetadata.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/DisplayMessageMetadata.java
@@ -1,0 +1,10 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
+
+public class DisplayMessageMetadata {
+
+    public String kind;
+    public Long version;
+    public Boolean typeCast;
+    public String clientDateTime;
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Limit.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Limit.java
@@ -7,5 +7,6 @@ public class Limit {
     public int lowLimit;
     public String kind;
     public int version;
+    public String timestamp;
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Marker.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Marker.java
@@ -1,5 +1,8 @@
 package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
 
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.CareLinkJsonAdapter;
+import com.google.gson.annotations.JsonAdapter;
+
 import java.util.Date;
 
 /**
@@ -28,6 +31,8 @@ public class Marker {
     public String kind;
     public int version;
     public Date dateTime;
+    @JsonAdapter(CareLinkJsonAdapter.class)
+    public Date timestamp = null;
     public Integer relativeOffset;
     public Boolean calibrationSuccess;
     public Double amount;
@@ -42,5 +47,43 @@ public class Marker {
     public String bolusType;
     public Boolean autoModeOn;
     public Float bolusAmount;
+    public MarkerData data;
+
+    public Date getDate(){
+        if(timestamp != null)
+            return timestamp;
+        else if(dateTime != null)
+            return dateTime;
+        else
+            return null;
+    }
+
+    public Float getInsulinAmount(){
+        if(deliveredExtendedAmount != null && deliveredFastAmount != null)
+            return deliveredExtendedAmount + deliveredFastAmount;
+        else if(data.dataValues != null && data.dataValues.deliveredFastAmount != null)
+            return data.dataValues.deliveredFastAmount;
+        else
+            return null;
+    }
+
+    public Double getCarbAmount(){
+        if(amount != null)
+            return amount;
+        else if(data.dataValues.amount != null)
+            return data.dataValues.amount;
+        else
+            return null;
+    }
+
+    public Double getBloodGlucose()
+    {
+        if(value != null)
+            return value;
+        else if(data.dataValues.unitValue != null)
+            return data.dataValues.unitValue;
+        else
+            return null;
+    }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/MarkerData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/MarkerData.java
@@ -1,0 +1,7 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
+
+public class MarkerData {
+
+    public MarkerDataValues dataValues;
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/MarkerDataValues.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/MarkerDataValues.java
@@ -1,0 +1,19 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
+
+public class MarkerDataValues {
+
+    public Double unitValue;
+    public String bgUnits;
+    public Boolean calibrationSuccess;
+    public Float bolusAmount;
+    public Float maxAutoBasalRate;
+    public String insulinType;
+    public Float  programmedFastAmount;
+    public Float deliveredFastAmount;
+    public String activationType;
+    public Boolean completed;
+    public String bolusType;
+    public Double amount;
+
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Notification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Notification.java
@@ -1,0 +1,29 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
+
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.CareLinkJsonAdapter;
+import com.google.gson.annotations.JsonAdapter;
+
+import java.util.Date;
+
+public class Notification {
+
+    @JsonAdapter(CareLinkJsonAdapter.class)
+    public Date dateTime;
+    public String type;
+    public int faultId;
+    public int instanceId;
+    public String messageId;
+    public String pumpDeliverySuspendState;
+    public String pnpId;
+    public int relativeOffset;
+
+    public String getMessageId(){
+        if(messageId != null)
+            return  messageId;
+        else if(faultId > 0)
+            return String.valueOf(faultId);
+        else
+            return null;
+    }
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/RecentData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/RecentData.java
@@ -1,5 +1,8 @@
 package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
 
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.CareLinkJsonAdapter;
+import com.google.gson.annotations.JsonAdapter;
+
 import java.util.Date;
 import java.util.List;
 
@@ -54,6 +57,17 @@ public class RecentData {
     public boolean isNGP() {
         return getDeviceFamily().equals(DEVICE_FAMILY_NGP);
     }
+
+    public int getDeviceBatteryLevel(){
+        if(pumpBatteryLevelPercent == 0)
+            return  medicalDeviceBatteryLevelPercent;
+        else
+            return  pumpBatteryLevelPercent;
+
+    }
+
+    //As of new BLE endpoint v11:
+    public Long lastConduitUpdateServerDateTime;
 
     public long lastSensorTS;
     public String medicalDeviceTimeAsString;
@@ -110,9 +124,12 @@ public class RecentData {
     public int belowHypoLimit;
     public int aboveHyperLimit;
     public int timeInRange;
+    public Boolean pumpSuspended;
+    public int pumpBatteryLevelPercent;
     public Boolean pumpCommunicationState;
     public Boolean gstCommunicationState;
     public int gstBatteryLevel;
+    @JsonAdapter(CareLinkJsonAdapter.class)
     public Date lastConduitDateTime;
     public float maxAutoBasalRate;
     public float maxBolusAmount;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/SensorGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/SensorGlucose.java
@@ -1,5 +1,8 @@
 package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
 
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.CareLinkJsonAdapter;
+import com.google.gson.annotations.JsonAdapter;
+
 import java.util.Date;
 
 /**
@@ -16,15 +19,23 @@ public class SensorGlucose {
     public String sensorState;
     public int relativeOffset;
 
-    public long timestamp = -1;
+    @JsonAdapter(CareLinkJsonAdapter.class)
+    public Date timestamp = null;
     public Date date = null;
+
+    public Date getDate(){
+        if(this.datetimeAsDate != null)
+            return datetimeAsDate;
+        else
+            return timestamp;
+    }
 
     public String toS() {
         String dt;
-        if (datetime == null) {
+        if (getDate() == null) {
             dt = "";
         } else {
-            dt = datetime;
+            dt = getDate().toString();
         }
         return dt + " " + sg;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/util/CareLinkJsonAdapter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/util/CareLinkJsonAdapter.java
@@ -1,0 +1,61 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class CareLinkJsonAdapter extends TypeAdapter<Date> {
+
+    protected static final SimpleDateFormat[] ZONED_DATE_FORMATS = {
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
+    };
+
+    @Override
+    public void write(JsonWriter out, Date value) throws IOException {
+
+    }
+
+    @Override
+    public Date read(JsonReader reader) throws IOException {
+
+        Date parsedDate = null;
+
+        if (reader.peek() == JsonToken.NULL) {
+            reader.nextNull();
+            return null;
+        }
+
+        String dateAsString = reader.nextString();
+
+        parsedDate = this.parseDateString(dateAsString);
+
+        if(parsedDate == null){
+            dateAsString = dateAsString + "Z";
+            parsedDate = this.parseDateString(dateAsString);
+        }
+
+        return  parsedDate;
+
+    }
+
+    protected Date parseDateString(String dateString) {
+        for (SimpleDateFormat zonedFormat : ZONED_DATE_FORMATS) {
+            try {
+                return zonedFormat.parse(dateString);
+            } catch (Exception ex) {
+            }
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
**Issue**
The old cloud data endpoint no longer works outside the US, so the new v11 data endpoint must be used in the EU  for 7xxG pump users . The data structure of the new data endpoint is different from the previous one, so the data structure must be extended and modified while maintaining compatibility with the old cloud data structure and also with the one used by the standalone sensors.

**Solution**
Implementation of the new v11 cloud data endpoint:
- replace endpoint in case of EU with v11 endpoint
- new and modified structures
- create new date correction logic for the new data structure (dates have no timezone)
- update data processing for new structures
- add JsonAdapter and structures to proguard

**Testing**
I have tested it with all kinds of accounts (patient, carepartner) with different devices (standalone CGM and 7xxG pump) in every region (EU,US) on different phones and it is was working fine without any errors and was stable.
Additionally, other EU pump users have also checked the new version and found it to be working properly:
https://github.com/NightscoutFoundation/xDrip/discussions/3855#discussioncomment-11872395
