### PR TITLE
Retire Parakeet Alerts

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -160,7 +160,11 @@ public class IdempotentMigrations {
         Pref.setBoolean("store_sensor_location", false);
         Pref.setBoolean("using_g6", true);
         Pref.setBoolean("tidepool_new_auth", true);
-        // TODO Simplify the code everywhere resolving conditionals based on "using_g6" now that it is always true.
+        Pref.setBoolean("bridge_battery_alerts", false); // Disable Parakeet
+        Pref.setInt("bridge_battery_alert_level", 30);
+        Pref.setBoolean("parakeet_status_alerts", false);
+        Pref.setBoolean("parakeet_charge_silent", false);
+
     }
     private static void legacySettingsMoveLanguageFromNoToNb() {
         // Check if the user's language preference is set to "no"

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -404,35 +404,6 @@
                     android:key="@string/other_xdrip_plus_alerts"
                     android:title="@string/other_xdrip_plus_alerts">
                     <SwitchPreference
-                        android:defaultValue="true"
-                        android:key="bridge_battery_alerts"
-                        android:summary="@string/notify_on_low_battery_level"
-                        android:switchTextOff="@string/short_off_text_for_switches"
-                        android:switchTextOn="@string/short_on_text_for_switches"
-                        android:title="@string/collector_battery_alerts" />
-                    <EditTextPreference
-                        android:defaultValue="30"
-                        android:dependency="bridge_battery_alerts"
-                        android:digits="0123456789"
-                        android:inputType="number"
-                        android:key="bridge_battery_alert_level"
-                        android:summary=""
-                        android:title="@string/low_battery_percentage" />
-                    <SwitchPreference
-                        android:defaultValue="true"
-                        android:dependency="engineering_mode"
-                        android:key="parakeet_status_alerts"
-                        android:summary="@string/notify_when_parakeet_device_stops_checking_in"
-                        android:switchTextOff="@string/short_off_text_for_switches"
-                        android:switchTextOn="@string/short_on_text_for_switches"
-                        android:title="@string/parakeet_related_alerts" />
-                    <CheckBoxPreference
-                        android:defaultValue="false"
-                        android:dependency="parakeet_status_alerts"
-                        android:key="parakeet_charge_silent"
-                        android:summary="@string/raise_parakeet_notification_silently_when_charging"
-                        android:title="@string/silent_alert_when_charging" />
-                    <SwitchPreference
                         android:defaultValue="false"
                         android:key="follower_chime"
                         android:summary="@string/notify_data_arrives_master"


### PR DESCRIPTION
My limited understanding of Parakeet is that it was used with G4.
We have retired G5.  So, we should retire Parakeet as well.
This PR removes the alerts related to Parakeet.  

I may need help with the data sources though.  That's why this PR is only focused on these particular alerts.  
I'm not sure if most users understand what they are.  I believe it is best to just remove them.  

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20250620-203151](https://github.com/user-attachments/assets/75fee25d-9eee-4f69-86af-b7e57dfafd88) | ![Screenshot_20250620-203936](https://github.com/user-attachments/assets/aad43172-5fc3-4dd2-bd32-6c8f609c0c07) |  
