### PR TITLE
Dex share 24-hour backfill

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareConstants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/sharefollow/ShareConstants.java
@@ -9,5 +9,5 @@ public class ShareConstants {
 
     static final String APPLICATION_ID = "d89443d2-327c-4a6f-89e5-496bbb0317db";
     static final long SESSION_ID_VALIDITY_TIME = 60 * 60 * 8 * 1000;
-    static final int MAX_RECORDS_TO_ASK_FOR = 36;
+    static final int MAX_RECORDS_TO_ASK_FOR = 288;
 }


### PR DESCRIPTION
A user has reported that the official Dex follow app backfills 24 hours while xDrip Dex share follower only backfills 3 hours.

![508605952_10231926262673881_7930662044093778139_n](https://github.com/user-attachments/assets/8f14cda8-812b-4519-9b09-b352053da424)  ![509359824_10231926194672181_790295824783738106_n](https://github.com/user-attachments/assets/3cdf2c73-d3d0-4a47-852f-834c8e953f23)

This PR changes the Dex share follow backfill limit from 3 hours to 24 hours.