### PR TITLE
Removing redundant build version conditionals

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
@@ -112,12 +112,10 @@ public class NavDrawerBuilder {
             }
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            if (DexCollectionType.hasBluetooth() && (DexCollectionType.getDexCollectionType() != DexCollectionType.DexcomG5)) {
+        if (DexCollectionType.hasBluetooth() && (DexCollectionType.getDexCollectionType() != DexCollectionType.DexcomG5)) {
 
-                this.nav_drawer_options.add(context.getString(R.string.bluetooth_scan));
-                this.nav_drawer_intents.add(new Intent(context, BluetoothScan.class));
-            }
+            this.nav_drawer_options.add(context.getString(R.string.bluetooth_scan));
+            this.nav_drawer_intents.add(new Intent(context, BluetoothScan.class));
         }
 
         //if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Reminders.java
@@ -619,20 +619,18 @@ public class Reminders extends ActivityWithRecycler implements SensorEventListen
     }
 
     private boolean checkPermissions() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (ContextCompat.checkSelfPermission(getApplicationContext(),
-                    android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    != PackageManager.PERMISSION_GRANTED) {
-                final Activity activity = this;
-                JoH.show_ok_dialog(activity, xdrip.getAppContext().getString(R.string.Please_Allow_Permission), xdrip.getAppContext().getString(R.string.need_storage_permission), new Runnable() {
-                    @Override
-                    public void run() {
-                        ActivityCompat.requestPermissions(activity,
-                                new String[]{android.Manifest.permission.WRITE_EXTERNAL_STORAGE}, MY_PERMISSIONS_REQUEST_STORAGE);
-                    }
-                });
-                return false;
-            }
+        if (ContextCompat.checkSelfPermission(getApplicationContext(),
+                android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            final Activity activity = this;
+            JoH.show_ok_dialog(activity, xdrip.getAppContext().getString(R.string.Please_Allow_Permission), xdrip.getAppContext().getString(R.string.need_storage_permission), new Runnable() {
+                @Override
+                public void run() {
+                    ActivityCompat.requestPermissions(activity,
+                            new String[]{android.Manifest.permission.WRITE_EXTERNAL_STORAGE}, MY_PERMISSIONS_REQUEST_STORAGE);
+                }
+            });
+            return false;
         }
         return true;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StartNewSensor.java
@@ -91,7 +91,7 @@ public class StartNewSensor extends ActivityWithMenu {
         button.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && DexCollectionType.hasBluetooth()) {
+                if (DexCollectionType.hasBluetooth()) {
                     if (!LocationHelper.locationPermission(StartNewSensor.this)) {
                         LocationHelper.requestLocationForBluetooth(StartNewSensor.this);
                     } else {
@@ -260,13 +260,11 @@ public class StartNewSensor extends ActivityWithMenu {
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            for (int i = 0; i < permissions.length; i++) {
-                if (permissions[i].equals(android.Manifest.permission.ACCESS_FINE_LOCATION)) {
-                    if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
-                        Ob1G5CollectionService.clearScanError();
-                        sensorButtonClick();
-                    }
+        for (int i = 0; i < permissions.length; i++) {
+            if (permissions[i].equals(android.Manifest.permission.ACCESS_FINE_LOCATION)) {
+                if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+                    Ob1G5CollectionService.clearScanError();
+                    sensorButtonClick();
                 }
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatusFragment.java
@@ -224,9 +224,7 @@ public class SystemStatusFragment extends Fragment {
     private void set_current_values() {
         notes.setText("");
         activeBluetoothDevice = ActiveBluetoothDevice.first();
-        if (Build.VERSION.SDK_INT >= 18) {
-            mBluetoothManager = (BluetoothManager) safeGetContext().getSystemService(Context.BLUETOOTH_SERVICE);
-        }
+        mBluetoothManager = (BluetoothManager) safeGetContext().getSystemService(Context.BLUETOOTH_SERVICE);
         setVersionName();
         //setCollectionMethod();
         setCurrentDevice();
@@ -323,9 +321,7 @@ public class SystemStatusFragment extends Fragment {
         String collection_method = prefs.getString("dex_collection_method", "BluetoothWixel");
         if (collection_method.compareTo("DexcomG5") == 0) {
             Transmitter defaultTransmitter = new Transmitter(prefs.getString("dex_txid", "ABCDEF"));
-            if (Build.VERSION.SDK_INT >= 18) {
-                mBluetoothAdapter = mBluetoothManager.getAdapter();
-            }
+            mBluetoothAdapter = mBluetoothManager.getAdapter();
             if (mBluetoothAdapter != null) {
                 Set<BluetoothDevice> pairedDevices = mBluetoothAdapter.getBondedDevices();
                 if ((pairedDevices != null) && (pairedDevices.size() > 0)) {
@@ -372,7 +368,7 @@ public class SystemStatusFragment extends Fragment {
 
     private void setConnectionStatus() {
         boolean connected = false;
-        if (mBluetoothManager != null && activeBluetoothDevice != null && (Build.VERSION.SDK_INT >= 18)) {
+        if (mBluetoothManager != null && activeBluetoothDevice != null) {
             for (BluetoothDevice bluetoothDevice : mBluetoothManager.getConnectedDevices(BluetoothProfile.GATT)) {
                 if (bluetoothDevice.getAddress().compareTo(activeBluetoothDevice.address) == 0) {
                     connected = true;
@@ -388,7 +384,7 @@ public class SystemStatusFragment extends Fragment {
         String collection_method = prefs.getString("dex_collection_method", "BluetoothWixel");
         if (collection_method.compareTo("DexcomG5") == 0) {
             Transmitter defaultTransmitter = new Transmitter(prefs.getString("dex_txid", "ABCDEF"));
-            if (Build.VERSION.SDK_INT >= 18) mBluetoothAdapter = mBluetoothManager.getAdapter();
+            mBluetoothAdapter = mBluetoothManager.getAdapter();
             if (mBluetoothAdapter != null) {
                 Set<BluetoothDevice> pairedDevices = mBluetoothAdapter.getBondedDevices();
                 if (pairedDevices.size() > 0) {
@@ -416,16 +412,11 @@ public class SystemStatusFragment extends Fragment {
     private void setNotes() {
         try {
 
-            if ((mBluetoothManager == null) || ((android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) && (mBluetoothManager.getAdapter() == null))) {
+            if ((mBluetoothManager == null) || (mBluetoothManager.getAdapter() == null)) {
                 notes.append("\n- This device does not seem to support bluetooth");
             } else {
-                if ((android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2)
-                        && !mBluetoothManager.getAdapter().isEnabled()) {
+                if (!mBluetoothManager.getAdapter().isEnabled()) {
                     notes.append("\n- Bluetooth seems to be turned off");
-                } else {
-                    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                        notes.append("\n- The android version of this device is not compatible with Bluetooth Low Energy");
-                    }
                 }
             }
         } catch (NullPointerException e) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/WidgetUpdateService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/WidgetUpdateService.java
@@ -58,8 +58,7 @@ public class WidgetUpdateService extends Service {
         super.onCreate();
         PowerManager pm = (PowerManager) getSystemService(Service.POWER_SERVICE);
         Log.d(TAG, "onCreate");
-        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && pm.isInteractive()) ||
-                (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP && pm.isScreenOn()))
+        if (pm.isInteractive())
             enableClockTicks();
         else
             disableClockTicks();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrum/MedtrumCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrum/MedtrumCollectionService.java
@@ -980,8 +980,7 @@ public class MedtrumCollectionService extends JamBaseBluetoothService implements
 
     @SuppressLint("ObsoleteSdkInt")
     private static boolean shouldServiceRun() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2
-                && DexCollectionType.getDexCollectionType().equals(DexCollectionType.Medtrum);
+        return DexCollectionType.getDexCollectionType().equals(DexCollectionType.Medtrum);
     }
 
     private void setRetryTimer() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/eassist/EmergencyAssistActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/eassist/EmergencyAssistActivity.java
@@ -97,20 +97,18 @@ public class EmergencyAssistActivity extends BaseAppCompatActivity {
     }
 
     private boolean checkContactsPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (ContextCompat.checkSelfPermission(getApplicationContext(),
-                    Manifest.permission.READ_CONTACTS)
-                    != PackageManager.PERMISSION_GRANTED) {
-                final Activity activity = this;
-                JoH.show_ok_dialog(activity, gs(R.string.please_allow_permission), gs(R.string.need_contacts_permission_to_select_message_recipients), new Runnable() {
-                    @Override
-                    public void run() {
-                        ActivityCompat.requestPermissions(activity,
-                                new String[]{Manifest.permission.READ_CONTACTS}, MY_PERMISSIONS_REQUEST_CONTACTS);
-                    }
-                });
-                return false;
-            }
+        if (ContextCompat.checkSelfPermission(getApplicationContext(),
+                Manifest.permission.READ_CONTACTS)
+                != PackageManager.PERMISSION_GRANTED) {
+            final Activity activity = this;
+            JoH.show_ok_dialog(activity, gs(R.string.please_allow_permission), gs(R.string.need_contacts_permission_to_select_message_recipients), new Runnable() {
+                @Override
+                public void run() {
+                    ActivityCompat.requestPermissions(activity,
+                            new String[]{Manifest.permission.READ_CONTACTS}, MY_PERMISSIONS_REQUEST_CONTACTS);
+                }
+            });
+            return false;
         }
         return true;
     }
@@ -121,20 +119,14 @@ public class EmergencyAssistActivity extends BaseAppCompatActivity {
     }
 
     private synchronized boolean checkSMSPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (!isSMSPermissionGranted()) {
-                if (JoH.ratelimit("check-sms-permission", 2)) {
-                    final Activity activity = this;
-                    JoH.show_ok_dialog(activity, gs(R.string.please_allow_permission), "Need SMS permission to send text messages to your emergency contacts."
-                            + "\n\n"
-                            + "Warning this can cost money at normal telecoms rates!", () -> ActivityCompat.requestPermissions(activity,
-                            new String[]{Manifest.permission.SEND_SMS}, MY_PERMISSIONS_REQUEST_SMS));
-                }
-                return false;
+        if (!isSMSPermissionGranted()) {
+            if (JoH.ratelimit("check-sms-permission", 2)) {
+                final Activity activity = this;
+                JoH.show_ok_dialog(activity, gs(R.string.please_allow_permission), "Need SMS permission to send text messages to your emergency contacts."
+                        + "\n\n"
+                        + "Warning this can cost money at normal telecoms rates!", () -> ActivityCompat.requestPermissions(activity,
+                        new String[]{Manifest.permission.SEND_SMS}, MY_PERMISSIONS_REQUEST_SMS));
             }
-        } else {
-            JoH.show_ok_dialog(this, "Needs Android 6+", "This feature is not designed for Android versions < 6\nIf you want this on an older phone please create an issue on the xDrip issue tracker and request it.", null);
-
             return false;
         }
         return true;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/PluginApplication.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/PluginApplication.java
@@ -39,15 +39,9 @@ public final class PluginApplication extends Application
                 Log.v(Constants.LOG_TAG, "Application is debuggable.  Enabling additional debug logging"); //$NON-NLS-1$
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD)
-            {
-                enableApiLevel9Debugging();
-            }
+            enableApiLevel9Debugging();
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-            {
-                enableApiLevel11Debugging();
-            }
+            enableApiLevel11Debugging();
 
             /*
              * If using the Fragment compatibility library, enable debug logging here

--- a/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/ui/AbstractPluginActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/localeTasker/ui/AbstractPluginActivity.java
@@ -47,15 +47,7 @@ public abstract class AbstractPluginActivity extends Activity
     {
         super.onCreate(savedInstanceState);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-        {
-            setupTitleApi11();
-        }
-        else
-        {
-            setTitle(BreadCrumber.generateBreadcrumb(getApplicationContext(), getIntent(),
-                                                     getString(R.string.plugin_name)));
-        }
+        setupTitleApi11();
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
@@ -88,15 +80,9 @@ public abstract class AbstractPluginActivity extends Activity
 
         getMenuInflater().inflate(R.menu.twofortyfouram_locale_help_save_dontsave, menu);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-        {
-            setupActionBarApi11();
-        }
+        setupActionBarApi11();
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)
-        {
-            setupActionBarApi14();
-        }
+        setupActionBarApi14();
 
         return true;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ProfileEditor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ProfileEditor.java
@@ -190,7 +190,7 @@ public class ProfileEditor extends BaseAppCompatActivity {
                             final int screen_height = dm.heightPixels;
                             boolean small_screen = false;
                             // smaller screens or lower version don't seem to play well with long dialog button names
-                            if ((screen_width < 720) || (screen_height < 720) || ((Build.VERSION.SDK_INT < Build.VERSION_CODES.M)))
+                            if ((screen_width < 720) || (screen_height < 720))
                                 small_screen = true;
 
                             AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(mContext);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/DexShareCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/DexShareCollectionService.java
@@ -212,13 +212,8 @@ public class DexShareCollectionService extends Service {
             if (pendingIntent != null)
                 alarm.cancel(pendingIntent);
             long wakeTime = calendar.getTimeInMillis() + retry_in;
-            pendingIntent = PendingIntent.getService(this, 0, new Intent(this, this.getClass()),  PendingIntent.FLAG_UPDATE_CURRENT);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                alarm.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                alarm.setExact(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
-            } else
-                alarm.set(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
+            pendingIntent = PendingIntent.getService(this, 0, new Intent(this, this.getClass()), PendingIntent.FLAG_UPDATE_CURRENT);
+            alarm.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
         }
     }
 
@@ -232,12 +227,7 @@ public class DexShareCollectionService extends Service {
                 alarm.cancel(pendingIntent);
             long wakeTime = calendar.getTimeInMillis() + retry_in;
             pendingIntent = PendingIntent.getService(this, 0, new Intent(this, this.getClass()), 0);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                alarm.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                alarm.setExact(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
-            } else
-                alarm.set(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
+            alarm.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
         } else {
             stopSelf();
         }
@@ -300,13 +290,13 @@ public class DexShareCollectionService extends Service {
     }
 
     public void requestHighPriority() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && mBluetoothGatt != null) {
+        if (mBluetoothGatt != null) {
             mBluetoothGatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH);
         }
     }
 
     public void requestLowPriority() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && mBluetoothGatt != null) {
+        if (mBluetoothGatt != null) {
             mBluetoothGatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER);
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsActivity.java
@@ -207,55 +207,29 @@ public class StatsActivity extends ActivityWithMenu {
                 break;
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-            ColorStateList csl = new ColorStateList(new int[][]{new int[0]}, new int[]{0xFF606060});
-            buttonTD.setBackgroundTintList(csl);
-            buttonYTD.setBackgroundTintList(csl);
-            button7d.setBackgroundTintList(csl);
-            button30d.setBackgroundTintList(csl);
-            button90d.setBackgroundTintList(csl);
-            csl = new ColorStateList(new int[][]{new int[0]}, new int[]{0xFFAA0000});
-            switch (state) {
-                case TODAY:
-                    buttonTD.setBackgroundTintList(csl);
-                    break;
-                case YESTERDAY:
-                    buttonYTD.setBackgroundTintList(csl);
-                    break;
-                case D7:
-                    button7d.setBackgroundTintList(csl);
-                    break;
-                case D30:
-                    button30d.setBackgroundTintList(csl);
-                    break;
-                case D90:
-                    button90d.setBackgroundTintList(csl);
-                    break;
-            }
-        } else {
-
-            buttonTD.setAlpha(0.5f);
-            buttonYTD.setAlpha(0.5f);
-            button7d.setAlpha(0.5f);
-            button30d.setAlpha(0.5f);
-            button90d.setAlpha(0.5f);
-            switch (state) {
-                case TODAY:
-                    buttonTD.setAlpha(1f);
-                    break;
-                case YESTERDAY:
-                    buttonYTD.setAlpha(1f);
-                    break;
-                case D7:
-                    button7d.setAlpha(1f);
-                    break;
-                case D30:
-                    button30d.setAlpha(1f);
-                    break;
-                case D90:
-                    button90d.setAlpha(1f);
-                    break;
-            }
+        ColorStateList csl = new ColorStateList(new int[][]{new int[0]}, new int[]{0xFF606060});
+        buttonTD.setBackgroundTintList(csl);
+        buttonYTD.setBackgroundTintList(csl);
+        button7d.setBackgroundTintList(csl);
+        button30d.setBackgroundTintList(csl);
+        button90d.setBackgroundTintList(csl);
+        csl = new ColorStateList(new int[][]{new int[0]}, new int[]{0xFFAA0000});
+        switch (state) {
+            case TODAY:
+                buttonTD.setBackgroundTintList(csl);
+                break;
+            case YESTERDAY:
+                buttonYTD.setBackgroundTintList(csl);
+                break;
+            case D7:
+                button7d.setBackgroundTintList(csl);
+                break;
+            case D30:
+                button30d.setBackgroundTintList(csl);
+                break;
+            case D90:
+                button90d.setBackgroundTintList(csl);
+                break;
         }
     }
 
@@ -345,16 +319,14 @@ public class StatsActivity extends ActivityWithMenu {
     }
 
     private boolean checkPermissions() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (ContextCompat.checkSelfPermission(getApplicationContext(),
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    != PackageManager.PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(getApplicationContext(),
+                Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
 
-                ActivityCompat.requestPermissions(this,
-                        new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                        MY_PERMISSIONS_REQUEST_STORAGE_SCREENSHOT);
-                return false;
-            }
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    MY_PERMISSIONS_REQUEST_STORAGE_SCREENSHOT);
+            return false;
         }
         return true;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/NumberGraphic.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/NumberGraphic.java
@@ -34,39 +34,35 @@ public class NumberGraphic {
 
     public static void testNotification(String text) {
         {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 
-                final Notification.Builder mBuilder = new Notification.Builder(xdrip.getAppContext());
+            final Notification.Builder mBuilder = new Notification.Builder(xdrip.getAppContext());
 
-                mBuilder.setSmallIcon(Icon.createWithBitmap(getSmallIconBitmap(text)));
+            mBuilder.setSmallIcon(Icon.createWithBitmap(getSmallIconBitmap(text)));
 
-                mBuilder.setContentTitle("Test Number Graphic");
-                mBuilder.setContentText("Check the number is visible");
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    mBuilder.setTimeoutAfter(Constants.SECOND_IN_MS * 30);
-                } else {
-                    JoH.runOnUiThreadDelayed(new Runnable() {
-                        @Override
-                        public void run() {
-                            JoH.cancelNotification(Constants.NUMBER_TEXT_TEST_ID);
-                        }
-                    }, Constants.SECOND_IN_MS * 30);
-                }
-                mBuilder.setOngoing(false);
-                mBuilder.setVibrate(vibratePattern);
-
-                int mNotificationId = Constants.NUMBER_TEXT_TEST_ID;
-                final NotificationManager mNotifyMgr = (NotificationManager) xdrip.getAppContext().getSystemService(NOTIFICATION_SERVICE);
-                mNotifyMgr.notify(mNotificationId, mBuilder.build());
+            mBuilder.setContentTitle("Test Number Graphic");
+            mBuilder.setContentText("Check the number is visible");
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                mBuilder.setTimeoutAfter(Constants.SECOND_IN_MS * 30);
+            } else {
                 JoH.runOnUiThreadDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        mNotifyMgr.notify(mNotificationId, mBuilder.build());
+                        JoH.cancelNotification(Constants.NUMBER_TEXT_TEST_ID);
                     }
-                }, 1000);
-            } else {
-                JoH.static_toast_long("Not supported below Android 6");
+                }, Constants.SECOND_IN_MS * 30);
             }
+            mBuilder.setOngoing(false);
+            mBuilder.setVibrate(vibratePattern);
+
+            int mNotificationId = Constants.NUMBER_TEXT_TEST_ID;
+            final NotificationManager mNotifyMgr = (NotificationManager) xdrip.getAppContext().getSystemService(NOTIFICATION_SERVICE);
+            mNotifyMgr.notify(mNotificationId, mBuilder.build());
+            JoH.runOnUiThreadDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mNotifyMgr.notify(mNotificationId, mBuilder.build());
+                }
+            }, 1000);
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/activities/NumberWallPreview.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/activities/NumberWallPreview.java
@@ -118,16 +118,14 @@ public class NumberWallPreview extends AppCompatActivity {
 
         public void folderImageButtonClick() {
             if (Pref.getString(PREF_numberwall_background, null) == null) {
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-                    if (SdcardImportExport.checkPermissions(activity, true, ASK_FILE_PERMISSION)) {
-                        final Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-                        intent.addCategory(Intent.CATEGORY_OPENABLE);
-                        intent.setType("image/*");
-                        startActivityForResult(intent, LOAD_IMAGE_RESULTS);
-                    } else {
-                        if (JoH.ratelimit("need-file-permission", 10)) {
-                            //JoH.static_toast_short("Need file permission");
-                        }
+                if (SdcardImportExport.checkPermissions(activity, true, ASK_FILE_PERMISSION)) {
+                    final Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+                    intent.addCategory(Intent.CATEGORY_OPENABLE);
+                    intent.setType("image/*");
+                    startActivityForResult(intent, LOAD_IMAGE_RESULTS);
+                } else {
+                    if (JoH.ratelimit("need-file-permission", 10)) {
+                        //JoH.static_toast_short("Need file permission");
                     }
                 }
             } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/activities/ThinJamActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/activities/ThinJamActivity.java
@@ -531,12 +531,10 @@ public class ThinJamActivity extends AppCompatActivity implements BtCallBack2, A
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            for (int i = 0; i < permissions.length; i++) {
-                if (permissions[i].equals(android.Manifest.permission.ACCESS_FINE_LOCATION)) {
-                    if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
-                        refreshFromStoredMac();
-                    }
+        for (int i = 0; i < permissions.length; i++) {
+            if (permissions[i].equals(android.Manifest.permission.ACCESS_FINE_LOCATION)) {
+                if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+                    refreshFromStoredMac();
                 }
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/graphic/TrendArrowFactory.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/graphic/TrendArrowFactory.java
@@ -26,11 +26,9 @@ public class TrendArrowFactory {
         final String arrow_type = Pref.getString(PREF_TREND_ARROW_TYPE, "");
 
         // yucky workaround for broken LG lack of gradient fill.
-        if (Build.VERSION.SDK_INT == 23 && Build.MANUFACTURER.startsWith("LG")) {
-            if (arrow_type.equals("JamTrendArrowImpl")) {
-                JoH.static_toast_long("LG Phones have problems with some arrows, choose another");
-                return create("JamTrendArrow2Impl", imageView);
-            }
+        if (arrow_type.equals("JamTrendArrowImpl")) {
+            JoH.static_toast_long("LG Phones have problems with some arrows, choose another");
+            return create("JamTrendArrow2Impl", imageView);
         }
         return create(arrow_type, imageView);
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/helpers/BitmapLoader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/helpers/BitmapLoader.java
@@ -116,9 +116,6 @@ public class BitmapLoader implements BitmapCacheProvider {
 
     private static Bitmap getBitmapFromVectorDrawable(int drawableId) {
         Drawable drawable = AppCompatResources.getDrawable(xdrip.getAppContext(), drawableId);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            drawable = (DrawableCompat.wrap(drawable)).mutate();
-        }
         final Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
                 drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
         final Canvas canvas = new Canvas(bitmap);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/helpers/DoNotDisturb.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/helpers/DoNotDisturb.java
@@ -24,23 +24,21 @@ public class DoNotDisturb {
     private static final String TAG = DoNotDisturb.class.getSimpleName();
 
     public static void checkAndAskForDoNotDisturbAccess(final Activity activity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            val mNotificationManager = (NotificationManager) activity.getSystemService(Context.NOTIFICATION_SERVICE);
-            try {
-                if (!mNotificationManager.isNotificationPolicyAccessGranted()) {
-                    JoH.show_ok_dialog(activity, activity.getString(R.string.please_allow_permission), activity.getString(R.string.allow_do_not_disturb_text), () -> {
-                        val intent = new Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
-                                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        activity.startActivity(intent);
-                    });
+        val mNotificationManager = (NotificationManager) activity.getSystemService(Context.NOTIFICATION_SERVICE);
+        try {
+            if (!mNotificationManager.isNotificationPolicyAccessGranted()) {
+                JoH.show_ok_dialog(activity, activity.getString(R.string.please_allow_permission), activity.getString(R.string.allow_do_not_disturb_text), () -> {
+                    val intent = new Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+                            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    activity.startActivity(intent);
+                });
 
-                } else {
-                    UserError.Log.d(TAG, "We have notification policy access");
-                }
-            } catch (Exception e) {
-                JoH.static_toast_long("Unable to open system settings");
-                UserError.Log.wtf(TAG, "Failed to start settings intent: " + e);
+            } else {
+                UserError.Log.d(TAG, "We have notification policy access");
             }
+        } catch (Exception e) {
+            JoH.static_toast_long("Unable to open system settings");
+            UserError.Log.wtf(TAG, "Failed to start settings intent: " + e);
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/AndroidBarcode.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/AndroidBarcode.java
@@ -88,19 +88,15 @@ public class AndroidBarcode extends AppCompatActivity
     }
 
     public void scan() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (ContextCompat.checkSelfPermission(activity.getApplicationContext(),
-                    Manifest.permission.CAMERA)
-                    != PackageManager.PERMISSION_GRANTED) {
-                try {
-                    // are we in an actual activity?
-                    requestPermission();
-                } catch (NullPointerException e) {
-                    returnTo = activity; // save return context
-                    JoH.startActivity(AndroidBarcode.class);
-                }
-            } else {
-                actuallyStartScan();
+        if (ContextCompat.checkSelfPermission(activity.getApplicationContext(),
+                Manifest.permission.CAMERA)
+                != PackageManager.PERMISSION_GRANTED) {
+            try {
+                // are we in an actual activity?
+                requestPermission();
+            } catch (NullPointerException e) {
+                returnTo = activity; // save return context
+                JoH.startActivity(AndroidBarcode.class);
             }
         } else {
             actuallyStartScan();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/LocationHelper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/LocationHelper.java
@@ -118,95 +118,89 @@ public class LocationHelper {
             return true;
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 
-            if (ContextCompat.checkSelfPermission(activity,
-                    Manifest.permission.ACCESS_FINE_LOCATION)
-                    != PackageManager.PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(activity,
+                Manifest.permission.ACCESS_FINE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED) {
 
-                JoH.show_ok_dialog(activity, activity.getString(R.string.please_allow_permission), activity.getString(R.string.without_location_scan_doesnt_work), new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            ActivityCompat.requestPermissions(activity,
-                                    new String[]{android.Manifest.permission.ACCESS_FINE_LOCATION},
-                                    0);
-                            // below is not ideal as we should really trap the activity result but it can come from different activities and there is no parent...
-                            Inevitable.task("location-perm-restart", 6000, CollectionServiceStarter::restartCollectionServiceBackground);
-                        } catch (Exception e) {
-                            JoH.static_toast_long("Got Exception with Location Permission: " + e);
-                        }
-                    }
-                });
-                return false;
-            } else {
-                // Android 10 check additional permissions
-                if (Build.VERSION.SDK_INT >= 29) {
-                    if (ContextCompat.checkSelfPermission(activity,
-                            ACCESS_BACKGROUND_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-
-                        JoH.show_ok_dialog(activity, activity.getString(R.string.please_allow_permission), activity.getString(R.string.android_10_need_background_location), new Runnable() {
-                            @Override
-                            public void run() {
-                                try {
-                                    ActivityCompat.requestPermissions(activity,
-                                            new String[]{ACCESS_BACKGROUND_LOCATION},
-                                            0);
-                                } catch (Exception e) {
-                                    JoH.static_toast_long("Got Exception with Android 10 Location Permission: " + e);
-                                }
-                            }
-                        });
-                        return false;
+            JoH.show_ok_dialog(activity, activity.getString(R.string.please_allow_permission), activity.getString(R.string.without_location_scan_doesnt_work), new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        ActivityCompat.requestPermissions(activity,
+                                new String[]{android.Manifest.permission.ACCESS_FINE_LOCATION},
+                                0);
+                        // below is not ideal as we should really trap the activity result but it can come from different activities and there is no parent...
+                        Inevitable.task("location-perm-restart", 6000, CollectionServiceStarter::restartCollectionServiceBackground);
+                    } catch (Exception e) {
+                        JoH.static_toast_long("Got Exception with Location Permission: " + e);
                     }
                 }
-            }
+            });
+            return false;
+        } else {
+            // Android 10 check additional permissions
+            if (Build.VERSION.SDK_INT >= 29) {
+                if (ContextCompat.checkSelfPermission(activity,
+                        ACCESS_BACKGROUND_LOCATION) != PackageManager.PERMISSION_GRANTED) {
 
-            LocationHelper.requestLocation(activity);
+                    JoH.show_ok_dialog(activity, activity.getString(R.string.please_allow_permission), activity.getString(R.string.android_10_need_background_location), new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                ActivityCompat.requestPermissions(activity,
+                                        new String[]{ACCESS_BACKGROUND_LOCATION},
+                                        0);
+                            } catch (Exception e) {
+                                JoH.static_toast_long("Got Exception with Android 10 Location Permission: " + e);
+                            }
+                        }
+                    });
+                    return false;
+                }
+            }
         }
+
+        LocationHelper.requestLocation(activity);
         return true;
     }
 
     public static void requestLocationForEmergencyMessage(final Activity activity) {
         // Location needs to be enabled for Bluetooth discovery on Marshmallow.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 
-            if (ContextCompat.checkSelfPermission(activity,
-                    android.Manifest.permission.ACCESS_FINE_LOCATION)
-                    != PackageManager.PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(activity,
+                android.Manifest.permission.ACCESS_FINE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED) {
 
-                JoH.show_ok_dialog(activity, activity.getString(R.string.please_allow_permission), activity.getString(R.string.without_location_permission_emergency_cannot_get_location), new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            ActivityCompat.requestPermissions(activity,
-                                    new String[]{android.Manifest.permission.ACCESS_FINE_LOCATION},
-                                    0);
-                        } catch (Exception e) {
-                            JoH.static_toast_long("Got Exception with Location Permission: " + e);
-                        }
+            JoH.show_ok_dialog(activity, activity.getString(R.string.please_allow_permission), activity.getString(R.string.without_location_permission_emergency_cannot_get_location), new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        ActivityCompat.requestPermissions(activity,
+                                new String[]{android.Manifest.permission.ACCESS_FINE_LOCATION},
+                                0);
+                    } catch (Exception e) {
+                        JoH.static_toast_long("Got Exception with Location Permission: " + e);
                     }
-                });
-            }
-
-            LocationHelper.requestLocation(activity);
+                }
+            });
         }
+
+        LocationHelper.requestLocation(activity);
     }
 
     // TODO probably can use application context here
     public static boolean isLocationPermissionOk(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (ContextCompat.checkSelfPermission(context,
+                android.Manifest.permission.ACCESS_FINE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED) {
+            return false;
+        }
+        if (Build.VERSION.SDK_INT >= 29) {
             if (ContextCompat.checkSelfPermission(context,
-                    android.Manifest.permission.ACCESS_FINE_LOCATION)
+                    ACCESS_BACKGROUND_LOCATION)
                     != PackageManager.PERMISSION_GRANTED) {
                 return false;
-            }
-            if (Build.VERSION.SDK_INT >= 29) {
-                if (ContextCompat.checkSelfPermission(context,
-                        ACCESS_BACKGROUND_LOCATION)
-                        != PackageManager.PERMISSION_GRANTED) {
-                    return false;
-                }
             }
         }
         return true;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -590,7 +590,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
     {
         super.onResume();
         PreferenceManager.getDefaultSharedPreferences(this).registerOnSharedPreferenceChangeListener(ActivityRecognizedService.prefListener);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && DexCollectionType.hasBluetooth() && !WholeHouse.isRpi()) {
+        if (DexCollectionType.hasBluetooth() && !WholeHouse.isRpi()) {
             LocationHelper.requestLocationForBluetooth(this); // double check!
         }
         PreferenceManager.getDefaultSharedPreferences(this).registerOnSharedPreferenceChangeListener(LeFunEntry.prefListener);
@@ -1239,7 +1239,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
                 findPreference(MiBandEntry.PREF_MIBAND_ENABLED).setOnPreferenceChangeListener((preference, newValue) -> {
                     if ((Boolean) newValue) {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && (boolean) newValue) {
+                        if ((boolean) newValue) {
                             LocationHelper.requestLocationForBluetooth((Activity) preference.getContext());
                         }
                         checkReadPermission(this.getActivity());
@@ -1544,7 +1544,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             final Preference inpen_enabled = findPreference("inpen_enabled");
             try {
                 inpen_enabled.setOnPreferenceChangeListener((preference, newValue) -> {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && (boolean) newValue) {
+                    if ( (boolean) newValue) {
                         LocationHelper.requestLocationForBluetooth((Activity) preference.getContext()); // double check!
                     }
                     InPenEntry.startWithRefresh();
@@ -2055,19 +2055,6 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                         // collectionCategory.removePreference(closeGatt);
                     } catch (NullPointerException e) {
                         Log.wtf(TAG, "Nullpointer removing txid ", e);
-                    }
-                }
-
-                if (Build.VERSION.SDK_INT < 21) {
-                    try {
-                        colorScreen.removePreference(flairCategory);
-                    } catch (Exception e) { //
-                    }
-                }
-                if (Build.VERSION.SDK_INT < 23) {
-                    try {
-                        ((PreferenceGroup)findPreference("xdrip_plus_display_category")).removePreference(findPreference("xdrip_plus_number_icon"));
-                    } catch (Exception e) { //
                     }
                 }
 
@@ -2670,17 +2657,15 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
 
        public static void checkReadPermission(final Activity activity) {
 
-            // TODO call log permission - especially for Android 9+
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                if (xdrip.getAppContext().checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE)
-                        != PackageManager.PERMISSION_GRANTED) {
+           // TODO call log permission - especially for Android 9+
+           if (xdrip.getAppContext().checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE)
+                   != PackageManager.PERMISSION_GRANTED) {
 
-                    ActivityCompat.requestPermissions(activity,
-                            new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
-                            Constants.GET_PHONE_READ_PERMISSION);
-                }
-            }
-        }
+               ActivityCompat.requestPermissions(activity,
+                       new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                       Constants.GET_PHONE_READ_PERMISSION);
+           }
+       }
 
         private void showSearchFragment() {
             // lazy instantiation

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/SdcardImportExport.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/SdcardImportExport.java
@@ -90,17 +90,15 @@ public class SdcardImportExport extends BaseAppCompatActivity {
 
     // TODO refactor to own class
     public static boolean checkPermissions(Activity context, boolean ask, int request_code) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (ContextCompat.checkSelfPermission(context,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    != PackageManager.PERMISSION_GRANTED) {
-                if (ask) {
-                    ActivityCompat.requestPermissions(context,
-                            new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                            request_code);
-                }
-                return false;
+        if (ContextCompat.checkSelfPermission(context,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            if (ask) {
+                ActivityCompat.requestPermissions(context,
+                        new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                        request_code);
             }
+            return false;
         }
         return true;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/IncomingCallsReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/IncomingCallsReceiver.java
@@ -43,18 +43,16 @@ public class IncomingCallsReceiver extends BroadcastReceiver {
     public static void checkPermission(final Activity activity) {
 
         // TODO call log permission - especially for Android 9+
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if ((xdrip.getAppContext().checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
-                    != PackageManager.PERMISSION_GRANTED)
-                    || xdrip.getAppContext().checkSelfPermission(Manifest.permission.READ_CONTACTS)
-                    != PackageManager.PERMISSION_GRANTED
-                    || ((Build.VERSION.SDK_INT > Build.VERSION_CODES.O && xdrip.getAppContext().checkSelfPermission(Manifest.permission.READ_CALL_LOG)
-                    != PackageManager.PERMISSION_GRANTED))) {
+        if ((xdrip.getAppContext().checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
+                != PackageManager.PERMISSION_GRANTED)
+                || xdrip.getAppContext().checkSelfPermission(Manifest.permission.READ_CONTACTS)
+                != PackageManager.PERMISSION_GRANTED
+                || ((Build.VERSION.SDK_INT > Build.VERSION_CODES.O && xdrip.getAppContext().checkSelfPermission(Manifest.permission.READ_CALL_LOG)
+                != PackageManager.PERMISSION_GRANTED))) {
 
-                ActivityCompat.requestPermissions(activity,
-                        new String[]{Manifest.permission.READ_PHONE_STATE, Manifest.permission.READ_CALL_LOG, Manifest.permission.READ_CONTACTS},
-                        Constants.GET_PHONE_READ_PERMISSION);
-            }
+            ActivityCompat.requestPermissions(activity,
+                    new String[]{Manifest.permission.READ_PHONE_STATE, Manifest.permission.READ_CALL_LOG, Manifest.permission.READ_CONTACTS},
+                    Constants.GET_PHONE_READ_PERMISSION);
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/usb/MtpTools.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/usb/MtpTools.java
@@ -163,10 +163,6 @@ public class MtpTools {
     }
 
     public static int createFile(final String fileName, final byte[] outputBytes, final MtpDevice mtpDevice, final int storage_id, final int parent_id) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            Log.e(TAG, "createFile cannot work below Android 7");
-            return -1;
-        }
 
         if (outputBytes != null) {
             ParcelFileDescriptor[] pipe = null;
@@ -223,10 +219,6 @@ public class MtpTools {
     }
 
     public static int createFolder(final String fileName, final MtpDevice mtpDevice, final int storage_id) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            Log.e(TAG, "createFolder cannot work below Android 7");
-            return -1;
-        }
 
         ParcelFileDescriptor[] pipe = null;
         try {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/Amazfitservice.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/Amazfitservice.java
@@ -263,9 +263,7 @@ public class Amazfitservice extends Service {
         String collection_method = prefs.getString("dex_collection_method", "BluetoothWixel");
         if (collection_method.compareTo("DexcomG5") == 0) {
             Transmitter defaultTransmitter = new Transmitter(prefs.getString("dex_txid", "ABCDEF"));
-            if (Build.VERSION.SDK_INT >= 18) {
-                mBluetoothAdapter = mBluetoothManager.getAdapter();
-            }
+            mBluetoothAdapter = mBluetoothManager.getAdapter();
             if (mBluetoothAdapter != null) {
                 Set<BluetoothDevice> pairedDevices = mBluetoothAdapter.getBondedDevices();
                 if ((pairedDevices != null) && (pairedDevices.size() > 0)) {

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -383,40 +383,38 @@ public class Home extends BaseWatchFace {
     }
 
     private void checkBatteryOptimization() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            final String packageName = getPackageName();
-            //Log.d(TAG, "Maybe ignoring battery optimization");
-            final PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
-            if (!pm.isIgnoringBatteryOptimizations(packageName)) {
-                // &&
-                //            !prefs.getBoolean("requested_ignore_battery_optimizations_new", false)) {
-                Log.d(TAG, "Requesting ignore battery optimization");
+        final String packageName = getPackageName();
+        //Log.d(TAG, "Maybe ignoring battery optimization");
+        final PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        if (!pm.isIgnoringBatteryOptimizations(packageName)) {
+            // &&
+            //            !prefs.getBoolean("requested_ignore_battery_optimizations_new", false)) {
+            Log.d(TAG, "Requesting ignore battery optimization");
 
-                // if (PersistentStore.incrementLong("asked_battery_optimization") < 40) {
-                // JoH.show_ok_dialog(this, gs(R.string.please_allow_permission), gs(R.string.xdrip_needs_whitelisting_for_proper_performance), new Runnable() {
+            // if (PersistentStore.incrementLong("asked_battery_optimization") < 40) {
+            // JoH.show_ok_dialog(this, gs(R.string.please_allow_permission), gs(R.string.xdrip_needs_whitelisting_for_proper_performance), new Runnable() {
 
-                //     @Override
-                //    public void run() {
-                try {
-                    final Intent intent = new Intent();
+            //     @Override
+            //    public void run() {
+            try {
+                final Intent intent = new Intent();
 
-                    // ignoring battery optimizations required for constant connection
-                    // to peripheral device - eg CGM transmitter.
-                    intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
-                    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    intent.setData(Uri.parse("package:" + packageName));
-                    startActivity(intent);
+                // ignoring battery optimizations required for constant connection
+                // to peripheral device - eg CGM transmitter.
+                intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                intent.setData(Uri.parse("package:" + packageName));
+                startActivity(intent);
 
-                } catch (ActivityNotFoundException e) {
-                    final String msg = "Device does not appear to support battery optimization whitelisting!";
-                    JoH.static_toast_short(msg);
-                    UserError.Log.wtf(TAG, msg);
-                }
-                //      }
-                //     });
-            } else {
-                JoH.static_toast_long("This app needs battery optimization whitelisting or it will not work well. Please reset app preferences");
+            } catch (ActivityNotFoundException e) {
+                final String msg = "Device does not appear to support battery optimization whitelisting!";
+                JoH.static_toast_short(msg);
+                UserError.Log.wtf(TAG, msg);
             }
+            //      }
+            //     });
+        } else {
+            JoH.static_toast_long("This app needs battery optimization whitelisting or it will not work well. Please reset app preferences");
         }
     }
     // just for code compatibility

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
@@ -441,13 +441,8 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                 }
                 //mAsyncBenchmarkTester = null;
             } else {
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                    Log.d(TAG, "Benchmark: runAsyncBenchmarkTester SDK < M call execute lastRequest:" + JoH.dateTimeText(lastRequest));
-                    mAsyncBenchmarkTester = (AsyncBenchmarkTester) new AsyncBenchmarkTester(Home.getAppContext(), node, pathdesc, path, payload, bDuplicateTest).execute();
-                } else {
-                    Log.d(TAG, "Benchmark: runAsyncBenchmarkTester SDK >= M call executeOnExecutor lastRequest:" + JoH.dateTimeText(lastRequest));
-                    mAsyncBenchmarkTester = (AsyncBenchmarkTester) new AsyncBenchmarkTester(Home.getAppContext(), node, pathdesc, path, payload, bDuplicateTest).executeOnExecutor(xdrip.executor);
-                }
+                Log.d(TAG, "Benchmark: runAsyncBenchmarkTester SDK >= M call executeOnExecutor lastRequest:" + JoH.dateTimeText(lastRequest));
+                mAsyncBenchmarkTester = (AsyncBenchmarkTester) new AsyncBenchmarkTester(Home.getAppContext(), node, pathdesc, path, payload, bDuplicateTest).executeOnExecutor(xdrip.executor);
             }
             return false;
         }
@@ -885,14 +880,9 @@ public class ListenerService extends WearableListenerService implements GoogleAp
             }
             //mDataRequester = null;
         }
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            Log.d(TAG, "sendData SDK < M call execute lastRequest:" + JoH.dateTimeText(lastRequest));
-            mDataRequester = (DataRequester) new DataRequester(this, path, payload).execute();
-        } else {
-            Log.d(TAG, "sendData SDK >= M call executeOnExecutor lastRequest:" + JoH.dateTimeText(lastRequest));
-            // TODO xdrip executor
-            mDataRequester = (DataRequester) new DataRequester(this, path, payload).executeOnExecutor(xdrip.executor);
-        }
+        Log.d(TAG, "sendData SDK >= M call executeOnExecutor lastRequest:" + JoH.dateTimeText(lastRequest));
+        // TODO xdrip executor
+        mDataRequester = (DataRequester) new DataRequester(this, path, payload).executeOnExecutor(xdrip.executor);
     }
 
     private void googleApiConnect() {
@@ -2491,7 +2481,6 @@ public class ListenerService extends WearableListenerService implements GoogleAp
     }
 
     private boolean checkLocationPermissions() {//KS
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true;
         Context myContext = getApplicationContext();
         mLocationPermissionApproved =
                 ActivityCompat.checkSelfPermission(

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/NFCReaderX.java
@@ -131,7 +131,7 @@ public class NFCReaderX {
     public static void disableNFC(final Activity context) {
         if (nfc_enabled) {
             try {
-                if ((Build.VERSION.SDK_INT >= 19) && (useReaderMode)) {
+                if (useReaderMode) {
                     Log.d(TAG, "Shutting down NFC reader mode");
                     mNfcAdapter.disableReaderMode(context);
                     nfc_enabled = false;
@@ -187,7 +187,7 @@ public class NFCReaderX {
             }
 
 
-            if ((Build.VERSION.SDK_INT >= 19) && (useReaderMode)) {
+            if (useReaderMode) {
                 try {
                     mNfcAdapter.disableReaderMode(context);
                     final Bundle options = new Bundle();
@@ -1001,22 +1001,13 @@ if (Pref.getBooleanDefaultFalse("external_blukon_algorithm")) {
 
     public static void windowFocusChange(final Activity context, boolean hasFocus, View decorView) {
         if (hasFocus) {
-            if (Build.VERSION.SDK_INT >= 19) {
-                decorView.setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                                | View.SYSTEM_UI_FLAG_FULLSCREEN
-                                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-            } else {
-                decorView.setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                                | View.SYSTEM_UI_FLAG_FULLSCREEN);
-            }
+            decorView.setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                            | View.SYSTEM_UI_FLAG_FULLSCREEN
+                            | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
         } else {
             final Handler handler = new Handler();
             handler.postDelayed(new Runnable() {


### PR DESCRIPTION
I wanted to see how many conditionals exit based on the build release that is unconditionally true or false.
I was surprised to find so many.
I have removed such conditionals.  Set the statements conditioned on true values to always run.  Deleted the statements conditioned on false values.

How could a change this extensive ever be adequately tested?