### PR TITLE
Sensor: fix inconsistencies

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Calibration.java
@@ -11,6 +11,7 @@ import com.activeandroid.ActiveAndroid;
 import com.activeandroid.Model;
 import com.activeandroid.annotation.Column;
 import com.activeandroid.annotation.Table;
+import com.activeandroid.query.Delete;
 import com.activeandroid.query.Select;
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
@@ -1359,6 +1360,12 @@ public class Calibration extends Model {
         String msg = "Deleted all calibrations for sensor";
         Log.ueh(TAG, msg);
         JoH.static_toast_long(msg);
+    }
+
+    public static void deleteAll() {
+        new Delete()
+                .from(Calibration.class)
+                .execute();
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SensorSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SensorSendQueue.java
@@ -5,6 +5,7 @@ import android.provider.BaseColumns;
 import com.activeandroid.Model;
 import com.activeandroid.annotation.Column;
 import com.activeandroid.annotation.Table;
+import com.activeandroid.query.Delete;
 import com.activeandroid.query.Select;
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
@@ -56,5 +57,11 @@ public class SensorSendQueue extends Model {
         if(Home.get_master()) {
             GcmActivity.syncSensor(sensor, true);
         }
+    }
+
+    public static void deleteAll() {
+        new Delete()
+                .from(SensorSendQueue.class)
+                .execute();
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/evaluators/PersistentHighTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/evaluators/PersistentHighTest.java
@@ -1,11 +1,14 @@
 package com.eveningoutpost.dexdrip.evaluators;
 
 import com.eveningoutpost.dexdrip.models.BgReading;
+import com.eveningoutpost.dexdrip.models.Calibration;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.Sensor;
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.robolectric.shadows.ShadowLog;
 
@@ -22,6 +25,22 @@ public class PersistentHighTest extends RobolectricTestWithConfig {
     private static long START_TIME = JoH.tsl() - Constants.HOUR_IN_MS * 4;
     private static final double HIGH_MARK = 170;
 
+    @Before
+    public void setUp() {
+        cleanEverything();
+    }
+
+    @After
+    public void tearDown() {
+        cleanEverything();
+    }
+
+    private void cleanEverything() {
+        BgReading.deleteALL();
+        Calibration.deleteAll();
+        Sensor.deleteAll();
+    }
+
     @Test
     public void dataQualityCheckTest() {
 
@@ -32,8 +51,9 @@ public class PersistentHighTest extends RobolectricTestWithConfig {
         assertWithMessage("Predating sensor should fail").that(PersistentHigh.dataQualityCheck(1000, HIGH_MARK)).isFalse();
         assertWithMessage("Post sensor start no data should fail").that(PersistentHigh.dataQualityCheck(JoH.tsl(), HIGH_MARK)).isFalse();
 
-        BgReading.deleteALL();
-        Sensor.create(START_TIME);
+        cleanEverything();
+        Sensor created = Sensor.create(START_TIME);
+        assertWithMessage("Sensor started when we wanted").that(created.started_at).isEqualTo(START_TIME);
         // various all high time slices
         for (int i = 0; i < (12 * 4); i++) {
             final long timestamp = START_TIME + Constants.MINUTE_IN_MS * 5 * i;
@@ -44,8 +64,9 @@ public class PersistentHighTest extends RobolectricTestWithConfig {
         }
 
         START_TIME++;
-        BgReading.deleteALL();
-        Sensor.create(START_TIME);
+        cleanEverything();
+        created = Sensor.create(START_TIME);
+        assertWithMessage("Sensor started when we wanted b").that(created.started_at).isEqualTo(START_TIME);
         // single dipped point in sequence after a point we might have succeeded
         for (int i = 0; i < (12 * 4); i++) {
             final long timestamp = START_TIME + Constants.MINUTE_IN_MS * 5 * i;
@@ -56,8 +77,9 @@ public class PersistentHighTest extends RobolectricTestWithConfig {
         }
 
         START_TIME++;
-        BgReading.deleteALL();
-        Sensor.create(START_TIME);
+        cleanEverything();
+        created = Sensor.create(START_TIME);
+        assertWithMessage("Sensor started when we wanted c").that(created.started_at).isEqualTo(START_TIME);
         // single dipped point in sequence before we would succeed
         for (int i = 0; i < (12 * 4); i++) {
             final long timestamp = START_TIME + Constants.MINUTE_IN_MS * 5 * i;

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/SensorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/SensorTest.java
@@ -23,6 +23,7 @@ public class SensorTest extends RobolectricTestWithConfig {
 
     private void cleanEverything() {
         BgReading.deleteALL();
+        Calibration.deleteAll();
         Sensor.deleteAll();
     }
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/SensorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/SensorTest.java
@@ -1,0 +1,170 @@
+package com.eveningoutpost.dexdrip.models;
+
+import static org.junit.Assert.*;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SensorTest extends RobolectricTestWithConfig {
+
+    @Before
+    public void setUp() {
+        cleanEverything();
+    }
+
+    @After
+    public void tearDown() {
+        cleanEverything();
+    }
+
+    private void cleanEverything() {
+        BgReading.deleteALL();
+        Sensor.deleteAll();
+    }
+
+    @Test // check basic functionality
+    public void continuityTest() {
+        assertNull("start with no active sensor", Sensor.currentSensor());
+        assertNull("start with no previous sensor", Sensor.lastStopped());
+        assertFalse("sensor not running", Sensor.isActive());
+
+        long time = 1741707535293L;
+        // sensor 1
+        Sensor one = Sensor.create(time);
+
+        assertNotNull("first sensor is active sensor", Sensor.currentSensor());
+        assertEquals("first sensor is active sensor we know", one, Sensor.currentSensor());
+        assertTrue("sensor is running", Sensor.isActive());
+
+        time += Constants.HOUR_IN_MS;
+
+        Sensor.setUnitTestStopTime(time); // force stop time to this
+
+
+        time += Constants.HOUR_IN_MS;
+        Sensor two = Sensor.create(time);
+        time += Constants.HOUR_IN_MS;
+
+        assertNotNull("second sensor is active sensor", Sensor.currentSensor());
+        assertEquals("second sensor is active sensor we know", two, Sensor.currentSensor());
+
+        //System.out.println("TWO: " + two);
+        two.stopped_at = time;
+        two.save();
+
+        assertFalse("sensor is not running", Sensor.isActive());
+        assertNull("any sensor is not active sensor", Sensor.currentSensor());
+
+        // restore sensor 1 to simulate out of order sequence previously possible
+        //one.stopped_at = 0; // not necessary as our cached version doesn't reflect the stop made to the database
+        one.save();
+
+        assertFalse("sensor is not running b", Sensor.isActive());
+        assertNull("any sensor is not active sensor b", Sensor.currentSensor());
+    }
+
+    @Test // check correct start/end times
+    public void testCreate() {
+        assertNull("start with no active sensor", Sensor.currentSensor());
+        assertNull("start with no previous sensor", Sensor.lastStopped());
+        assertFalse("sensor not running", Sensor.isActive());
+
+        long time = 1741707535292L;
+        //System.out.println("TIME start: " + JoH.dateTimeText(time));
+
+        // sensor 1
+        Sensor one = Sensor.create(time);
+
+        assertNotNull("first sensor is active sensor", Sensor.currentSensor());
+        assertEquals("first sensor is active sensor we know", one, Sensor.currentSensor());
+        // assertSame("first sensor is active sensor we know",one, Sensor.currentSensor());
+        assertNull("first sensor no previous sensor", Sensor.lastStopped());
+        assertTrue("sensor 1 is running", Sensor.isActive());
+
+        //System.out.println(one);
+        // sensor 2 create while sensor 1 running
+
+        time += Constants.HOUR_IN_MS;
+
+        Sensor.setUnitTestStopTime(time); // force stop time to this
+
+        // Try and start a sensor 3 hours in the past which should then be started at the last sensor stop time +1ms
+        Sensor two = Sensor.create(time - Constants.HOUR_IN_MS * 3);
+
+
+        assertNotNull("second sensor is active sensor", Sensor.currentSensor());
+        assertEquals("second sensor is active sensor we know", two, Sensor.currentSensor());
+        // assertSame("first sensor is active sensor we know",one, Sensor.currentSensor());
+        assertEquals("first sensor is previous sensor", one, Sensor.lastStopped());
+        assertTrue("sensor 2 is running", Sensor.isActive());
+
+        assertEquals("last sensor (one) stopped at now time", time, Sensor.lastStopped().stopped_at);
+        assertEquals("current sensor (two) started at now time + 1 ms", Sensor.lastStopped().stopped_at + 1, Sensor.currentSensor().started_at);
+
+
+        //System.out.println(Sensor.currentSensor());
+        //System.out.println(Sensor.lastStopped());
+
+        time += Constants.HOUR_IN_MS;
+        // add a reading
+        BgReading reading1 = BgReading.bgReadingInsertFromG5(123, time, "Backfill");
+        assertNotNull("bg reading created", reading1);
+
+        //System.out.println("Bg Reading created at: " + JoH.dateTimeText(reading1.getEpochTimestamp()));
+
+        time += Constants.HOUR_IN_MS;
+        Sensor.setUnitTestStopTime(time); // force stop time to this
+
+        // Try and start a sensor 3 hours in the past which should then be started at the last reading time
+        Sensor three = Sensor.create(time - Constants.HOUR_IN_MS * 3);
+        //System.out.println(three);
+
+        assertNotNull("third sensor is active sensor", Sensor.currentSensor());
+        assertEquals("third sensor is active sensor we know", three, Sensor.currentSensor());
+        // assertSame("first sensor is active sensor we know",one, Sensor.currentSensor());
+        assertEquals("third sensor is previous sensor", two, Sensor.lastStopped());
+        assertTrue("sensor 3 is running", Sensor.isActive());
+
+        assertEquals("last sensor (two) stopped at now time", reading1.timestamp + 1, Sensor.lastStopped().stopped_at);
+        assertEquals("current sensor (three) started at now time + 1 ms", Sensor.lastStopped().stopped_at + 1, Sensor.currentSensor().started_at);
+
+
+        time += Constants.HOUR_IN_MS;
+        // add a reading
+        BgReading reading2 = BgReading.bgReadingInsertFromG5(124, time, "Backfill");
+        assertNotNull("bg reading created 2", reading2);
+
+        time += Constants.HOUR_IN_MS;
+        Sensor.setUnitTestStopTime(time); // force stop time to this
+
+        long timeAtStop = time;
+        // Manually stop the sensor
+        Sensor.stopSensor();
+        assertNull("fourth sensor is not active", Sensor.currentSensor());
+        assertFalse("sensor 4 is not running", Sensor.isActive());
+
+
+        // advance time another hour
+        time += Constants.HOUR_IN_MS;
+        Sensor.setUnitTestStopTime(time); // force stop time to this
+
+        // Try and start a sensor 3 hours in the past which should then be started at the last reading time
+        Sensor four = Sensor.create(time - Constants.HOUR_IN_MS * 3);
+        //System.out.println("FOUR:" + four);
+
+
+        assertNotNull("fourth sensor is active sensor", Sensor.currentSensor());
+        assertEquals("fourth sensor is active sensor we know", four, Sensor.currentSensor());
+        // assertSame("first sensor is active sensor we know",one, Sensor.currentSensor());
+        assertEquals("third sensor is previous sensor", three, Sensor.lastStopped());
+        assertTrue("sensor 4 is running", Sensor.isActive());
+
+        assertEquals("last sensor (three) stopped at now time when stopped", timeAtStop, Sensor.lastStopped().stopped_at);
+        assertEquals("current sensor (four) started at now time + 1 ms", Sensor.lastStopped().stopped_at + 1, Sensor.currentSensor().started_at);
+
+    }
+}


### PR DESCRIPTION
This pull request is designed to resolve some inconsistencies with how the `Sensor` class works which are likely to contribute to other problems.

In simple terms it should not be possible to have more than one "active" sensor within the database and sensor sessions should not be able to overlap.

Prior to this change, if you have two sensor records which do not have stop times and you then stop the sensor, the last one is stopped but then the previous one is considered to be active which is not intended.

The current code allows for creating a new sensor session without stopping the previous one and doesn't correctly handle the situation where the latest sensor is stopped at which point we should not have any active sensor sessions.

The code changes also allow for new sensor starts which point the start time to the past to then correctly stop the previous sensor and prevent the start time of the new sensor overlapping the stop time of the previous sensor. 

In order to allow the maximum number of readings where physical sensors may actually overlap we can automatically make the stop time of the previous sensor clamp to the last recorded reading time so that we have opportunities for backfilling before the current time but after the physical end time of the previous sensor.

Much of this relates to legacy support where individual sensor sessions are important for calibration reasons but there are clear inconsistencies in how this class handles data vs the modelling of how we would expect it to work and this PR is designed to resolve those which should then potentially resolve other related issues.