### PR TITLE
Overwrite calibrations for fake data source only

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
@@ -20,6 +20,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.calibrations.CalibrationAbstract;
 import com.eveningoutpost.dexdrip.utils.ActivityWithMenu;
+import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 
 import java.text.DateFormat;
 import java.text.DecimalFormat;
@@ -220,8 +221,8 @@ public class CalibrationGraph extends ActivityWithMenu {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
 
-        //Just generate the menu in engineering mode
-        if (!Pref.getBooleanDefaultFalse("engineering_mode")) {
+        if (DexCollectionType.getDexCollectionType() != DexCollectionType.Mock) {
+            // Generate the menu only for fake data source
             return false;
         }
 


### PR DESCRIPTION
It is dangerous to be able to modify the calibration constants.  Because if you make a mistake, it could have dangerous results.
I suppose that is why it can only be done in engineering mode.

This PR changes this so that it can only be done for the fake data source.  So, it can still be done for testing (fake data source),  But, it will not be an option when using xDrip with a real data source.  