### PR TITLE
Y axis range menu orientation fix

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -501,30 +501,30 @@
     </string-array>
 
     <string-array name="ymin_entries">
-        <item>40 mg/dl (2.2 mmol/l) ></item>
-        <item>50 mg/dl (2.8 mmol/l)</item>
-        <item>60 mg/dl (3.3 mmol/l)</item>
         <item>70 mg/dl (3.9 mmol/l)</item>
+        <item>60 mg/dl (3.3 mmol/l)</item>
+        <item>50 mg/dl (2.8 mmol/l)</item>
+        <item>40 mg/dl (2.2 mmol/l) ></item>
     </string-array>
     <string-array name="ymin_values">
-        <item>40</item>
-        <item>50</item>
-        <item>60</item>
         <item>70</item>
+        <item>60</item>
+        <item>50</item>
+        <item>40</item>
     </string-array>
     <string-array name="ymax_entries">
-        <item>210 mg/dl (11.7 mmol/l)</item>
-        <item>230 mg/dl (12.8 mmol/l)</item>
-        <item>250 mg/dl (13.9 mmol/l) ></item>
-        <item>300 mg/dl (16.7 mmol/l)</item>
         <item>400 mg/dl (22.2 mmol/l)</item>
+        <item>300 mg/dl (16.7 mmol/l)</item>
+        <item>250 mg/dl (13.9 mmol/l) ></item>
+        <item>230 mg/dl (12.8 mmol/l)</item>
+        <item>210 mg/dl (11.7 mmol/l)</item>
     </string-array>
     <string-array name="ymax_values">
-        <item>210</item>
-        <item>230</item>
-        <item>250</item>
-        <item>300</item>
         <item>400</item>
+        <item>300</item>
+        <item>250</item>
+        <item>230</item>
+        <item>210</item>
     </string-array>
 
     <!--    Nightscout follow wake delay, with respect to the source timestamp


### PR DESCRIPTION
This is not anything that is broken.  But, I think it looks better if the ranges are shown with the maxes at the top.  
This is actually something I added a few years ago.  I'm not sure why it didn't look wrong then.  It sure looks wrong now.  

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20250531-154811](https://github.com/user-attachments/assets/d8b172ba-019c-4444-8edc-415438958a78) | ![Screenshot_20250531-155111](https://github.com/user-attachments/assets/85ec8c3a-bcf1-4a97-813a-dd64039fdd15) |  
![Screenshot_20250531-154835](https://github.com/user-attachments/assets/0a6deacb-57ec-4fa0-bb60-dbb38e5cc5b6) | ![Screenshot_20250531-155130](https://github.com/user-attachments/assets/cf86f47e-de14-4f21-93ce-4edfd5e65bf4) |  



