### PR TITLE
Add strings to make xDrip more translated and fix logging of BG alert to be in English only

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/AlertList.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/AlertList.java
@@ -52,7 +52,7 @@ public class AlertList extends ActivityWithMenu {
 
     String stringTimeFromAlert(AlertType alert) {
         if (alert.all_day) {
-            return "all day";
+            return getString(R.string.all_day);
         }
         String start = timeFormatString(AlertType.time2Hours(alert.start_time_minutes), AlertType.time2Minutes(alert.start_time_minutes));
         String end = timeFormatString(AlertType.time2Hours(alert.end_time_minutes), AlertType.time2Minutes(alert.end_time_minutes));
@@ -61,9 +61,9 @@ public class AlertList extends ActivityWithMenu {
 
     HashMap<String, String> createAlertMap(AlertType alert) {
         HashMap<String, String> map = new HashMap<String, String>();
-        String overrideSilentMode = "Override Silent Mode";
-        if (alert.override_silent_mode == false) {
-            overrideSilentMode = "No Alert in Silent Mode";
+        String overrideSilentMode = getString(R.string.override_silent_mode);
+        if (!alert.override_silent_mode) {
+            overrideSilentMode = getString(R.string.no_alert_in_silent_mode);
         }
         // We use a - sign to tell that this text should be stiked through
         String extra = "-";

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -2465,7 +2465,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             updateCurrentBgInfoCommon(collector, notificationText);
         }
         if (collector.equals(DexCollectionType.Disabled)) {
-            notificationText.append("\n DATA SOURCE DISABLED");
+            notificationText.append(getString(R.string.__data_source_disabled));
             if (!Experience.gotData()) {
                 // TODO should this move to Experience::processSteps ?
                 final Activity activity = this;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
@@ -525,8 +525,10 @@ public class AlertPlayer {
             minsFromStartPlaying = MAX_ASCENDING_MINUTES;
         }
         final String highlow = (alert.above ? context.getString(R.string.high) : context.getString(R.string.low)).toUpperCase();
+        final String highlowLog = (alert.above ? "HIGH" : "LOW");
         String title = bgValue + " " + alert.name;
         String content = context.getString(R.string.bg_alert, highlow, bgValue, JoH.hourMinuteString());
+        String contentLog = "BG " + highlowLog + " ALERT: " + bgValue + "  (@" + JoH.hourMinuteString() + ")";
         final Intent intent = new Intent(context, SnoozeActivity.class);
 
         boolean localOnly = (Home.get_forced_wear() && PersistentStore.getBoolean("bg_notifications_watch"));
@@ -593,7 +595,7 @@ public class AlertPlayer {
             // seems to be needed. This pattern basically does not vibrate:
             builder.setVibrate(new long[]{1, 0});
         }
-        Log.ueh("Alerting", content);
+        Log.ueh("Alerting", contentLog);
         final NotificationManager mNotifyMgr = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         //mNotifyMgr.cancel(Notifications.exportAlertNotificationId); // this appears to confuse android wear version 2.0.0.141773014.gms even though it shouldn't - can we survive without this?
         mNotifyMgr.notify(Notifications.exportAlertNotificationId, XdripNotificationCompat.build(builder));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
@@ -526,7 +526,7 @@ public class AlertPlayer {
         }
         final String highlow = (alert.above ? context.getString(R.string.high) : context.getString(R.string.low)).toUpperCase();
         String title = bgValue + " " + alert.name;
-        String content = "BG " + highlow + " ALERT: " + bgValue + "  (@" + JoH.hourMinuteString() + ")";
+        String content = context.getString(R.string.bg_alert, highlow, bgValue, JoH.hourMinuteString());
         final Intent intent = new Intent(context, SnoozeActivity.class);
 
         boolean localOnly = (Home.get_forced_wear() && PersistentStore.getBoolean("bg_notifications_watch"));

--- a/app/src/main/res/layout/activity_home_shelf_settings.xml
+++ b/app/src/main/res/layout/activity_home_shelf_settings.xml
@@ -87,7 +87,7 @@
                 android:checked="@{safeUnbox(vs.included[`graphic_trend_arrow`])}"
                 android:onCheckedChanged="@{(v, result) -> home.showArrowConfigurator(v, false, true)}"
                 android:onClick="@{() -> vs.ptoggle(`graphic_trend_arrow`)}"
-                android:text="Show Graphical Trend Arrow" />
+                android:text="@string/show_graphical_trend_arrow" />
 
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1939,4 +1939,7 @@
     <string name="use_camera_light_summary">Flash camera light during alerts when connected to a charger</string>
     <string name="g7_should_start_automatically">G7 should start automatically</string>
     <string name="screenshot">Screenshot</string>
+    <string name="bg_alert">BG %1$s ALERT: %2$s (@%3$s)</string>
+    <string name="show_graphical_trend_arrow">Show Graphical Trend Arrow</string>
+    <string name="no_alert_in_silent_mode">No Alert in Silent mode</string>
 </resources>


### PR DESCRIPTION
Some obvious places missing translation. This will help getting xDrip app seem more complete in terms of localisation.

Below are screenshots of where these strings are seen in app.

| List of Glucose alerts: | Warning when Data Source is disabled in main screen:|
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6d1809b2-7856-41e1-a443-1b0bb0854ee2) | ![image](https://github.com/user-attachments/assets/b3108338-93c8-4ba0-bfdb-b511047fa486)|
| BG alert:| Touch and hold on xDrip logo on main screen to display below settings: |
|Alert in notification:![image](https://github.com/user-attachments/assets/bfffc635-b284-478c-bf25-5a668ef3ca17)Alert in log now English only:![image](https://github.com/user-attachments/assets/852b7983-3614-40c0-8ada-892ba95e9e2b)| ![image](https://github.com/user-attachments/assets/9f9aa3dc-9bbe-4483-a8f5-4a797916a693)|




