### PR TITLE
No Follower calibration except xDrip Sync

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
@@ -68,7 +68,10 @@ public class NavDrawerBuilder {
         if ((prefs.getString("dex_collection_method", "").equals("Follower"))) {
             this.nav_drawer_options.add(context.getString(R.string.add_calibration));
             this.nav_drawer_intents.add(new Intent(context, AddCalibration.class));
-        } else {
+        } else if (!getBestCollectorHardwareName().equals("Nightscout") &&
+                !getBestCollectorHardwareName().equals("Share") &&
+                !getBestCollectorHardwareName().equals("UI Based") &&
+                !getBestCollectorHardwareName().equals("CareLink")) { // Only if the collector is neither Nightscout follower nor Dex share follower nor companion app not Carelink follower
 
             if (is_active_sensor) {
                 if (!CollectionServiceStarter.isBTShare(context)) {


### PR DESCRIPTION
Problem:
The main menu offers an "Initial Calibration" option for the Dex share follower:
https://github.com/NightscoutFoundation/xDrip/discussions/4071 

In fact, it also shows an option to Stop Sensor.  
But, neither of those functions can actually be performed.  You cannot calibrate a sensor through Dex share servers.  You also cannot stop a sensor running on the master transmitter through Dex share servers.

Suggested solution:
This PR removes the options to start sensor, or stop sensor or calibrate for either Nightscout follower or Dex share follower or CareLink follower or Companion app.  

Before - After  

Tests  
