### PR TITLE
Stop binding a retired setting's summary

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1133,7 +1133,6 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             bindPreferenceSummaryToValue(findPreference("falling_bg_val"));
             bindPreferenceSummaryToValue(findPreference("rising_bg_val"));
             bindPreferenceSummaryToValue(findPreference("other_alerts_sound"));
-            bindPreferenceSummaryToValue(findPreference("bridge_battery_alert_level"));
             bindPreferenceSummaryToUnitizedValueAndEnsureNumeric(findPreference("persistent_high_threshold"));
             bindPreferenceSummaryToUnitizedValueAndEnsureNumeric(findPreference("forecast_low_threshold"));
 


### PR DESCRIPTION
Problem: 
With any xDrip release starting from 2025.07.04, go to Settings.  Then, go back to the main screen.  Now, look at the logs.  You will see this log:
<img width="524" height="118" alt="Screenshot_20251013-184628" src="https://github.com/user-attachments/assets/b18cf1fa-ec8e-4bd0-a5a9-d2bba1b44122" />  
  
Go to Settings again and go back to the main screen.  You will see another instance of that same log.  
  
---  
  
I retired the parakeet settings in this PR: https://github.com/NightscoutFoundation/xDrip/pull/4063 
But, I forgot to remove a line in Preferences that binds the value of one of those settings to its summary.  With the setting gone, every time you go to settings, it causes an exception.  
  
This PR removes the binding of the value to the summary for that retired setting.  

The log is not shown any longer every time you go to settings after this PR.
