### PR TITLE
YD instead of YTD

### DIFF
--- a/app/src/main/res/layout/activity_statistics.xml
+++ b/app/src/main/res/layout/activity_statistics.xml
@@ -24,26 +24,30 @@
             <Button
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="TD"
+                android:text="Td"
                 android:id="@+id/button_stats_today"
                 android:layout_marginTop="1dp"
                 android:layout_marginBottom="1dp"
                 android:paddingTop="1dp"
                 android:paddingBottom="1dp"
                 android:minHeight="1dp"
-                android:minWidth="1dp"/>
+                android:minWidth="1dp"
+                android:textAllCaps="false"/>
 
             <Button
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="YD"
+                android:text="Yest"
                 android:id="@+id/button_stats_yesterday"
                 android:layout_marginTop="1dp"
                 android:layout_marginBottom="1dp"
                 android:paddingTop="1dp"
                 android:paddingBottom="1dp"
+                android:paddingLeft="7dp"
+                android:paddingRight="7dp"
                 android:minHeight="1dp"
-                android:minWidth="1dp"/>
+                android:minWidth="1dp"
+                android:textAllCaps="false"/>
 
             <Button
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_statistics.xml
+++ b/app/src/main/res/layout/activity_statistics.xml
@@ -36,7 +36,7 @@
             <Button
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="YTD"
+                android:text="YD"
                 android:id="@+id/button_stats_yesterday"
                 android:layout_marginTop="1dp"
                 android:layout_marginBottom="1dp"


### PR DESCRIPTION
The abbreviation YTD is often mistaken for year to date when in fact it is meant to stand for yesterday.
This PR changes it to YD hoping that less will be confused.  
Shown next to TD for today, I hope that most will accept and understand YD standing for yesterday.  
  
---  
  
Edit:  **Outdated - See next post**  

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20250307-194634](https://github.com/user-attachments/assets/e45e3f14-9a73-4961-aeb1-38c304404418) | ![Screenshot_20250307-195145](https://github.com/user-attachments/assets/2695f2a7-36b2-4e7a-8b86-a1e4ba1e5982) |  

