### PR TITLE
CareLinkFollower - v11 endpoint for US also

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -649,8 +649,8 @@ public class CareLinkClient {
 
         requestBody = RequestBody.create(MediaType.get("application/json; charset=utf-8"), gson.toJson(userJson));
 
-        //use new v11 endpoint outside US
-        useNewEndpoint = !this.carelinkCountry.equals("us") ? true : false;
+        //use new v11 endpoint in every region
+        useNewEndpoint = true;
 
         //new endpoint url
         newEndpointUrl = new HttpUrl.Builder()


### PR DESCRIPTION
**Issue**
The old cloud data endpoint no longer works inside the US, so the new v11 data endpoint must be used in case of US also for 7xxG pump users .

**Solution**
Use the new v11 cloud data endpoint for every region in case of cloud datasource.

**Testing**
I have tested it with all kinds of accounts (patient, carepartner) with different devices (standalone CGM and 7xxG pump) in every region (EU,US) on different phones and it is was working fine without any errors and was stable.
Additionally, other US pump users have also checked the new version and found it to be working properly:
https://github.com/NightscoutFoundation/xDrip/discussions/3855#discussioncomment-11953103