### PR TITLE
Notify and log failure to upload to all intended Nightscout sites

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/DailyIntentService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/DailyIntentService.java
@@ -20,6 +20,7 @@ import com.eveningoutpost.dexdrip.models.UserError.Log;
 import com.eveningoutpost.dexdrip.utilitymodels.BgSendQueue;
 import com.eveningoutpost.dexdrip.utilitymodels.CalibrationSendQueue;
 import com.eveningoutpost.dexdrip.utilitymodels.IncompatibleApps;
+import com.eveningoutpost.dexdrip.utilitymodels.NightscoutUploader;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utilitymodels.UploaderQueue;
 import com.eveningoutpost.dexdrip.cloud.backup.Backup;
@@ -171,6 +172,12 @@ public class DailyIntentService extends IntentService {
                     SettingsValidation.notifyAboutInadvisableSettings();
                 } catch (Exception e) {
                     Log.e(TAG, "Exception in SettingsValidation: " + e);
+                }
+
+                try {
+                    NightscoutUploader.notifyInconsistentMultiSiteUpload();
+                } catch (Exception e) {
+                    Log.e(TAG, "Exception in Nightscout multi site upload failure log: " + e);
                 }
 
                 Log.i(TAG, "DailyIntentService onHandleIntent exiting after " + ((JoH.tsl() - start) / 1000) + " seconds");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
