### PR TITLE
Add insulin stock tracking feature

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/InsulinStockManager.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/InsulinStockManager.java
@@ -1,0 +1,89 @@
+package com.eveningoutpost.dexdrip.models;
+
+import android.content.Context;
+import android.content.Context;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.eveningoutpost.dexdrip.xdrip;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref; // Corrected
+import com.eveningoutpost.dexdrip.models.UserError; // Corrected
+
+
+public class InsulinStockManager {
+
+    private static final String PREF_NAME = "InsulinStockPrefs";
+    private static final String KEY_CURRENT_STOCK = "current_insulin_stock";
+    private static final String KEY_INITIAL_STOCK_SET = "initial_stock_set"; // To track if initial stock was set after enabling
+
+    private static final int DEFAULT_INITIAL_STOCK = 300;
+
+    private static SharedPreferences getPrefs() {
+        return xdrip.getAppContext().getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+    }
+
+    public static boolean isStockTrackingEnabled() {
+        return Pref.getBooleanDefaultFalse("insulin_stock_tracking_enabled");
+    }
+
+    public static float getCurrentStock() {
+        if (!isStockTrackingEnabled()) {
+            return -1; // Or throw an exception, depending on desired behavior
+        }
+        return getPrefs().getFloat(KEY_CURRENT_STOCK, 0);
+    }
+
+    public static void setInitialStock(float units) {
+        if (!isStockTrackingEnabled()) {
+            return;
+        }
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.putFloat(KEY_CURRENT_STOCK, units);
+        editor.putBoolean(KEY_INITIAL_STOCK_SET, true);
+        editor.apply();
+        // Consider broadcasting an update or using a listener for UI changes
+    }
+
+    public static void decreaseStock(double unitsToDecrease) {
+        if (!isStockTrackingEnabled() || unitsToDecrease <= 0) {
+            return;
+        }
+        // Ensure initial stock is set before decreasing
+        if (!isInitialStockSet()) {
+            // If initial stock was never explicitly set by user after enabling,
+            // and we try to decrease, set it to the default initial value first.
+            // Or, prompt user / handle differently. For now, using default.
+            float defaultInitial = Pref.getStringAsInt("initial_insulin_stock", DEFAULT_INITIAL_STOCK);
+            setInitialStock(defaultInitial);
+        }
+
+        float currentStock = getCurrentStock();
+        float newStock = currentStock - (float) unitsToDecrease;
+        if (newStock < 0) {
+            newStock = 0; // Stock cannot be negative
+            // TODO: Consider alerting the user that stock is depleted or low
+            UserError.Log.wtf("InsulinStockManager", "Insulin stock depleted. Attempted to decrease by " + unitsToDecrease + ", current was " + currentStock);
+        }
+
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.putFloat(KEY_CURRENT_STOCK, newStock);
+        editor.apply();
+        // Consider broadcasting an update or using a listener for UI changes
+    }
+
+    public static boolean isInitialStockSet() {
+        return getPrefs().getBoolean(KEY_INITIAL_STOCK_SET, false);
+    }
+
+    public static void resetInitialStockTracking() {
+        // Called when tracking is disabled, to allow fresh setup if re-enabled
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.remove(KEY_INITIAL_STOCK_SET);
+        // editor.remove(KEY_CURRENT_STOCK); // Optionally clear current stock value too
+        editor.apply();
+    }
+
+    public static int getDefaultInitialStock() {
+        return DEFAULT_INITIAL_STOCK;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
@@ -61,6 +61,7 @@ import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import static java.lang.StrictMath.abs;
 import static com.eveningoutpost.dexdrip.models.JoH.emptyString;
+import com.eveningoutpost.dexdrip.models.InsulinStockManager; // Added import
 
 // TODO Switchable Carb models
 // TODO Linear array timeline optimization
@@ -297,6 +298,11 @@ public class Treatments extends Model {
         treatment.save();
         // GcmActivity.pushTreatmentAsync(Treatment);
         //  NSClientChat.pushTreatmentAsync(Treatment);
+
+        // Decrease insulin stock if tracking is enabled and insulin is given
+        if (insulinSum > 0) {
+            InsulinStockManager.decreaseStock(insulinSum);
+        }
 
         pushTreatmentSync(treatment);
         UndoRedo.addUndoTreatment(treatment.uuid);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1969,4 +1969,14 @@
     <string name="sensor_will_expire_in">Sensor will expire in %1$s</string>
     <string name="xdrip_update">xDrip+ Update</string>
     <string name="a_new_version_on_channel_1_s_is_available">A new version on channel %1$s is available</string>
+
+    <!-- Insulin Stock Management -->
+    <string name="insulin_stock_management_title">Insulin Stock Management</string>
+    <string name="insulin_stock_management_summary">Track insulin vial/pen stock levels</string>
+    <string name="enable_insulin_stock_tracking">Enable Stock Tracking</string>
+    <string name="enable_insulin_stock_tracking_summary">Automatically deduct insulin doses from a configured stock level</string>
+    <string name="initial_insulin_stock_title">Initial Insulin Units</string>
+    <string name="initial_insulin_stock_summary">Set the starting units for a new vial/pen</string>
+    <string name="current_insulin_stock_title">Current Insulin Stock</string>
+    <string name="current_insulin_stock_summary_default">Stock tracking not enabled or not set</string>
 </resources>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -733,6 +733,36 @@
                     android:title="@string/title_multiple_insulin_use_basal_activity"/>
             </PreferenceScreen>
 
+            <PreferenceScreen
+                android:key="insulin_stock_management_settings"
+                android:title="@string/insulin_stock_management_title"
+                android:summary="@string/insulin_stock_management_summary">
+
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:key="insulin_stock_tracking_enabled"
+                    android:title="@string/enable_insulin_stock_tracking"
+                    android:summary="@string/enable_insulin_stock_tracking_summary"
+                    android:switchTextOff="@string/short_off_text_for_switches"
+                    android:switchTextOn="@string/short_on_text_for_switches" />
+
+                <EditTextPreference
+                    android:key="initial_insulin_stock"
+                    android:title="@string/initial_insulin_stock_title"
+                    android:summary="@string/initial_insulin_stock_summary"
+                    android:inputType="number"
+                    android:defaultValue="300"
+                    android:dependency="insulin_stock_tracking_enabled" />
+
+                <Preference
+                    android:key="current_insulin_stock"
+                    android:title="@string/current_insulin_stock_title"
+                    android:summary="@string/current_insulin_stock_summary_default"
+                    android:selectable="false"
+                    android:dependency="insulin_stock_tracking_enabled"/>
+
+            </PreferenceScreen>
+
             <Preference
                 android:key="profile_carb_ratio_default"
                 android:summary="@string/grams_of_carbohydrate_one_unit_covers"


### PR DESCRIPTION
- Adds preferences to enable/disable insulin stock tracking and set initial stock.
- Introduces InsulinStockManager to handle stock logic using SharedPreferences.
- Modifies Treatment creation to decrease stock when insulin is administered.
- Updates settings UI to display current stock and manage initial stock value.
- Initializes stock with a default of 300 units, user-configurable.