### PR TITLE
Make context characteristic optional

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/BluetoothGlucoseMeter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/BluetoothGlucoseMeter.java
@@ -223,8 +223,14 @@ public class BluetoothGlucoseMeter extends Service {
                     Bluetooth_CMD.notify(GLUCOSE_SERVICE, GLUCOSE_CHARACTERISTIC, "notify new glucose record");
                     Bluetooth_CMD.enable_notification_value(GLUCOSE_SERVICE, GLUCOSE_CHARACTERISTIC, "notify new glucose value");
 
-                    Bluetooth_CMD.enable_notification_value(GLUCOSE_SERVICE, CONTEXT_CHARACTERISTIC, "notify new context value");
-                    Bluetooth_CMD.notify(GLUCOSE_SERVICE, CONTEXT_CHARACTERISTIC, "notify new glucose context");
+                    if (hasContextCharacteristic(gatt)) {
+                        Bluetooth_CMD.enable_notification_value(GLUCOSE_SERVICE, CONTEXT_CHARACTERISTIC, "notify new context value");
+                        Bluetooth_CMD.notify(GLUCOSE_SERVICE, CONTEXT_CHARACTERISTIC, "notify new glucose context");
+                    } else {
+                        if (d) {
+                            Log.d(TAG, "Device has no context characteristic. Skipping");
+                        }
+                    }
 
                     Bluetooth_CMD.enable_indications(GLUCOSE_SERVICE, RECORDS_CHARACTERISTIC, "readings indication request");
                     Bluetooth_CMD.notify(GLUCOSE_SERVICE, RECORDS_CHARACTERISTIC, "notify glucose record");
@@ -239,6 +245,15 @@ public class BluetoothGlucoseMeter extends Service {
             } else {
                 Log.w(TAG, "onServicesDiscovered received: " + status);
             }
+        }
+
+        private boolean hasContextCharacteristic(BluetoothGatt gatt) {
+            BluetoothGattService glucoseService = gatt.getService(GLUCOSE_SERVICE);
+            if (glucoseService != null) {
+                BluetoothGattCharacteristic contextCharacteristic = glucoseService.getCharacteristic(CONTEXT_CHARACTERISTIC);
+                return contextCharacteristic != null;
+            }
+            return false;
         }
 
         @Override


### PR DESCRIPTION
Glucose measurement context is an optional characteristic according to https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/GLS_v1.0.1/out/en/index-en.html#UUID-45a50e27-d452-3609-08f4-8204fa4b87ae  

This patch makes xdrip support the "ACCU-Chek Instant" glucose meter (see discussion https://github.com/NightscoutFoundation/xDrip/discussions/2997 )