### PR TITLE
CareLink Follower - Simplera CGM

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -300,7 +300,7 @@ public class CareLinkClient {
             return null;
 
         for(DataUpload upload : this.sessionRecentUploads.recentUploads){
-            if(upload.device.toUpperCase().contains("MINIMED"))
+            if(upload.device.toUpperCase().contains("MINIMED") || upload.device.toUpperCase().contains("SIMPLERA"))
                 return  true;
             else if(upload.device.toUpperCase().contains("GUARDIAN"))
                 return  false;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Alarm.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Alarm.java
@@ -14,7 +14,7 @@ public class Alarm {
         return null;
     }
 
-    public int code;
+    public String code;
     //@JsonAdapter(CareLinkJsonAdapter.class)
     public String datetime;
     public Date datetimeAsDate;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Marker.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Marker.java
@@ -33,6 +33,8 @@ public class Marker {
     public Date dateTime;
     @JsonAdapter(CareLinkJsonAdapter.class)
     public Date timestamp = null;
+    @JsonAdapter(CareLinkJsonAdapter.class)
+    public Date displayTime = null;
     public Integer relativeOffset;
     public Boolean calibrationSuccess;
     public Double amount;
@@ -50,7 +52,9 @@ public class Marker {
     public MarkerData data;
 
     public Date getDate(){
-        if(timestamp != null)
+        if(displayTime != null)
+            return displayTime;
+        else if(timestamp != null)
             return timestamp;
         else if(dateTime != null)
             return dateTime;
@@ -63,6 +67,12 @@ public class Marker {
             return deliveredExtendedAmount + deliveredFastAmount;
         else if(data.dataValues != null && data.dataValues.deliveredFastAmount != null)
             return data.dataValues.deliveredFastAmount;
+        else if(data != null && data.dataValues != null && data.dataValues.insulinUnits != null)
+            try {
+                return Float.parseFloat(data.dataValues.insulinUnits);
+            } catch (Exception ex){
+                return null;
+            }
         else
             return null;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/MarkerDataValues.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/MarkerDataValues.java
@@ -8,6 +8,7 @@ public class MarkerDataValues {
     public Float bolusAmount;
     public Float maxAutoBasalRate;
     public String insulinType;
+    public String insulinUnits;
     public Float  programmedFastAmount;
     public Float deliveredFastAmount;
     public String activationType;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Notification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Notification.java
@@ -10,7 +10,7 @@ public class Notification {
     @JsonAdapter(CareLinkJsonAdapter.class)
     public Date dateTime;
     public String type;
-    public int faultId;
+    public String faultId;
     public int instanceId;
     public String messageId;
     public String pumpDeliverySuspendState;
@@ -20,8 +20,8 @@ public class Notification {
     public String getMessageId(){
         if(messageId != null)
             return  messageId;
-        else if(faultId > 0)
-            return String.valueOf(faultId);
+        else if(faultId != null)
+            return faultId;
         else
             return null;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Patient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/Patient.java
@@ -12,7 +12,7 @@ public class Patient {
     public boolean patientUsesConnect;
 
     public boolean isBle() {
-        return lastDeviceFamily.contains("BLE");
+        return (lastDeviceFamily.contains("BLE") || lastDeviceFamily.contains("SIMPLERA"));
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/RecentData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/RecentData.java
@@ -10,6 +10,7 @@ public class RecentData {
 
     public static final String DEVICE_FAMILY_GUARDIAN = "GUARDIAN";
     public static final String DEVICE_FAMILY_NGP = "NGP";
+    public static final String DEVICE_FAMILY_CGM = "CGM";
 
     //sensorState
     public static final String SENSOR_STATE_CALIBRATION_REQUIRED = "CALIBRATION_REQUIRED";
@@ -56,6 +57,10 @@ public class RecentData {
 
     public boolean isNGP() {
         return getDeviceFamily().equals(DEVICE_FAMILY_NGP);
+    }
+
+    public boolean isCGM() {
+        return getDeviceFamily().equals(DEVICE_FAMILY_CGM);
     }
 
     public int getDeviceBatteryLevel(){

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/SensorGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/SensorGlucose.java
@@ -1,14 +1,18 @@
 package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
 
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.message.util.CareLinkJsonAdapter;
+import com.eveningoutpost.dexdrip.models.DateUtil;
 import com.google.gson.annotations.JsonAdapter;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
  * CareLink SensorGlucose message with helper methods for processing
  */
 public class SensorGlucose {
+
+    private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     public Integer sg;
     public String datetime;
@@ -35,9 +39,9 @@ public class SensorGlucose {
         if (getDate() == null) {
             dt = "";
         } else {
-            dt = getDate().toString();
+            dt = DateUtil.toISOString(getDate());
         }
-        return dt + " " + sg;
+        return dt + " - " + sg;
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/TextMap.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/message/TextMap.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip.cgm.carelinkfollow.message;
 
+import com.microsoft.appcenter.ingestion.models.json.DefaultLogSerializer;
+
 import java.util.HashMap;
 
 public class TextMap {
@@ -311,21 +313,27 @@ public class TextMap {
         return getErrorMessage(deviceFamily, notification.messageId, notification.faultId);
     }
 
-    public static String getNotificationMessage(String deviceFamily, String messageId, int faultId) {
+    public static String getNotificationMessage(String deviceFamily, String messageId, String faultId) {
         return getErrorMessage(deviceFamily, messageId, faultId);
     }
 
-    public static String getErrorMessage(String deviceFamily, String guardianErrorCode, int ngpErrorCode) {
+    public static String getErrorMessage(String deviceFamily, String guardianErrorCode, String ngpErrorCode) {
         String errorTextId;
         String internalEC;
+        String formattedEC;
 
         if (deviceFamily.equals(RecentData.DEVICE_FAMILY_GUARDIAN)) {
             if (guardianErrorCode != null)
                 errorTextId = ERROR_TEXT_PREFIX_GUARDIAN + guardianErrorCode;
             else
                 errorTextId = null;
-        } else if (deviceFamily.equals(RecentData.DEVICE_FAMILY_NGP)) {
-            String formattedEC = String.format("%03d", ngpErrorCode);
+        } else if (deviceFamily.equals(RecentData.DEVICE_FAMILY_NGP) || deviceFamily.equals(RecentData.DEVICE_FAMILY_CGM)) {
+            if(ngpErrorCode.matches("\\d+"))
+            {
+                formattedEC = String.format("%03d", Integer.parseInt(ngpErrorCode));
+            }
+            else
+                formattedEC = ngpErrorCode;
             if (errorCodeMap.containsKey(formattedEC))
                 internalEC = errorCodeMap.get(formattedEC);
             else


### PR DESCRIPTION
**Issue**
CareLink Follower is not working for standalone Simplera CGM users.

**Solution**
In case the device type is standalone Simplera CGM the data is downloaded through the same API as for 7xxG pumps with some minor modifications.
Data available in case of standalone Simplera CGM:
- sensor glucose measurements
- blood glucose measurements
- carbs
- insulin

**Testing**
I have tested it with all kinds of accounts (patient, carepartner) with different devices (standalone Guardian 4 CGM, standalone Simplera CGM  and 7xxG pump) in EU on different phones and it is was working fine without any errors and was stable. Since US region uses the same API endpoint versions, it should be working there also.