### PR TITLE
Session start time update for alt (corrects Nightscout SAGE) (phase 2)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
@@ -453,8 +453,8 @@ public class Treatments extends Model {
         val lastSensorStart = Treatments.lastEventTypeFromXdrip(Treatments.SENSOR_START_EVENT_TYPE);
         long localStartedAt = lastSensorStart.timestamp; // When the xDrip local session started
         long dexStartedAt = DexSessionKeeper.getStart(); // When the current session on the transmitter started
-        if (dexStartedAt > 0 && !(Math.abs(dexStartedAt - localStartedAt) < MINUTE_IN_MS * 5)) { // If the start time of the local session is more than 5 minutes different than the one on the transmitter
-            Treatments.sensorStart(dexStartedAt, "Start time updated");
+        if (dexStartedAt > 0 && Math.abs(dexStartedAt - localStartedAt) > MINUTE_IN_MS * 5) { // If the local session start time differs from the transmitter session start time by more than 5 minutes
+            Treatments.sensorStart(dexStartedAt, "Start time updated"); // Update the local session start time.
         }
     }
 


### PR DESCRIPTION
After you insert a new sensor with your old sensor still active, you have 2 options:

1- You can disable collection in xDrip, peel off the old sensor and move away, re-enable collection and change transmitter ID to the pairing code of the new device. 

2- You can wait for your old sensor to expire.  Then, peel it off and move away. Then, change the transmitter ID to that of the new device.  

In either case, there will be a discrepancy between the local session start time and the real session start time as reported by the new device transmitter.  

This discrepancy was addressed for case 1 here: https://github.com/NightscoutFoundation/xDrip/pull/4047 
It has been tested for a month now.  
This PR addresses the discrepancy for the remaining case 2 as well.  

I will be able to test this in 10 days making sure there will be no backfill overlap.  Hopefully, it will pass and I will then bring this out of draft mode.  