### PR TITLE
Notification records (Logs)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
@@ -392,7 +392,7 @@ public class GcmListenerSvc extends JamListenerSvc {
                             final String body = payloadA[1];
                             final PendingIntent pendingIntent = android.app.PendingIntent.getActivity(xdrip.getAppContext(), 0, new Intent(xdrip.getAppContext(), Home.class), android.app.PendingIntent.FLAG_UPDATE_CURRENT);
                             showNotification(title, body, pendingIntent, GCM_NOTIFICATION_ITEM, true, true, false);
-                            UserError.Log.e(TAG, "Follower Notification with payload");
+                            UserError.Log.uel(TAG, "Follower Notification with payload");
                         } catch (Exception e) {
                             UserError.Log.e(TAG, "Error showing follower notification with payload: " + payload);
                         }
@@ -467,7 +467,7 @@ public class GcmListenerSvc extends JamListenerSvc {
                         }
                         if (Pref.getBooleanDefaultFalse("follower_chime") && JoH.pratelimit("bgs-notify", 1200)) {
                             JoH.showNotification("New glucose data @" + JoH.hourMinuteString(), "Follower Chime: will alert whenever it has been more than 20 minutes since last", null, 60311, true, true, true);
-                            UserError.Log.e(TAG, "Follower Chime");
+                            UserError.Log.uel(TAG, "Follower Chime");
                         }
                     } else {
                         Log.e(TAG, "Received remote BG packet but we are not set as a follower");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1007,7 +1007,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                 }
                 final PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
                 JoH.showNotification(bundle.getString(SHOW_NOTIFICATION), bundle.getString("notification_body"), pendingIntent, notification_id, true, true, true);
