### PR TITLE
Follower Chime menu update

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1432,6 +1432,8 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 }
             }
 
+            final Preference xSyncFollowChime = findPreference("follower_chime");
+
 
             if (collectionType != DexCollectionType.WebFollow) {
                 try {
@@ -1858,6 +1860,14 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     collectionCategory.removePreference(nsFollowUrl);
                     collectionCategory.removePreference(nsFollowDownload);
                     collectionCategory.removePreference(nsFollowLag);
+                } catch (Exception e) {
+                    //
+                }
+            }
+
+            if (collectionType != DexCollectionType.Follower) {
+                try {
+                    collectionCategory.removePreference(xSyncFollowChime);
                 } catch (Exception e) {
                     //
                 }
@@ -2578,6 +2588,10 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                         collectionCategory.addPreference(nsFollowUrl);
                         collectionCategory.addPreference(nsFollowDownload);
                         collectionCategory.addPreference(nsFollowLag);
+                    }
+
+                    if (collectionType == DexCollectionType.Follower) {
+                        collectionCategory.addPreference(xSyncFollowChime);
                     }
 
 

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -242,6 +242,14 @@
             android:summary="Your account and follower app are from the USA"
             android:title="US Servers" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="follower_chime"
+            android:summary="@string/notify_data_arrives_master"
+            android:switchTextOff="@string/short_off_text_for_switches"
+            android:switchTextOn="@string/short_on_text_for_switches"
+            android:title="@string/follower_chime_new" />
+
         <ListPreference
             android:defaultValue="gb"
             android:entries="@array/carelinkCountryEntries"

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -400,17 +400,6 @@
                         android:switchTextOn="@string/short_on_text_for_switches"
                         android:title="@string/title_sens_expiry_notify" />
                 </PreferenceScreen>
-                <PreferenceScreen
-                    android:key="@string/other_xdrip_plus_alerts"
-                    android:title="@string/other_xdrip_plus_alerts">
-                    <SwitchPreference
-                        android:defaultValue="false"
-                        android:key="follower_chime"
-                        android:summary="@string/notify_data_arrives_master"
-                        android:switchTextOff="@string/short_off_text_for_switches"
-                        android:switchTextOn="@string/short_on_text_for_switches"
-                        android:title="@string/follower_chime_new" />
-                </PreferenceScreen>
             </PreferenceScreen>
         </PreferenceCategory>
     </PreferenceScreen>


### PR DESCRIPTION
The follower chime alert is only functional when the hardware data source is xDrip Sync follower.
For that reason, I believe it would be best to locate the setting under the hardware data source and only visible when the hardware data source is set to xDrip Sync follower.  That's all this PR does.  
There is no change to functionality.  There is only a change to the user interface.  

| Before | After |  
| ------- | ------ |  
| ![Screenshot_20250708-150633](https://github.com/user-attachments/assets/24b8e0f1-3789-4103-855f-d5ea83e3b9b3) | ![Screenshot_20250708-150447](https://github.com/user-attachments/assets/2eaf9dd0-4d82-403f-84d0-b1d734d22ea0) |  
| ![Screenshot_20250708-150654](https://github.com/user-attachments/assets/5a7dd495-c065-476d-acb7-71b3d1d92217) | ![Screenshot_20250708-150514](https://github.com/user-attachments/assets/bf811033-96d1-4851-a558-dccd91643661) |  
