### PR TITLE
Honor wake workaround

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/BuggySamsung.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/BuggySamsung.java
@@ -69,9 +69,10 @@ public class BuggySamsung {
     public static boolean isSamsung() {
         return Build.MANUFACTURER.toLowerCase().contains("samsung")
                 || Build.MANUFACTURER.toLowerCase().contains("xiaomi")
-                || Build.MANUFACTURER.toLowerCase().contains("oneplus")    // experimental test
-                || Build.MANUFACTURER.toLowerCase().contains("oppo")      // experimental test
-                || Build.MANUFACTURER.toLowerCase().contains("huawei");      // experimental test
+                || Build.MANUFACTURER.toLowerCase().contains("oneplus")
+                || Build.MANUFACTURER.toLowerCase().contains("oppo")
+                || Build.MANUFACTURER.toLowerCase().contains("huawei")
+                || Build.MANUFACTURER.toLowerCase().contains("honor");
     }
 
 }


### PR DESCRIPTION
There is another phone brand that shows slow wake and has intermittent connectivity.
Honor  
  
![541841248_24689241684042926_5788188651777387575_n](https://github.com/user-attachments/assets/35cbc391-a995-4629-919c-98dc296bed6e)  
  
![541827375_24689396394027455_8248540822146490938_n](https://github.com/user-attachments/assets/624372d7-f20c-4e1d-b4d6-e7f19374bf34)  
  
![540084794_24689390257361402_1508430847596020425_n](https://github.com/user-attachments/assets/c31d2a71-7a77-43b7-b7d1-9ddea4557883)  
  
---  
  
**After Test Release**  
![541672711_24690227777277650_123081302536205672_n](https://github.com/user-attachments/assets/bcd0dfdd-36cd-4c83-b568-5d7fa6818a0a)  
  
![542732473_24690267583940336_1597632359628216135_n](https://github.com/user-attachments/assets/1b8f4d21-212e-4161-91e3-cfd731d791b3)