-                UserError.Log.e(TAG, bundle.getString("notification_body"));
+                UserError.Log.uel(TAG, bundle.getString("notification_body"));
             } else if (bundle.getString(Home.BLUETOOTH_METER_CALIBRATION) != null) {
                 try {
                     processFingerStickCalibration(JoH.tolerantParseDouble(bundle.getString(Home.BLUETOOTH_METER_CALIBRATION), 0d),

--- a/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
@@ -50,7 +50,7 @@ public class SensorExpiry extends BaseAlert {
         val expireMsg = xdrip.gs(R.string.sensor_will_expire_in, expiry);
         showNotification(xdrip.gs(R.string.sensor_expiring), expireMsg, null, notificationId, null, true, true, null, null, null, true);
         Treatments.create_note("Warning: " + expireMsg, tsl()); // TODO i18n but note classifier also needs updating for that
-        UserError.Log.e(TAG, "Sensor will expire soon");
+        UserError.Log.uel(TAG, "Sensor will expire soon");
         return true;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/alert/UpdateAvailable.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/alert/UpdateAvailable.java
@@ -47,7 +47,7 @@ public class UpdateAvailable extends BaseAlert {
 
         val channel = Pref.getString("update_channel", "beta"); // get the current update channel
         showNotification(xdrip.gs(R.string.xdrip_update), xdrip.gs(R.string.a_new_version_on_channel_1_s_is_available, channel), pendingIntent, notificationId, null, true, true, null, null, null, false);
-        UserError.Log.e(TAG, "A new version is available");
+        UserError.Log.uel(TAG, "A new version is available");
         return true;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cloud/backup/BackupActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cloud/backup/BackupActivity.java
@@ -321,7 +321,7 @@ public class BackupActivity extends BackupBaseActivity implements BackupStatus {
     static void notifySecurityError() {
         if (JoH.pratelimit("backup-security-notification-n", 60 * 60 * 12)) {
             showNotification(xdrip.gs(R.string.please_reselect_backup_file), xdrip.gs(R.string.backup_file_security_error_advice), getStartIntent(), BACKUP_ACTIVITY_ID, true, true, true);
-            UserError.Log.e(TAG, "Backup file is reporting security error. Re-select it to continue to allow xDrip access.");
+            UserError.Log.uel(TAG, "Backup file is reporting security error. Re-select it to continue to allow xDrip access.");
         }
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/Ob1G5StateMachine.java
@@ -1623,7 +1623,7 @@ public class Ob1G5StateMachine {
             if (glucose.calibrationState().sensorFailed() && Sensor.isActive()) {
                 if (JoH.pratelimit("G5 Sensor Failed", 3600 * 3)) {
                     JoH.showNotification(devName() + " SENSOR FAILED", "Sensor reporting failed", null, Constants.G5_SENSOR_ERROR, true, true, false);
-                    UserError.Log.e(TAG, "Sensor reporting failed");
+                    UserError.Log.uel(TAG, "Sensor reporting failed");
                 }
             }
         }
@@ -1727,7 +1727,7 @@ public class Ob1G5StateMachine {
                 if (!usingG6()) {
                     setG6Defaults();
                     JoH.showNotification("Enabled defaults", "Default settings automatically enabled", null, Constants.G6_DEFAULTS_MESSAGE, false, true, false);
-                    UserError.Log.e(TAG, "Default Dex settings automatically enabled");
+                    UserError.Log.uel(TAG, "Default Dex settings automatically enabled");
                 } else if (!onlyUsingNativeMode() && !Home.get_engineering_mode()) {
                     // TODO revisit this now that there is scaling
                     setG6Defaults();
@@ -1826,7 +1826,7 @@ public class Ob1G5StateMachine {
                     final boolean loud = !PowerStateReceiver.is_power_connected();
                     JoH.showNotification("Battery Low", "Transmitter battery has dropped to: " + batteryInfoRxMessage.voltagea + " it may fail soon",
                             null, 770, NotificationChannels.LOW_TRANSMITTER_BATTERY_CHANNEL, loud, loud, null, null, null);
-                    UserError.Log.e(TAG, "Dex battery has dropped to: " + batteryInfoRxMessage.voltagea);
+                    UserError.Log.uel(TAG, "Dex battery has dropped to: " + batteryInfoRxMessage.voltagea);
                 }
             }
             PersistentStore.cleanupOld(G5_BATTERY_LEVEL_MARKER);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/G5CollectionService.java
@@ -356,7 +356,7 @@ public class G5CollectionService extends G5BaseService {
                 if (!usingG6()) {
                     setG6bareBones();
                     JoH.showNotification("Enabled G6", "G6 Features for old collector automatically enabled", null, Constants.G6_DEFAULTS_MESSAGE, false, true, false);
-                    UserError.Log.e(TAG, "G6 Features for old collector automatically enabled");
+                    UserError.Log.uel(TAG, "G6 Features for old collector automatically enabled");
                 }
             }
         }
@@ -1640,7 +1640,7 @@ public class G5CollectionService extends G5BaseService {
                     final boolean loud = !PowerStateReceiver.is_power_connected();
                     JoH.showNotification("G5 Battery Low", "G5 Transmitter battery has dropped to: " + batteryInfoRxMessage.voltagea + " it may fail soon",
                             null, 770, NotificationChannels.LOW_TRANSMITTER_BATTERY_CHANNEL, loud, loud, null, null, null);
-                    UserError.Log.e(TAG, "G5 Transmitter battery has dropped to: " + batteryInfoRxMessage.voltagea);
+                    UserError.Log.uel(TAG, "G5 Transmitter battery has dropped to: " + batteryInfoRxMessage.voltagea);
                 }
             }
             PersistentStore.setLong(G5_BATTERY_LEVEL_MARKER + transmitterId, batteryInfoRxMessage.voltagea);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -1898,7 +1898,7 @@ public class Ob1G5CollectionService extends G5BaseService {
                 final PendingIntent pi = PendingIntent.getActivity(xdrip.getAppContext(), G5_CALIBRATION_REQUEST, JoH.getStartActivityIntent(c), PendingIntent.FLAG_UPDATE_CURRENT);
                 // pending intent not used on wear
                 JoH.showNotification(state.getText(), "Calibration Required", android_wear ? null : pi, G5_CALIBRATION_REQUEST, state == CalibrationState.NeedsFirstCalibration, true, false);
-                UserError.Log.e(TAG, "Calibration Required");
+                UserError.Log.uel(TAG, "Calibration Required");
 
             });
         } else if (!needs_calibration && was_needing_calibration) {
@@ -1918,7 +1918,7 @@ public class Ob1G5CollectionService extends G5BaseService {
                     }
                     final PendingIntent pi = PendingIntent.getActivity(xdrip.getAppContext(), G5_SENSOR_RESTARTED, JoH.getStartActivityIntent(Home.class), PendingIntent.FLAG_UPDATE_CURRENT);
                     JoH.showNotification("Auto Start", "Sensor Requesting Restart", pi, G5_SENSOR_RESTARTED, true, true, false);
-                    UserError.Log.e(TAG, "Sensor Requesting Restart");
+                    UserError.Log.uel(TAG, "Sensor Requesting Restart");
                 } else {
                     UserError.Log.uel(TAG, "Marking sensor session as stopped");
                     Sensor.stopSensor();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/CompatibleApps.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/CompatibleApps.java
@@ -52,7 +52,7 @@ public class CompatibleApps extends BroadcastReceiver {
             if (!Pref.getBooleanDefaultFalse("xdrip_webservice")) {
                 if (JoH.pratelimit(package_name + NOTIFY_MARKER, RENOTIFY_TIME)) {
                     id = notify(gs(R.string.garmin), gs(R.string.enable_local_web_server_feature), id, Feature.ENABLE_GARMIN_FEATURES);
-                    UserError.Log.e(TAG, "Enable local web server feature for Garmin watchface?");
+                    UserError.Log.uel(TAG, "Enable local web server feature for Garmin watchface?");
                 }
             }
         } else {
@@ -61,7 +61,7 @@ public class CompatibleApps extends BroadcastReceiver {
                 if (!Pref.getBooleanDefaultFalse("xdrip_webservice")) {
                     if (JoH.pratelimit(package_name + NOTIFY_MARKER, RENOTIFY_TIME)) {
                         id = notify(gs(R.string.fitbit), gs(R.string.enable_local_web_server_feature_fitbit), id, Feature.ENABLE_FITBIT_FEATURES);
-                        UserError.Log.e(TAG, "Enable local web server feature for Fitbit watchface?");
+                        UserError.Log.uel(TAG, "Enable local web server feature for Fitbit watchface?");
                     }
                 }
             }
@@ -72,7 +72,7 @@ public class CompatibleApps extends BroadcastReceiver {
             if (!Pref.getBooleanDefaultFalse("wear_sync")) {
                 if (JoH.pratelimit(package_name + NOTIFY_MARKER, RENOTIFY_TIME)) {
                     id = notify(gs(R.string.androidwear), gs(R.string.enable_wear_os_sync), id, Feature.ENABLE_WEAR_OS_SYNC);
-                    UserError.Log.e(TAG, "Enable Sync to Android Wear OS?");
+                    UserError.Log.uel(TAG, "Enable Sync to Android Wear OS?");
                 }
             }
         }
@@ -82,7 +82,7 @@ public class CompatibleApps extends BroadcastReceiver {
             if (!Pref.getBooleanDefaultFalse("broadcast_data_through_intents")) {
                 if (JoH.pratelimit(package_name + NOTIFY_MARKER, RENOTIFY_TIME)) {
                     id = notify(gs(R.string.androidaps), gs(R.string.enable_local_broadcast), id, Feature.ENABLE_ANDROIDAPS_FEATURE1);
-                    UserError.Log.e(TAG, "Enable local broadcast?");
+                    UserError.Log.uel(TAG, "Enable local broadcast?");
                 }
             }
 
@@ -90,7 +90,7 @@ public class CompatibleApps extends BroadcastReceiver {
                 if (!Pref.getString("local_broadcast_specific_package_destination", "").contains(package_name)) {
                     if (JoH.pratelimit(package_name + NOTIFY_MARKER + "2", RENOTIFY_TIME)) {
                         id = notify(gs(R.string.androidaps), gs(R.string.broadcast_only_to), id, Feature.ENABLE_ANDROIDAPS_FEATURE2);
-                        UserError.Log.e(TAG, "Broadcast only to AAPS?");
+                        UserError.Log.uel(TAG, "Broadcast only to AAPS?");
                     }
                 }
             }
@@ -101,7 +101,7 @@ public class CompatibleApps extends BroadcastReceiver {
             if (!Pref.getString("local_broadcast_specific_package_destination", "").contains(package_name)) {
                 if (JoH.pratelimit(package_name + NOTIFY_MARKER, RENOTIFY_TIME)) {
                     id = notify("Tasker", gs(R.string.enable_local_broadcast), id, Feature.ENABLE_TASKER);
-                    UserError.Log.e(TAG, "Enable local broadcast?");
+                    UserError.Log.uel(TAG, "Enable local broadcast?");
                 }
             }
         }
@@ -111,7 +111,7 @@ public class CompatibleApps extends BroadcastReceiver {
             if (DexCollectionType.getDexCollectionType() != DexCollectionType.LibreAlarm) {
                 if (JoH.pratelimit(package_name + NOTIFY_MARKER, RENOTIFY_TIME)) {
                     id = notify(gs(R.string.librealarm), gs(R.string.use_librealarm), id, Feature.ENABLE_LIBRE_ALARM);
-                    UserError.Log.e(TAG, "Use LibreAlarm app as data source?");
+                    UserError.Log.uel(TAG, "Use LibreAlarm app as data source?");
                 }
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IncompatibleApps.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IncompatibleApps.java
@@ -72,13 +72,13 @@ public class IncompatibleApps {
 
     private static int notify(String short_name, String package_string, String msg, int id) {
         JoH.showNotification("Incompatible App " + short_name, "Please uninstall or disable " + package_string, null, id, true, true, null, null, ((msg.length() > 0) ? msg + "\n\n" : "") + "Another installed app may be incompatible with xDrip. The other app should be uninstalled or disabled to prevent conflicts with shared resources.\nThe package identifier is: " + package_string);
-        UserError.Log.e(TAG, "Please uninstall or disable package");
+        UserError.Log.uel(TAG, "Please uninstall or disable package");
         return id + 1;
     }
 
     private static int notify2(String short_name, String package_string, String msg, int id) {
         JoH.showNotification(short_name, msg, null, id, true, true, null, null, ((msg.length() > 0) ? msg + "\n\n" : "") + "The Package identifier is: " + package_string);
-        UserError.Log.e(TAG, "Remove xDrip from duraspeed");
+        UserError.Log.uel(TAG, "Remove xDrip from duraspeed");
         return id + 1;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
@@ -628,7 +628,7 @@ public class NightscoutUploader {
                                         + " times. With message: " + last_exception + " " + ((last_success_time > 0) ? "Last succeeded: " + JoH.dateTimeText(last_success_time) : ""),
 
                                 MegaStatus.getStatusPendingIntent("Uploaders"), Constants.NIGHTSCOUT_ERROR_NOTIFICATION_ID, NotificationChannels.NIGHTSCOUT_UPLOADER_CHANNEL, false, false, null, null, msg);
-                        UserError.Log.e(TAG, "REST-API upload to Nightscout has failed");
+                        UserError.Log.uel(TAG, "REST-API upload to Nightscout has failed");
                     } else {
                         Log.e(TAG, "Cannot alert for nightscout failures as preference setting is disabled");
                     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SettingsValidation.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SettingsValidation.java
@@ -22,7 +22,7 @@ public class SettingsValidation {
         if (Pref.getBooleanDefaultFalse("engineering_mode")) {
             if (JoH.pratelimit(setting_name + NOTIFY_MARKER, RENOTIFY_TIME)) {
                 id = notifyDis("Engineering Mode", setting_name, "" + xdrip.getAppContext().getString(R.string.eng_mode_is_on), id);
-                UserError.Log.e(TAG, "Disable Engineering mode");
+                UserError.Log.uel(TAG, "Disable Engineering mode");
             }
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBattery.java
@@ -69,7 +69,7 @@ public class CheckBridgeBattery {
                     final PendingIntent pendingIntent = android.app.PendingIntent.getActivity(xdrip.getAppContext(), 0, new Intent(xdrip.getAppContext(), Home.class), android.app.PendingIntent.FLAG_UPDATE_CURRENT);
                     showNotification("Low bridge battery", "Bridge battery dropped to: " + this_level + "%",
                             pendingIntent, NOTIFICATION_ITEM, NotificationChannels.LOW_BRIDGE_BATTERY_CHANNEL, sound, vibrate, null, null, null);
-                    UserError.Log.e(TAG, "Bridge battery dropped to: " + this_level + "%");
+                    UserError.Log.uel(TAG, "Bridge battery dropped to: " + this_level + "%");
                 }
             } else {
                 if (notification_showing) {
@@ -127,7 +127,7 @@ public class CheckBridgeBattery {
                     cancelNotification(PARAKEET_NOTIFICATION_ITEM);
                     showNotification(xdrip.getAppContext().getString(R.string.low_parakeet_battery), "Parakeet battery dropped to: " + this_level + "%",
                             pendingIntent, PARAKEET_NOTIFICATION_ITEM, NotificationChannels.LOW_BRIDGE_BATTERY_CHANNEL, true, true, null, null, null);
-                    UserError.Log.e(TAG, "Parakeet battery dropped to: " + this_level + "%");
+                    UserError.Log.uel(TAG, "Parakeet battery dropped to: " + this_level + "%");
                     last_parakeet_notification = JoH.tsl();
                     if (d) UserError.Log.e(TAG, "checkParakeetBattery RAISED ALERT threshold:" + threshold + " this_level:" + this_level + " last:" + last_parakeet_level);
                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/WatchUpdaterService.java
@@ -298,7 +298,7 @@ public class WatchUpdaterService extends WearableListenerService implements
             if (force_wearG5) {
                 final PendingIntent pendingIntent = android.app.PendingIntent.getActivity(xdrip.getAppContext(), 0, new Intent(xdrip.getAppContext(), Home.class), android.app.PendingIntent.FLAG_UPDATE_CURRENT);
                 showNotification("Force Wear Enabled", node_wearG5 + " Watch has enabled Force Wear Collection Service", pendingIntent, 771, true, true, true);
-                UserError.Log.e(TAG, node_wearG5 + " Watch has enabled Force Wear Collection Service");
+                UserError.Log.uel(TAG, node_wearG5 + " Watch has enabled Force Wear Collection Service");
             }
         }
 


### PR DESCRIPTION
There are many notifications that create a corresponding log.  
However, we also have notifications that do not.
The ones that are part of an interactive sequence, do not need a log.  As an example, if you are going through hard resetting a device and get a notification, it is unlikely that you would later need to see it again.  Even so, you can see it again by going through the same process again.

There are notifications that are not part of an interactive sequence and do not create a corresponding log.
After a user swipes away such a notification, they will have no way of accessing any information about it.  
It happens when a user swipes away an incorrect notification by mistake.
There are also times a user swipes away a notification after seeing what it is.  But, later needs info about it.   For example, they may need that in order to show it to us in a forum.

This PR adds corresponding logs to notifications that are not part of an interactive sequence and do not create a corresponding log already. 

I believe it is a very good practice to have a log for every notification as notifications are swiped away; but, logs remain for a few days.  