### PR TITLE
CareLinkFollower - Use Cloud servers for standalone sensors

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -608,14 +608,26 @@ public class CareLinkClient {
 
         Map<String, String> queryParams = null;
         RecentData recentData = null;
+        boolean useCloudServer = false;
 
         queryParams = new HashMap<String, String>();
         queryParams.put("cpSerialNumber", "NONE");
         queryParams.put("msgType", "last24hours");
         queryParams.put("requestTime", String.valueOf(System.currentTimeMillis()));
 
+        //use cloud server in every region
+        useCloudServer = true;
+
         try {
-            recentData = this.getData(this.careLinkServer(), "patient/connect/data", queryParams, null, RecentData.class);
+            //Get data
+            //carelink cloud server and no query params
+            if(useCloudServer)
+                recentData = this.getData(this.cloudServer(), "patient/connect/data", null, null, RecentData.class);
+            //old carelink minimed server + query params
+            else
+                recentData = this.getData(this.careLinkServer(), "patient/connect/data", queryParams, null, RecentData.class);
+
+            //Correct time
             if (recentData != null)
                 correctTimeInRecentData(recentData);
         } catch (Exception e) {
@@ -668,7 +680,7 @@ public class CareLinkClient {
                     correctTimeInRecentData(recentData);
                 }
             }
-            //Use new data format outside US
+            //Use new data format for new endpoint
             else {
                 displayMessage = this.getData(newEndpointUrl, requestBody, DisplayMessage.class);
                 if (displayMessage != null && displayMessage.patientData != null) {
@@ -686,6 +698,8 @@ public class CareLinkClient {
     // New M2M last24hours webapp data
     public RecentData getM2MPatientData(String patientUsername) {
 
+        RecentData recentData = null;
+        boolean useCloudServer = false;
         Map<String, String> queryParams = null;
 
         //Patient username is mandantory!
@@ -697,9 +711,21 @@ public class CareLinkClient {
         queryParams.put("msgType", "last24hours");
         queryParams.put("requestTime", String.valueOf(System.currentTimeMillis()));
 
-        RecentData recentData = this.getData(this.careLinkServer(), "/patient/m2m/connect/data/gc/patients/" + patientUsername, queryParams, null, RecentData.class);
+        //use cloud server in every region
+        useCloudServer = true;
+
+        //Get data
+        //carelink cloud server and no query params
+        if(useCloudServer)
+            recentData = this.getData(this.cloudServer(), "patient/m2m/connect/data/gc/patients/" + patientUsername, null, null, RecentData.class);
+        //old carelink minimed server + query params
+        else
+            recentData = this.getData(this.careLinkServer(), "patient/m2m/connect/data/gc/patients/" + patientUsername, queryParams, null, RecentData.class);
+
+        //Correct time
         if (recentData != null)
             correctTimeInRecentData(recentData);
+
         return recentData;
 
     }


### PR DESCRIPTION
**Issue**
The old servers are no longer providing new data as standalone sensors have been migrated from old servers to the cloud servers.
This migration affects every region (US and outside US).
Following standalone sensors is currently not possible in any region.

**Solution**
Using cloud servers for data retrieval in the case of standalone sensors.

**Testing**
I have tested it with all kinds of accounts (patient, carepartner) with different devices (standalone CGM and 7xxG pump) in every region (EU,US) on different phones and it is was working fine without any errors and was stable.