### PR TITLE
Add sensor iCan Health Asia version

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
@@ -108,6 +108,7 @@ public class UiBasedCollector extends NotificationListenerService {
         coOptedPackages.add("com.senseonics.eversense365.us");
         coOptedPackages.add("com.kakaohealthcare.pasta"); // A Health app for sensors that we already collect from
         coOptedPackages.add("com.sinocare.cgm.ce");
+        coOptedPackages.add("com.sinocare.ican.health.ce"); //for iCan Health Asia version
 
         coOptedPackagesAll.add("com.dexcom.dexcomone");
         coOptedPackagesAll.add("com.dexcom.d1plus");
@@ -123,6 +124,7 @@ public class UiBasedCollector extends NotificationListenerService {
         coOptedPackagesAll.add("com.senseonics.eversense365.us");
         coOptedPackagesAll.add("com.kakaohealthcare.pasta"); // Experiment
         coOptedPackagesAll.add("com.sinocare.cgm.ce");
+        coOptedPackagesAll.add("com.sinocare.ican.health.ce"); //for iCan Health Asia version
 
         companionAppIoBPackages.add("com.insulet.myblue.pdm");
 


### PR DESCRIPTION
Add support for iCan Health Asia app (com.sinocare.ican.health.ce)

This commit adds the package name for iCan Health Asia app to both coOptedPackages  and coOptedPackagesAll lists. This enables xDrip to receive and process glucose  values from iCan Health app notifications, allowing users to use this app as a  Companion App data source.

The standard Sinocare CGM CE app was already supported, but the iCan Health app  uses a different package name that needed to be explicitly added for compatibility.