### PR TITLE
Tidepool uploader queue

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
@@ -190,6 +190,7 @@ public class MegaStatus extends FloatingLocaleActivityWithScreenshot {
             }
             if (Pref.getBooleanDefaultFalse("cloud_storage_mongodb_enable")
                     || Pref.getBooleanDefaultFalse("cloud_storage_api_enable")
+                    || Pref.getBooleanDefaultFalse("cloud_storage_tidepool_enable")
                     || Pref.getBooleanDefaultFalse("share_upload")
                     || (Pref.getBooleanDefaultFalse("wear_sync") && Home.get_engineering_mode())) {
                 addAsection(UPLOADERS, "Cloud Uploader Queues");


### PR DESCRIPTION
Problem:
If you only upload to Tidepool, you will not be able to see the queue because the Uploaders status page will not exist. 
But, if you are uploading to Tidepool as well as Nightscout, you can see both queues on the Uploaders status page.

This PR changes that such that even if you only upload to Tidepool, you will still be able to see the uploader queue.
The following image shows the queue on a test phone set to upload to Tidepool only after this PR:
<img width="270" height="540" alt="Screenshot_20251015-140947" src="https://github.com/user-attachments/assets/ee369e8e-c1aa-4207-b564-01b34d60101a" />
