### PR TITLE
QR scanner camera title/summary clarification

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
     <string name="auto_configure_title">Auto configure</string>
     <string name="prefs_auto_config_summary">Auto configure using a barcode.</string>
     <string name="auto_config_cam_title">Landscape Camera</string>
-    <string name="auto_config_cam_summary">Rotate the phone to landscape mode before tapping \'Landscape Camera\'.  Scan a QR code with your mobile (recommended)</string>
+    <string name="auto_config_cam_summary">Rotate the phone to landscape mode before tapping \'Landscape Camera\' to scan a QR code with your mobile (recommended)</string>
     <string name="auto_config_image_title">Image file</string>
     <string name="auto_config_image_summary">You can save a QR code as an image file (such as .png or .jpeg) on your mobile. Then, use this option to scan the QR code from the saved file.</string>
     <string name="scan_share2_barcode">Scan Share Barcode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,8 +39,8 @@
     <string name="pref_header_cloud_storage">Cloud Storage</string>
     <string name="auto_configure_title">Auto configure</string>
     <string name="prefs_auto_config_summary">Auto configure using a barcode.</string>
-    <string name="auto_config_cam_title">Camera</string>
-    <string name="auto_config_cam_summary">Scan a QR code with your mobile (recommended)</string>
+    <string name="auto_config_cam_title">Landscape Camera</string>
+    <string name="auto_config_cam_summary">Rotate the phone to landscape mode before tapping \'Landscape Camera\'.  Scan a QR code with your mobile (recommended)</string>
     <string name="auto_config_image_title">Image file</string>
     <string name="auto_config_image_summary">You can save a QR code as an image file (such as .png or .jpeg) on your mobile. Then, use this option to scan the QR code from the saved file.</string>
     <string name="scan_share2_barcode">Scan Share Barcode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,8 +39,10 @@
     <string name="pref_header_cloud_storage">Cloud Storage</string>
     <string name="auto_configure_title">Auto configure</string>
     <string name="prefs_auto_config_summary">Auto configure using a barcode.</string>
-    <string name="auto_config_cam_title">Landscape Camera</string>
-    <string name="auto_config_cam_summary">Rotate the phone to landscape mode before tapping \'Landscape Camera\' to scan a QR code with your mobile (recommended)</string>
+    <string name="auto_config_cam_title">Camera</string>
+    <string name="title_wa_auto_config_cam">Landscape Camera</string>
+    <string name="auto_config_cam_summary">Scan a QR code with your mobile (recommended)</string>
+    <string name="summary_wa_auto_config_cam">Rotate the phone to landscape mode before tapping \'Landscape Camera\' to scan a QR code with your mobile (recommended)</string>
     <string name="auto_config_image_title">Image file</string>
     <string name="auto_config_image_summary">You can save a QR code as an image file (such as .png or .jpeg) on your mobile. Then, use this option to scan the QR code from the saved file.</string>
     <string name="scan_share2_barcode">Scan Share Barcode</string>

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -13,8 +13,8 @@
             android:title="@string/auto_configure_title">
             <PreferenceScreen
                 android:key="auto_configure"
-                android:summary="@string/auto_config_cam_summary"
-                android:title="@string/auto_config_cam_title" />
+                android:summary="@string/summary_wa_auto_config_cam"
+                android:title="@string/title_wa_auto_config_cam" />
             <PreferenceScreen
                 android:key="qr_code_from_file"
                 android:summary="@string/auto_config_image_summary"


### PR DESCRIPTION
Our QR scanner runs assuming you are in landscape mode.
On some phones, this looks OK and the window is landscape centered on the phone screen as you rotate it.

However, on some phones, if you are holding it in portrait mode, the scanner preview is panned to the side.  Rotating the phone after starting the scanner will not center the preview screen.

There are suggested fixes for this.  But, it is much easier to just hold the phone in landscape mode before starting to scan.
The following video shows the problem on one phone (Pixel 6a) that suffers from it:

https://github.com/user-attachments/assets/da9f57e7-86ed-4e54-8800-81e82c737769

<br/>  

The following video shows the same phone in landscape mode before starting to scan.  

https://github.com/user-attachments/assets/f42d603c-54c9-48a4-9fc7-bc997302f941

<br/>  

I believe we may be better off just helping users know that all they need to do is to rotate the phone before scanning instead of trying to change the code to fix it, which would require lots of testing.  

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20250621-164330](https://github.com/user-attachments/assets/a8fc244b-655d-484b-aa67-535256424a33) | ![Screenshot_20250621-165804](https://github.com/user-attachments/assets/b50a3c7f-f6f8-4655-b5ae-61d66db18423) |  
  
  
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/3705 
