### PR TITLE
Add strings to make Reminders and Calibration graph fully translated

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
@@ -88,7 +88,7 @@ public class CalibrationGraph extends ActivityWithMenu {
             DecimalFormat df = new DecimalFormat("#");
             df.setMaximumFractionDigits(2);
             df.setMinimumFractionDigits(2);
-            String Header = "slope = " + df.format(calibration.slope) + " intercept = " + df.format(calibration.intercept);
+            String Header = getString(R.string.calibration_slope_intercept, df.format(calibration.slope), df.format(calibration.intercept));
             GraphHeader.setText(Header);
 
             //red line
@@ -133,8 +133,8 @@ public class CalibrationGraph extends ActivityWithMenu {
         }
         Axis axisX = new Axis();
         Axis axisY = new Axis().setHasLines(true);
-        axisX.setName("Raw Value");
-        axisY.setName("Glucose " + (doMgdl ? "mg/dl" : "mmol/l"));
+        axisX.setName(getString(R.string.axis_x_raw_value));
+        axisY.setName(getString(R.string.axis_y_glucose_mgdl_mmol, (doMgdl ? "mg/dl" : "mmol/l")));
 
 
         data = new LineChartData(lines);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
@@ -1022,7 +1022,7 @@ public class Reminders extends ActivityWithRecycler implements SensorEventListen
 
         dialogBuilder.setTitle(((reminder == null) ? xdrip.getAppContext().getString(R.string.title_add_reminder) : xdrip.getAppContext().getString(R.string.title_edit_reminder)));
         //dialogBuilder.setMessage("Enter text below");
-        dialogBuilder.setPositiveButton("Done", new DialogInterface.OnClickListener() {
+        dialogBuilder.setPositiveButton(xdrip.getAppContext().getString(R.string.done), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 String reminder_title = titleEditText.getText().toString().trim();
                 Log.d(TAG, "Got reminder title: " + reminder_title);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/HomeWifi.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/HomeWifi.java
@@ -38,14 +38,14 @@ public class HomeWifi {
         if (isConnectedToAnything()) {
             final String ssid = getSSID();
             final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-            builder.setTitle("Set Home Network");
-            builder.setMessage(String.format("My Home WiFi Network name is:\n\n%s", ssid));
+            builder.setTitle(activity.getString(R.string.set_home_network));
+            builder.setMessage(activity.getString(R.string.my_home_network_is, ssid));
 
             builder.setPositiveButton(activity.getString(R.string.yes), new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
                    Pref.setString(PREF,ssid);
-                   JoH.static_toast_long(String.format("Set home network to: %s",ssid));
+                   JoH.static_toast_long(activity.getString(R.string.set_home_network_to, ssid));
                 }
             });
             builder.setNegativeButton(activity.getString(R.string.cancel), new DialogInterface.OnClickListener() {
@@ -57,7 +57,7 @@ public class HomeWifi {
 
             builder.create().show();
         } else {
-            JoH.static_toast_long("Not connected to Wifi");
+            JoH.static_toast_long(activity.getString(R.string.not_connected_to_wifi));
         }
     }
 

--- a/app/src/main/res/layout/reminder_new_dialog.xml
+++ b/app/src/main/res/layout/reminder_new_dialog.xml
@@ -16,7 +16,7 @@
             android:id="@+id/reminder_edit_alt_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Reminder alternate title"
+            android:hint="@string/reminder_alternate_title"
             android:inputType="text|textCapWords"
             android:lines="4"
             android:linksClickable="false"
@@ -192,7 +192,7 @@
             android:layout_below="@+id/weekEndsCheckbox"
             android:layout_alignParentStart="true"
             android:checked="false"
-            android:text="Graph Note"/>
+            android:text="@string/graph_note"/>
 
         <CheckBox
             android:id="@+id/speakCheckbox"
@@ -202,7 +202,7 @@
             android:layout_marginLeft="10dp"
             android:layout_toRightOf="@+id/GraphIconCheckbox"
             android:checked="false"
-            android:text="Speak" />
+            android:text="@string/speak" />
 
         <CheckBox
             android:id="@+id/homeOnlyCheckbox"
@@ -212,7 +212,7 @@
             android:layout_marginLeft="10dp"
             android:layout_marginTop="3dp"
             android:checked="false"
-            android:text="At Home Only" />
+            android:text="@string/at_home_only" />
 
         <CheckBox
             android:id="@+id/highPriorityCheckbox"

--- a/app/src/main/res/menu/menu_reminders.xml
+++ b/app/src/main/res/menu/menu_reminders.xml
@@ -48,7 +48,7 @@
 
     <item
         android:id="@+id/reminders_home_network"
-        android:title="Set Home Network"
+        android:title="@string/set_home_network"
         android:visible="true"
         android:onClick="onRemindersHomeNetworkClick"
         />

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -200,9 +200,9 @@
     </string-array>
 
     <string-array name="reminderAlertType">
-        <item>Android Ringtone/Alarm</item>
-        <item>Custom Audio file</item>
-        <item>Default xDrip+ reminder sound</item>
+        <item>@string/android_ringtone_alarm</item>
+        <item>@string/custom_audio_file</item>
+        <item>@string/default_xdrip_reminder_sound</item>
     </string-array>
 
 <!--    TODO abstract noise values to single source -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1942,4 +1942,18 @@
     <string name="bg_alert">BG %1$s ALERT: %2$s (@%3$s)</string>
     <string name="show_graphical_trend_arrow">Show Graphical Trend Arrow</string>
     <string name="no_alert_in_silent_mode">No Alert in Silent mode</string>
+    <string name="calibration_slope_intercept">slope = %1$s intercept = %2$s</string>
+    <string name="axis_x_raw_value">Raw Value</string>
+    <string name="axis_y_glucose_mgdl_mmol">Glucose + %s</string>
+    <string name="set_home_network">Set Home Network</string>
+    <string name="my_home_network_is">My Home WiFi Network name is:\n\n%s</string>
+    <string name="set_home_network_to">Set home network to: %s</string>
+    <string name="not_connected_to_wifi">Not connected to WiFi</string>
+    <string name="at_home_only">At Home Only</string>
+    <string name="speak">Speak</string>
+    <string name="graph_note">Graph Note</string>
+    <string name="reminder_alternate_title">Reminder alternate title</string>
+    <string name="default_xdrip_reminder_sound">Default xDrip+ reminder sound</string>
+    <string name="custom_audio_file">Custom Audio file</string>
+    <string name="android_ringtone_alarm">Android Ringtone/Alarm</string>
 </resources>


### PR DESCRIPTION
* Tested OK on my test-rig with all features in Reminders
* Tested with adding Norwegian translations in longer text length to ensure nothing breaks
* As far as I can see no logging are impacted by new strings.

Some screenshots:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/13877f5c-2768-4fc8-ac2c-9acf50d75f7b) | ![image](https://github.com/user-attachments/assets/1a731de9-967d-4e00-aab8-b5bf9e3302c9)|
| ![image](https://github.com/user-attachments/assets/ecf04df7-e037-405e-ab5d-279b405556c0)| ![image](https://github.com/user-attachments/assets/7c7a8619-5da2-4510-af26-b40ed1f097c9) |
| ![image](https://github.com/user-attachments/assets/924fa388-d768-45b3-b2fd-0dc54fd6af38)| ![image](https://github.com/user-attachments/assets/ef346099-6708-4883-bb96-8ff62708b895) |
| ![image](https://github.com/user-attachments/assets/bc31aef3-7b5a-470b-9b2d-d19e0fcefdc6)| ![image](https://github.com/user-attachments/assets/ce3e9f50-1fd0-4f1a-8d76-bc71506bb5aa)|
| ![image](https://github.com/user-attachments/assets/edc239c8-1d80-4049-a904-5f5b544a06ac)| ![image](https://github.com/user-attachments/assets/a5c5658d-e3f3-4776-9bf3-519b15035840) |
| ![image](https://github.com/user-attachments/assets/cd0befef-9299-4a5b-9222-775cde9d937c)| ![image](https://github.com/user-attachments/assets/92d33641-f623-469a-b84e-a382b9bfdb80)| 