### PR TITLE
Making buttons in system status match parent to be more symmetrical

### DIFF
--- a/app/src/main/res/layout/activity_system_status.xml
+++ b/app/src/main/res/layout/activity_system_status.xml
@@ -231,7 +231,7 @@
                         android:id="@+id/restart_collection_service"
                         style="?android:attr/buttonStyleSmall"
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:text="@string/restart_collector" />
 
                     <Button
@@ -239,7 +239,7 @@
                         app:showIfTrue="@{ms.bluetooth()}"
                         style="?android:attr/buttonStyleSmall"
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:text="@string/forget_device" />
                 </LinearLayout>
 


### PR DESCRIPTION
Hello everyone :)

I have noticed a tiny UI misalignment that occurs at least when using polish strings.
The system status activity has buttons on different heights because one of the texts is longer that usual.
![image](https://github.com/user-attachments/assets/6c173481-7d1d-47e9-ba7d-8294135aff9a)

That could be potentially fixed with replacing wrap_content with match_parent on those two buttons. From my perspective this is rather safe change that should not break the view for other languages. Please correct me if I am wrong.

Screen after change
![image](https://github.com/user-attachments/assets/0af7a099-f034-4fe4-af2a-ff852cb30b71)
