### PR TITLE
Dex collector Last Connected - Color

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -2179,7 +2179,7 @@ public class Ob1G5CollectionService extends G5BaseService {
 
         if (static_last_connected > 0) {
             long since = msSince(static_last_connected);
-            l.add(new StatusItem("Last Connected", niceTimeScalar(since) + " ago", since < 300000 ? Highlight.NORMAL : NOTICE));
+            l.add(new StatusItem("Last Connected", niceTimeScalar(since) + " ago", since < MINUTE_IN_MS * 5 ? Highlight.NORMAL : NOTICE));
         }
 
         if ((!lastState.startsWith("Service Stopped")) && (!lastState.startsWith("Not running")))


### PR DESCRIPTION
This will let me see if the "Last Connected" value is less than 5 minutes or not without having to understand the translated words for minutes or seconds when helping xDrip users.  
![Screenshot_20250526-091650](https://github.com/user-attachments/assets/257a59e2-893c-48a0-9d41-c78886f40a7b)  
    
If this PR is merged, there will be no need for the following any longer:
https://github.com/NightscoutFoundation/xDrip/pull/3817 