### PR TITLE
Font Settings

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -271,11 +271,17 @@ public class BgGraphBuilder {
 
 
     static public boolean isXLargeTablet(Context context) {
-        return (context.getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_XLARGE;
+        if (Pref.getBooleanDefaultFalse("enlarge_fonts_on_large_screens")) {
+            return (context.getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_XLARGE;
+        }
+        return false;
     }
 
     static public boolean isLargeTablet(Context context) {
-        return (context.getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE;
+        if (Pref.getBooleanDefaultFalse("enlarge_fonts_on_large_screens")) {
+            return (context.getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE;
+        }
+        return false;
     }
 
     public static double mmolConvert(double mgdl) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,6 +339,10 @@
     <string name="pebble_and_android_wear_options">Options for different Watches</string>
     <string name="customize_colours">Customize Colors</string>
     <string name="xdrip_plus_color_settings">xDrip+ Color Settings</string>
+    <string name="summary_font_settings">Customize Fonts</string>
+    <string name="title_font_settings">Font Settings</string>
+    <string name="summary_enlarge_fonts_on_large_screens">Automatically enlarge the font size on large screens, such as tablets</string>
+    <string name="title_enlarge_fonts_on_large_screens">Enlarge fonts on larger displays</string>
     <string name="glucose_values_and_lines">Glucose Values and Lines</string>
     <string name="high_glucose_values">High Glucose Values</string>
     <string name="in_range_glucose_values">In-range Glucose Values</string>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -309,6 +309,17 @@
                 </PreferenceCategory>
             </PreferenceScreen>
 
+            <PreferenceScreen
+                android:key="xdrip_font_settings"
+                android:summary="@string/summary_font_settings"
+                android:title="@string/title_font_settings">
+                <CheckBoxPreference
+                    android:defaultValue="true"
+                    android:key="enlarge_fonts_on_large_screens"
+                    android:summary="@string/summary_enlarge_fonts_on_large_screens"
+                    android:title="@string/title_enlarge_fonts_on_large_screens" />
+            </PreferenceScreen>
+
             <SwitchPreference
                 android:defaultValue="false"
                 android:key="force_english"


### PR DESCRIPTION
xDrip categorizes a device into 4 groups based on the screen size: small, normal, large tablet and extra large tablet.
The last two tablet categories were added here: https://github.com/NightscoutFoundation/xDrip/pull/29.

Today, there are new phones that are categorized by that routine as large or extra large tablets.  The result is that the font size, specially the extra status line font, becomes unreasonably large.
You can see some of the reports below:
https://github.com/NightscoutFoundation/xDrip/discussions/3196
https://github.com/NightscoutFoundation/xDrip/discussions/3782
https://github.com/NightscoutFoundation/xDrip/discussions/4105
There are reports on facebook as well.

At first, I wanted to change the categorization and add more resolution to it.  For example, having 6 categories instead of just 4.  But, that wouldn't be a futureproof solution.  Neither would it be easy to guarantee that it would not impact real tablet behavior.
So, I decided to add a setting.

This PR adds a new setting group under xDrip Display settings called Font Settings.  That group is where any font settings we may decide to add in the future can go.  Currently, it will have one setting that enlarges fonts on large screens.  This setting is enabled by default, in which case, xDrip behaves exactly as it does before this PR.
Disabling the new setting will stop xDrip from enlarging fonts on tablets.  Therefore, users of new phones or foldables that are unhappy with large fonts, can disable the setting.
This guarantees the behavior of xDrip remains unchanged if the new setting is left enabled.

| Before | After |  
| ------- | ----- |  
| <img width="271" height="300" alt="Screenshot_20250815-220928" src="https://github.com/user-attachments/assets/8630a649-1c5a-4f2f-b183-1a9e7f2d10f2" /> | <img width="269" height="298" alt="Screenshot_20250815-220332" src="https://github.com/user-attachments/assets/4e833e53-7311-45af-8dca-69b30bd0f287" /> |  
|  | <img width="270" height="232" alt="Screenshot_20250815-220645" src="https://github.com/user-attachments/assets/f9b20b4c-6137-4058-a434-2cdfcc6273f2" /> |  
  
<br/>  
  
---  
  
**Testing**  
To recreate a problem, I have used a Pixel 6a.  Go to Android display settings > Display size and text 
and reduce "Display size" to minimum.  You will see that xDrip enlarges the Extra Status Line font size dramatically.  
xDrip categorizes the screen as a large tablet then.  
Disabling the new setting, minimizing xDrip and opening it again changes the font size to very small size by disabling xDrip's font enlargement for tablets.  

| Pixel 6a before | Pixel 6a after |  
| ---------------- | -------------- |  
| <img width="269" height="299" alt="Screenshot_20250815-222301" src="https://github.com/user-attachments/assets/72fa65a3-fa06-42a6-9724-d8d8c429d639" /> | <img width="269" height="299" alt="Screenshot_20250815-222501" src="https://github.com/user-attachments/assets/091d0da2-fb1e-4d16-b685-a98aa7d93ef3" /> |  
|  | New setting disabled <br/>  <img width="269" height="299" alt="Screenshot_20250815-222536" src="https://github.com/user-attachments/assets/5a4829b8-919a-4843-b9c4-36af90bf9ce8" /> |  
  


