### PR TITLE
Make the alpha channel default

### DIFF
--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -1080,7 +1080,7 @@
             android:switchTextOn="@string/short_on_text_for_switches"
             android:title="@string/automatic_update_check" />
         <ListPreference
-            android:defaultValue="beta"
+            android:defaultValue="alpha"
             android:entries="@array/UpdateChannelDetail"
             android:entryValues="@array/UpdateChannel"
             android:key="update_channel"


### PR DESCRIPTION
This makes the alpha update channel the default channel.
It will only affect new installs.

Considering the alpha and beta channels both provide the same number of updates per year, this is not a significant change for the majority.
However, currently, when a new alpha is released, not many see a change, which defeats the purpose of the 2 week earlier release of alpha with respect to beta.  