### PR TITLE
Retrieve LibreLinkUp data every two minutes

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/webfollow/WebFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/webfollow/WebFollowService.java
@@ -119,7 +119,7 @@ public class WebFollowService extends ForegroundService {
                     }
                 }
                 if (context != null) {
-                    if (JoH.pratelimit("last-web-follow-poll", 180)) {
+                    if (JoH.pratelimit("last-web-follow-poll", 90)) {
                         Inevitable.task("WebFollow-Work", 200, () -> {
                             try {
                                 new Cmd(context).processAll();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
@@ -339,6 +339,8 @@ public enum DexCollectionType {
         switch (type) {
             case LibreReceiver:
                 return libreOneMinute ? 60_000 : 300_000;
+            case WebFollow:
+                return 120_000;
             default:
                 return 300_000; // 5 minutes
         }


### PR DESCRIPTION
This commit adjusts the `WebFollowerService`'s sampling period so that the app retrieves glucose data every two minutes from `LibreLinkUp`. Currently, the sampling period is set to five minutes.
For that change to work, I also needed to decrease the `WebFollower`'s rate limit, where I chose a value of 90 seconds.
First, I wanted to retrieve the data every minute but my `Libre 3` app seems to retrieve data from my `Libre 3 Plus` test sensor every two minutes at most although it's advertised otherwise.