### PR TITLE
Exclude raw-related logs from G7 calibrations

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Calibration.java
@@ -42,6 +42,7 @@ import java.util.UUID;
 
 import static com.eveningoutpost.dexdrip.models.BgReading.isDataSuitableForDoubleCalibration;
 import static com.eveningoutpost.dexdrip.calibrations.PluggableCalibration.newFingerStickData;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
 
 
 class DexParameters extends SlopeParameters {
@@ -640,7 +641,8 @@ public class Calibration extends Model {
                     } else {
                         Log.d(TAG, "Follower mode or note so not processing calibration deeply");
                     }
-                } else {
+                } else if (!getBestCollectorHardwareName().equals("G7")) {
+                    // Only if we are not using newer devices, which are limited to native behavior
                     final String msg = "Sensor data fails sanity test - Cannot Calibrate! raw:" + bgReading.raw_data;
                     UserError.Log.e(TAG, msg);
                     JoH.static_toast_long(msg);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/SensorSanity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/SensorSanity.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip.models;
 
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
+
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
@@ -71,7 +73,7 @@ public class SensorSanity {
             else if (raw_value > DEXCOM_MAX_RAW) state = false;
         }
 
-        if (!state) {
+        if (!state && !getBestCollectorHardwareName().equals("G7")) {
             if (JoH.ratelimit("sanity-failure", 20)) {
                 final String msg = "Sensor Raw Data Sanity Failure: " + raw_value;
                 UserError.Log.e(TAG, msg);


### PR DESCRIPTION
This is a cleanup of this PR: https://github.com/NightscoutFoundation/xDrip/pull/3646 

When you submit a calibration for G7 or similar, you get two logs that are related to raw values.  They should not be shown because they are confusing and irrelevant.  
This image shows the incorrect logs:
![361501578-755b46ef-b249-48df-9aa8-bb24c5e5dfac](https://github.com/user-attachments/assets/d3d92ac6-ab1b-4fcc-a867-42f888f062d7)  
  
The following shows a calibration performed on a G7 after this PR:  
<img width="270" height="600" alt="Screenshot_20251005-225642" src="https://github.com/user-attachments/assets/a8ce821e-7afe-4c18-bc0d-9f6b11954fbb" />
