### PR TITLE
Sensor expiry note overlap fix

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/alert/SensorExpiry.java
@@ -49,7 +49,7 @@ public class SensorExpiry extends BaseAlert {
         cancelNotification(notificationId);
         val expireMsg = xdrip.gs(R.string.sensor_will_expire_in, expiry);
         showNotification(xdrip.gs(R.string.sensor_expiring), expireMsg, null, notificationId, null, true, true, null, null, null, true);
-        Treatments.create_note("Warning: " + expireMsg, tsl()); // TODO i18n but note classifier also needs updating for that
+        Treatments.create_note("" + expireMsg, tsl()); // TODO i18n but note classifier also needs updating for that
         UserError.Log.uel(TAG, "Sensor will expire soon");
         return true;
     }


### PR DESCRIPTION
I cannot guarantee this is a perfect fix for all phones and all languages.
But, it is a very simple change that addresses the issue for the flagged cases here: https://github.com/NightscoutFoundation/xDrip/discussions/4187 
  
A more elegant solution may be to change the layout and stack them vertically.  But, that's going to make things look different for those who have got used to things.  And it will be much more work.
I will do it if you want.

To make testing possible, I created a custom version of xDrip to trigger the note early.

The following shows the problem for Russian before this PR:  
<img width="270" height="600" alt="share_3198234421738001446" src="https://github.com/user-attachments/assets/2eca98ed-40a9-4d0a-9ef3-78f43455078a" />  
  
The following shows Russian after this PR:  
<img width="270" height="600" alt="Screenshot_20251007-145732" src="https://github.com/user-attachments/assets/17306b40-95c7-41b6-9d04-d58122130ad7" />  
  
The following shows German after this PR:  
<img width="270" height="600" alt="Screenshot_20251007-163112" src="https://github.com/user-attachments/assets/75ec2fac-5a40-4756-9831-58ef8473005c" />  