### PR TITLE
Session start time update for alt (corrects Nightscout SAGE) 

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
@@ -18,6 +18,7 @@ import com.activeandroid.query.Select;
 import com.activeandroid.util.SQLiteUtils;
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
+import com.eveningoutpost.dexdrip.g5model.DexSessionKeeper;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.services.SyncService;
@@ -58,7 +59,6 @@ import lombok.val;
 import static com.eveningoutpost.dexdrip.models.JoH.msSince;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.HOUR_IN_MS;
 import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
-import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import static java.lang.StrictMath.abs;
 import static com.eveningoutpost.dexdrip.models.JoH.emptyString;
 
@@ -446,6 +446,14 @@ public class Treatments extends Model {
             Treatments.sensorStart(null, "Started by transmitter");
         } else {
             UserError.Log.i(TAG, "Not creating treatment for Sensor Start because one was created too recently: " + JoH.msSince(lastSensorStart.timestamp) + "ms ago");
+        }
+    }
+
+    public static void sensorUpdateStartTimeIfNeeded() {
+        val lastSensorStart = Treatments.lastEventTypeFromXdrip(Treatments.SENSOR_START_EVENT_TYPE);
+        long onTransmitterSessionStartTimestamp = DexSessionKeeper.getStart();
+        if (!(onTransmitterSessionStartTimestamp - lastSensorStart.timestamp < MINUTE_IN_MS * 5)) { // If the start time of the local session is older than the one on the transmitter
+            Treatments.sensorStart(onTransmitterSessionStartTimestamp, "Start time updated");
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
@@ -451,9 +451,10 @@ public class Treatments extends Model {
 
     public static void sensorUpdateStartTimeIfNeeded() {
         val lastSensorStart = Treatments.lastEventTypeFromXdrip(Treatments.SENSOR_START_EVENT_TYPE);
-        long onTransmitterSessionStartTimestamp = DexSessionKeeper.getStart();
-        if (!(onTransmitterSessionStartTimestamp - lastSensorStart.timestamp < MINUTE_IN_MS * 5)) { // If the start time of the local session is older than the one on the transmitter
-            Treatments.sensorStart(onTransmitterSessionStartTimestamp, "Start time updated");
+        long localStartedAt = lastSensorStart.timestamp; // When the xDrip local session started
+        long dexStartedAt = DexSessionKeeper.getStart(); // When the current session on the transmitter started
+        if (dexStartedAt > 0 && !(dexStartedAt - localStartedAt < MINUTE_IN_MS * 5)) { // If the start time of the local session is more than 5 minutes older than the one on the transmitter
+            Treatments.sensorStart(dexStartedAt, "Start time updated");
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -1943,6 +1943,10 @@ public class Ob1G5CollectionService extends G5BaseService {
         updateG5State(needs_calibration, was_needing_calibration, NEEDING_CALIBRATION);
         updateG5State(is_started, was_started, IS_STARTED);
         updateG5State(is_failed, was_failed, IS_FAILED);
+
+        if (is_started && shortTxId() && JoH.pratelimit("update_alternate_dex_session_start_time", 60 * 60)) { // Once an hour if there is a local session
+            Treatments.sensorUpdateStartTimeIfNeeded();
+        }
     }
 
 


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/4044

If you don't wait for your current sensor to expire before switching the transmitter ID to the new one, your local session will never end and new one will never start.
The result is that xDrip will continue to upload the previous start time to Nightscout.
Nightscout uses that start time to calculate the age of the sensor:
![Screenshot 2025-06-11 183503](https://github.com/user-attachments/assets/96882e7d-5d7e-48a5-a3dd-d22599df0ca7)
  
In the above screenshot, you can see the sensor age reported by Nightscout (SAGE) to be close to 11 days.  But, that's really the age of my previous sensor that I peeled off yesterday before its expiry because I wanted to recreate the problem reported on facebook.  

I have also reported this in the following issue after getting the report on facebook:
https://github.com/NightscoutFoundation/xDrip/issues/4044

After this PR, the following is what Nightscout shows:
![Screenshot 2025-06-11 184439](https://github.com/user-attachments/assets/424e3f70-168e-466e-84ea-8c7d6a242e6e)
It now shows 1 day and 11 hours, which is the correct age of my current sensor.  

And the following shows the added treatment when the session really started (yesterday morning): 
![share_5177174540425584126](https://github.com/user-attachments/assets/7bd41577-4409-49f4-9925-734d0ca15084)
