### PR TITLE
Backfill overlap avoidance

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2624,9 +2624,11 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         boolean isSensorActive = Sensor.isActive();
 
         // automagically start an xDrip sensor session if G5 transmitter already has active sensor
-        if (!isSensorActive && Ob1G5CollectionService.isG5SensorStarted() && !Sensor.stoppedRecently()) {
+        if (!isSensorActive && Ob1G5CollectionService.isG5SensorStarted() && (!Sensor.stoppedRecently() || shortTxId())) {
             JoH.static_toast_long(getString(R.string.auto_starting_sensor));
-            Sensor.create(tsl() - HOUR_IN_MS * 3);
+            Sensor.create(tsl() - Ob1G5StateMachine.getLatestReadingsTime()); // Create an internal session after last existing readings
+            UserError.Log.ueh(TAG, "Started internal session (native session in progress H)");
+            Treatments.sensorStartIfNeeded();
             isSensorActive = Sensor.isActive();
         }
 


### PR DESCRIPTION
I made two major mistakes in this PR: https://github.com/NightscoutFoundation/xDrip/pull/3557 
And it is not working.  
I believe this PR is a solution.  
  
My first mistake was that I overlooked that there are two different lines in the code that auto start a sensor for a session in progress.  That PR attempted to address only one of them (Ob1G5StateMachine) and not the other (Home).

My second mistake was that I incorrectly used a method for finding last readings overlooking the need to ignore the sensor.  By not ignoring the sensor, the method would detect that there is no local session and return null causing a full backfill causing overlap.  

This PR addresses those two oversights.  It also addresses a cosmetic issue.  it creates a log showing that we have started an internal session because there is a session in progress on G7.  
<br/>  
  
**Tests**  
I have tested G6 to G7.  The following shows an Android 11 Motorola.
![Screenshot_20250126-115910](https://github.com/user-attachments/assets/50caeb87-8323-4f97-a06f-179cd8f203ac)
  
![Screenshot_20250126-115940](https://github.com/user-attachments/assets/116cac5e-268c-4717-b179-a5dfc79594dc)
  
I will test G7 to G7 in 5 days and report the results here.  
