### PR TITLE
Dex Collector Status Page Heading update

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
@@ -169,11 +169,7 @@ public class MegaStatus extends FloatingLocaleActivityWithScreenshot {
                 addAsection(G4_STATUS, "Bluetooth Collector Status");
             }
             if (dexCollectionType.equals(DexcomG5)) {
-                if (Pref.getBooleanDefaultFalse(Ob1G5CollectionService.OB1G5_PREFS)) {
-                    addAsection(G5_STATUS, "G6/Dex1/G7/1+ Collector/Transmitter Status");
-                } else {
-                    addAsection(G5_STATUS, "G5 Collector and Transmitter Status");
-                }
+                addAsection(G5_STATUS, "Dex Collector/Transmitter Status");
             } else if (dexCollectionType.equals(Medtrum)) {
                 addAsection(MEDTRUM_STATUS, "Medtrum A6 Status");
             }


### PR DESCRIPTION
This PR updates the sub-heading for the Dex status page.  I overlooked this when we retired G5.  

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20250618-201845](https://github.com/user-attachments/assets/59ee611e-55b2-4e6e-88be-786bae30b15e) | ![Screenshot_20250618-202346](https://github.com/user-attachments/assets/9b1678ef-e229-411f-8dda-c7abae2a7e69) |  