@@ -512,10 +512,10 @@ public class NightscoutUploader {
             }
         }
         if (any_successes && any_failures) { // If there has been success as well as failure (inconsistent upload)
-            if (!inconsistentMultiSteUpload) { // If there has been no inconsistent upload yet
+            if (!inconsistentMultiSteUpload) { // If there had been no inconsistent uploads yet, which makes this the first
                 firstInconsistentMultiSiteUploadTime = JoH.tsl(); // Record this time as the time of the first inconsistent upload
             }
-            inconsistentMultiSteUpload = true; // There has been success as well as failure.
+            inconsistentMultiSteUpload = true; // There has been inconsistent upload and we have recorded the time.
         }
         return any_successes;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
@@ -510,22 +510,22 @@ public class NightscoutUploader {
             }
         }
         if (any_successes && any_failures) { // Only if there has been success as well as failure (inconsistent upload)
-            if (!PersistentStore.getBoolean(TAG + "inconsistentMultiSteUpload")) { // If there had been no inconsistent uploads yet, which makes this the first
-                PersistentStore.setLong(TAG + "firstInconsistentMultiSiteUploadTime", JoH.tsl()); // Record this time as the time of the first inconsistent upload
+            if (!PersistentStore.getBoolean(TAG + "_inconsistentMultiSteUpload")) { // If there had been no inconsistent uploads yet, which makes this the first
+                PersistentStore.setLong(TAG + "_firstInconsistentMultiSiteUploadTime", JoH.tsl()); // Record this time as the time of the first inconsistent upload
             }
-            PersistentStore.setBoolean(TAG + "inconsistentMultiSteUpload", true); // There has been inconsistent upload and we have recorded the time.  Let's set the flag.
+            PersistentStore.setBoolean(TAG + "_inconsistentMultiSteUpload", true); // There has been inconsistent upload and we have recorded the time.  Let's set the flag.
         }
         return any_successes;
     }
 
     public static void notifyInconsistentMultiSiteUpload() {
-        long firstInconsistentMultiSiteUploadTime = PersistentStore.getLong(TAG + "firstInconsistentMultiSiteUploadTime"); // Updating the local representation of the last inconsistent upload time
-        if (PersistentStore.getBoolean(TAG + "inconsistentMultiSteUpload")) { // If there has been a failure to upload and the queue has been cleared
+        long firstInconsistentMultiSiteUploadTime = PersistentStore.getLong(TAG + "_firstInconsistentMultiSiteUploadTime"); // Updating the local representation of the last inconsistent upload time
+        if (PersistentStore.getBoolean(TAG + "_inconsistentMultiSteUpload")) { // If there has been a failure to upload and the queue has been cleared
             if (Pref.getBooleanDefaultFalse("warn_nightscout_multi_site_upload_failure")) { // Issue notification only if enabled
                 JoH.showNotification(xdrip.gs(R.string.title_nightscout_upload_failure_backfill_required), null, null, Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID, null, false, false, null, null, xdrip.gs(R.string.nightscout_upload_failure_backfill_required, JoH.dateTimeText(firstInconsistentMultiSiteUploadTime)), true);
             }
             UserError.Log.uel(TAG, "Inconsistent Multi-site Nightscout upload - Backfill recommended - First failure: " + JoH.dateTimeText(firstInconsistentMultiSiteUploadTime));
-            PersistentStore.setBoolean(TAG + "inconsistentMultiSteUpload", false); // We have notified.  Clearing the flag
+            PersistentStore.setBoolean(TAG + "_inconsistentMultiSteUpload", false); // We have notified.  Clearing the flag
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1225,6 +1225,8 @@
     <string name="summary_cloud_storage_api_download_enable">Also try to download treatments from Nightscout</string>
     <string name="title_cloud_storage_api_download_enable">Download treatments</string>
     <string name="title_cloud_storage_api_download_from_xdrip">Skip items from xDrip</string>
+    <string name="nightscout_upload_failure_backfill_required">Uploads have not succeeded for all sites.  Backfill is recommended.  First failure: %1$s</string>
+    <string name="title_nightscout_upload_failure_backfill_required">Inconsistent Multi-Site Nightscout Upload</string>
     <string name="summary_cloud_storage_api_download_from_xdrip">Avoid downloading items uploaded by xDrip</string>
     <string name="summary_bluetooth_meter_for_calibrations_auto">Calibrate using new blood glucose readings if the conditions appear right to do so without asking confirmation (experimental)</string>
     <string name="title_bluetooth_meter_for_calibrations_auto">Automatic Calibration</string>
@@ -1237,6 +1239,8 @@
     <string name="title_send_treatments_to_nightscout">Upload treatments</string>
     <string name="summary_warn_nightscout_failures">Display and sound a notification if Nightscout upload is failing.</string>
     <string name="title_warn_nightscout_failures">Alert on failures</string>
+    <string name="summary_warn_nightscout_multi_site_upload_failure">xDrip clears the upload queue even if only one site has a successful upload, leaving others incomplete. This notifies you, allowing you to backfill as needed.</string>
+    <string name="title_warn_nightscout_multi_site_upload_failure">Alert on multi-site upload failure</string>
     <string name="summary_nightscout_device_append_source_info">For Dex, sends collector type (e.g. OB1) and reading backfill status (for native) to Nightscout.</string>
     <string name="title_nightscout_device_append_source_info">Append source info to device name</string>
     <string name="summary_tap_to_send_historical_data">Tap to send historical data to Nightscout</string>

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -122,6 +122,11 @@
                         android:key="nightscout_device_append_source_info"
                         android:summary="@string/summary_nightscout_device_append_source_info"
                         android:title="@string/title_nightscout_device_append_source_info" />
+                    <CheckBoxPreference
+                        android:defaultValue="true"
+                        android:key="warn_nightscout_multi_site_upload_failure"
+                        android:summary="@string/summary_warn_nightscout_multi_site_upload_failure"
+                        android:title="@string/title_warn_nightscout_multi_site_upload_failure" />
                     <Preference
                         android:key="back_fill_data_activity_intent_key"
                         android:summary="@string/summary_tap_to_send_historical_data"


### PR DESCRIPTION
When uploading to more than one site, a silent notification is presented and a log is created once a day if there is a failure to upload to one site but not the other.  

If some day we add dedicated (per site) queues, all of this will be removed because there will be no need for any of it then.

I am sorry I have added a new setting.  Unfortunately, someone may use Nightscout and not care about inconsistent uploads.  In that case, having to acknowledge a notification everyday may not be convenient.  
  
| Before | After |  
| ------- | ------ |  
| ![Screenshot_20250130-092153](https://github.com/user-attachments/assets/0444b856-bd34-4194-b8ad-b37c87deec4a)   | ![Screenshot_20250130-080824](https://github.com/user-attachments/assets/2708cc42-307f-4f35-8e36-b026052a01e9) |  

**Notification**  
![Screenshot_20250130-080725](https://github.com/user-attachments/assets/95ba27d3-ff2e-4cc1-85a8-592ce8527571)
  
**Log**  
![Screenshot_20250130-080638](https://github.com/user-attachments/assets/a8d6e5c5-01f2-4466-a109-2915fa8007b9)  

**Translations**
The notification and its title will be translated.
The log will not be translated.  
<br/>  

**Tests**
This has been tested on Motorola Android 11 and Motorola Android 8.
There is no notification if all uploads fail (no WiFi).
There is notification and log when there is a failure to upload to one site but not the other.  By default, the notification is enabled.
Disabling the notification will still generate a log but no notification.
To cause failure to upload to only one site, the Google Cloud Nightscout site was temporarily stopped. 
