### PR TITLE
Fixed companion app IoB reporting when CV is empty

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
@@ -171,10 +171,24 @@ public class UiBasedCollector extends NotificationListenerService {
         if (notification.contentView != null) {
             processCompanionAppIoBNotificationCV(notification.contentView);
         } else {
-            UserError.Log.e(TAG, "Content is empty");
+            processCompanionAppIoBNotificationTitle(notification);
         }
     }
 
+    private void processCompanionAppIoBNotificationTitle(final Notification notification) {
+        Double iob = null;
+        try {
+            String notificationTitle = notification.extras.getString("android.title");
+            iob = parseIoB(notificationTitle);
+
+            if (iob != null) {
+                if (debug) UserError.Log.d(TAG, "Inserting new IoB value extracted from title: " + iob);
+                iob_store.set(iob);
+            }
+        } catch (Exception e) {
+            UserError.Log.e(TAG, "exception in processCompanionAppIoBNotificationTitle: " + e);
+        }
+    }
     private void processCompanionAppIoBNotificationCV(final RemoteViews cview) {
         if (cview == null) return;
         val applied = cview.apply(this, null);
@@ -196,7 +210,7 @@ public class UiBasedCollector extends NotificationListenerService {
             }
 
             if (iob != null) {
-                if (debug) UserError.Log.d(TAG, "Inserting new IoB value: " + iob);
+                if (debug) UserError.Log.d(TAG, "Inserting new IoB value extracted from CV: " + iob);
                 iob_store.set(iob);
             }
         } catch (Exception e) {


### PR DESCRIPTION
I noticed that the IoB reporting stopped working recently (after either the Android or Omnipod app update).

On my phone, the CV value of the Omnipod notification is empty. Debug logs:
```
2025-09-28 17:33:13.218  5547-5547  UiBasedCollector        com.eveningoutpost.dexdrip           I  Notification from: com.insulet.myblue.pdm
2025-09-28 17:33:13.218  5547-5547  UiBasedCollector        com.eveningoutpost.dexdrip           E  Content is empty
2025-09-28 17:33:14.017  5547-5547  UiBasedCollector        com.eveningoutpost.dexdrip           I  Notification from: com.insulet.myblue.pdm
2025-09-28 17:33:14.017  5547-5547  UiBasedCollector        com.eveningoutpost.dexdrip           E  Content is empty
```

The IoB value is store in the notification title instead, in the "extras" bundle:
```
2025-09-28 17:46:21.230  9732-9732  UiBasedCollector        com.eveningoutpost.dexdrip           E  notification extras: Bundle[{android.title=Automated Mode (IOB: 0.85 U), android.reduced.images=true, android.subText=null, android.showChronometer=false, android.text=null, android.progress=0, android.progressMax=0, android.appInfo=Supplier{VAL_PARCELABLE@436+2012}, android.showWhen=true, android.largeIcon=null, android.infoText=null, android.progressIndeterminate=false, android.remoteInputHistory=null}]
```

This PR adds parsing of the notification title if CV is empty. This should ensure backwards compatibility with Android and Omnipod software versions that still report IoB values through CV, while fixing it for cases where it is only reported in the notification title.

Debug logs with the PR:
```
2025-09-28 18:03:29.740 14096-14096 UiBasedCollector        com.eveningoutpost.dexdrip           D  Inserting new IoB value: 0.8
```