### PR TITLE
24-hour format support

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/g5model/SensorDays.java
@@ -207,11 +207,30 @@ public class SensorDays {
         if (expiryMs > 0) {
             if (expiryMs > CAL_THRESHOLD1) {
                 val fmt = xdrip.gs(R.string.expires_days);
-                return new SpannableString(MessageFormat.format(fmt, roundDouble((double) expiryMs / DAY_IN_MS, 1)));
+                return new SpannableString(
+                        MessageFormat.format(fmt, roundDouble((double) expiryMs / DAY_IN_MS, 1))
+                );
             } else {
                 // expiring soon
-                val niceTime = new SimpleDateFormat(expiryMs < CAL_THRESHOLD2 ? "h:mm a" : "EEE, h:mm a", Locale.getDefault()).format(getSensorEndTimestamp());
-                return Span.colorSpan(MessageFormat.format(xdrip.gs(R.string.expires_at), niceTime), expiryMs < CAL_THRESHOLD2 ? Highlight.BAD.color() : Highlight.NOTICE.color());
+                val context = xdrip.getAppContext();
+                boolean is24Hour = android.text.format.DateFormat.is24HourFormat(context);
+
+                // choose skeleton: time only or weekday+time
+                String skeleton = (expiryMs < CAL_THRESHOLD2)
+                        ? (is24Hour ? "Hm" : "hma")        // time only
+                        : (is24Hour ? "EEEHm" : "EEEhma"); // weekday + time
+
+                // build best pattern for this locale + system 12h/24h setting
+                String pattern = android.text.format.DateFormat.getBestDateTimePattern(
+                        Locale.getDefault(), skeleton);
+
+                val dateFormat = new SimpleDateFormat(pattern, Locale.getDefault());
+                String niceTime = dateFormat.format(getSensorEndTimestamp());
+
+                return Span.colorSpan(
+                        MessageFormat.format(xdrip.gs(R.string.expires_at), niceTime),
+                        expiryMs < CAL_THRESHOLD2 ? Highlight.BAD.color() : Highlight.NOTICE.color()
+                );
             }
         }
         return new SpannableString("");


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/3616 

Currently, we show sensor expiry using am/pm regardless of what time format is set in Android system settings.
This PR changes xDrip so that when 24-hour format is selected in Android settings, sensor expiry time uses the 24-hour format.

The following 2 screenshots show sensor expiry with the 24-hour time format enabled and disabled.

<img width="270" height="600" alt="Screenshot_20250816-203244" src="https://github.com/user-attachments/assets/ae4cb793-8a46-4a02-af16-6d2f272e7a7b" />  
  
<img width="270" height="600" alt="Screenshot_20250816-204607" src="https://github.com/user-attachments/assets/316e4aa3-d8b5-40fe-bb7e-68904cd162da" />
  