### PR TITLE
Offering Forecast Low Threshold as an independent setting

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -129,6 +129,7 @@ public class BgGraphBuilder {
     private SharedPreferences prefs;
     public double highMark;
     public double lowMark;
+    public double forecastLowMark; // Marker used for forecast low analysis
     public double defaultMinY;
     public double defaultMaxY;
     public boolean doMgdl;
@@ -243,6 +244,10 @@ public class BgGraphBuilder {
         this.context = context;
         this.highMark = tolerantParseDouble(prefs.getString("highValue", "170"), 170);
         this.lowMark = tolerantParseDouble(prefs.getString("lowValue", "70"), 70);
+        this.forecastLowMark = this.lowMark; // Set the forecast low marker to match the low value marker
+        if (!Pref.getBoolean("low_value_is_forecast_low_threshold", true)) { // If the user has chosen not to use the Low Value as the Forecast Low threshold
+            this.forecastLowMark = tolerantParseDouble(prefs.getString("forecast_low_threshold", "70"), 70); // Set the forecast low marker to match the forecast low threshold specified by the user
+        }
         this.doMgdl = (prefs.getString("units", "mgdl").equals("mgdl"));
         defaultMinY = unitized(40);
         defaultMaxY = unitized(250);
@@ -1461,15 +1466,15 @@ public class BgGraphBuilder {
                         double polyPredicty = poly.predict(plow_timestamp);
                         Log.d(TAG, "Low predictor at max lookahead is: " + JoH.qs(polyPredicty));
                         low_occurs_at_processed_till_timestamp = highest_bgreading_timestamp; // store that we have processed up to this timestamp
-                        if (polyPredicty <= (lowMark + offset)) {
+                        if (polyPredicty <= (forecastLowMark + offset)) {
                             low_occurs_at = plow_timestamp;
-                            final double lowMarkIndicator = (lowMark - (lowMark / 4));
+                            final double lowMarkIndicator = (forecastLowMark - (forecastLowMark / 4));
                             //if (d) Log.d(TAG, "Poly predict: "+JoH.qs(polyPredict)+" @ "+JoH.qsz(iob.timestamp));
                             while (plow_timestamp > plow_now) {
 //                                plow_timestamp = plow_timestamp - FUZZER;
                                 plow_timestamp = plow_timestamp - (1000 * 30 * 5); // TODO check this! 2.5 minute accuracy on dots and low mark intercept for low_occurs at
                                 polyPredicty = poly.predict(plow_timestamp);
-                                if (polyPredicty > (lowMark + offset)) {
+                                if (polyPredicty > (forecastLowMark + offset)) {
                                     PointValue zv = new HPointValue((double) (plow_timestamp / FUZZER), (float) polyPredicty);
                                     polyBgValues.add(zv);
                                 } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -171,6 +171,7 @@ public class IdempotentMigrations {
     // Include new preference settings here that represent glucose values.
     private static void prefSettingRangeVerification() {
         Preferences.applyPrefSettingRange("persistent_high_threshold", "170", MIN_GLUCOSE_INPUT, MAX_GLUCOSE_INPUT);
+        Preferences.applyPrefSettingRange("forecast_low_threshold", "70", MIN_GLUCOSE_INPUT, MAX_GLUCOSE_INPUT);
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1134,6 +1134,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             bindPreferenceSummaryToValue(findPreference("other_alerts_sound"));
             bindPreferenceSummaryToValue(findPreference("bridge_battery_alert_level"));
             bindPreferenceSummaryToUnitizedValueAndEnsureNumeric(findPreference("persistent_high_threshold"));
+            bindPreferenceSummaryToUnitizedValueAndEnsureNumeric(findPreference("forecast_low_threshold"));
 
             addPreferencesFromResource(R.xml.pref_data_source);
 
@@ -3116,6 +3117,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             final Double default_insulin_sensitivity = Double.parseDouble(preferences.getString("profile_insulin_sensitivity_default", "54"));
             final Double default_target_glucose = Double.parseDouble(preferences.getString("plus_target_range", "100"));
             final Double persistent_high_Val = Double.parseDouble(preferences.getString("persistent_high_threshold", "0"));
+            final Double forecast_low_Val = Double.parseDouble(preferences.getString("forecast_low_threshold", "0"));
 
 
             static_units = newValue.toString();
@@ -3130,6 +3132,11 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 if (persistent_high_Val < 36) {
                     ProfileEditor.convertData(Constants.MMOLL_TO_MGDL);
                     preferences.edit().putString("persistent_high_threshold", Long.toString(Math.round(persistent_high_Val * Constants.MMOLL_TO_MGDL))).apply();
+                    Profile.invalidateProfile();
+                }
+                if (forecast_low_Val < 36) {
+                    ProfileEditor.convertData(Constants.MMOLL_TO_MGDL);
+                    preferences.edit().putString("forecast_low_threshold", Long.toString(Math.round(forecast_low_Val * Constants.MMOLL_TO_MGDL))).apply();
                     Profile.invalidateProfile();
                 }
                 if (lowVal < 36) {
@@ -3153,6 +3160,11 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     preferences.edit().putString("persistent_high_threshold", JoH.qs(persistent_high_Val * Constants.MGDL_TO_MMOLL, 1)).apply();
                     Profile.invalidateProfile();
                 }
+                if (forecast_low_Val > 35) {
+                    ProfileEditor.convertData(Constants.MGDL_TO_MMOLL);
+                    preferences.edit().putString("forecast_low_threshold", JoH.qs(forecast_low_Val * Constants.MGDL_TO_MMOLL, 1)).apply();
+                    Profile.invalidateProfile();
+                }
                 if (lowVal > 35) {
                     ProfileEditor.convertData(Constants.MGDL_TO_MMOLL);
                     preferences.edit().putString("lowValue", JoH.qs(lowVal * Constants.MGDL_TO_MMOLL, 1)).apply();
@@ -3166,6 +3178,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 allPrefsFragment.setSummary("highValue");
                 allPrefsFragment.setSummary("lowValue");
                 allPrefsFragment.setSummary("persistent_high_threshold");
+                allPrefsFragment.setSummary("forecast_low_threshold");
             }
             if (profile_insulin_sensitivity_default != null) {
                 Log.d(TAG, "refreshing profile insulin sensitivity default display");

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,6 +252,7 @@
     <string name="pref_was_less_than_min">%1$s was set to a value less than minimum allowed.  It has been changed to minimum.</string>
     <string name="extrapolate_data_to_try_to_predict_lows">Extrapolate data to try to predict lows</string>
     <string name="alarm_at_forecasted_low_mins">Alarm at Forecasted Low mins</string>
+    <string name="title_forecast_low_threshold">Threshold</string>
     <string name="other_xdrip_plus_alerts">Other xDrip+ alerts</string>
     <string name="xdrip_plus_display_settings">xDrip+ Display Settings</string>
     <string name="display_customisations">Display customizations</string>
@@ -1532,6 +1533,8 @@
     <string name="summary_persistent_high_alert">When above threshold and not falling for long</string>
     <string name="summary_persistent_high_threshold_link">When enabled, High Value is the threshold.\nWhen disabled, the threshold is the value specified below.</string>
     <string name="title_persistent_high_threshold_link">Threshold: High Value</string>
+    <string name="summary_forecast_low_threshold_link">When enabled, Low Value is the threshold.\nWhen disabled, the threshold is the value specified below.</string>
+    <string name="title_forecast_low_threshold_link">Threshold: Low Value</string>
     <string name="note_search_button">SEARCH</string>
     <string name="all_note_button">ALL</string>
     <string name="title_full_screen_mode">Full Screen mode</string>

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -360,6 +360,18 @@
                         android:key="predict_lows_alarm"
                         android:summary="@string/notify_when_predicted_low_time_reaches_threshold"
                         android:title="@string/raise_alarm_on_forecast_low" />
+                    <SwitchPreference
+                        android:defaultValue="true"
+                        android:disableDependentsState="true"
+                        android:key="low_value_is_forecast_low_threshold"
+                        android:summary="@string/summary_forecast_low_threshold_link"
+                        android:title="@string/title_forecast_low_threshold_link" />
+                    <EditTextPreference
+                        android:defaultValue="70"
+                        android:dependency="low_value_is_forecast_low_threshold"
+                        android:inputType="numberDecimal"
+                        android:key="forecast_low_threshold"
+                        android:title="@string/title_forecast_low_threshold" />
                     <EditTextPreference
                         android:defaultValue="40"
                         android:dependency="predict_lows_alarm"


### PR DESCRIPTION
This PR adds the option to adjust your forecast low threshold without an impact on statistics or the colors in your graphs.
After this PR, by default, xDrip acts as it does now using the Low Value as the forecast Low Threshold.
But, the user will have the choice of disabling the setting "Threshold: Low Value", in which case, the specified threshold will be used instead.  

This is almost identical to the PR below except that was for the Persistent High threshold: https://github.com/NightscoutFoundation/xDrip/pull/3704  

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20250207-190148](https://github.com/user-attachments/assets/0c36c10f-4ee1-4a6f-98d4-ae1a587e252d) | ![Screenshot_20250207-185952](https://github.com/user-attachments/assets/84b96974-bad2-403d-8002-2d344e4f24d6) |  
