### PR TITLE
Vibrate on alert choice for extra alerts

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/MissedReadingActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/MissedReadingActivity.java
@@ -36,6 +36,7 @@ public class MissedReadingActivity extends ActivityWithMenu {
     private CheckBox checkboxAllDay;
     private CheckBox checkboxEnableReraise;
     private CheckBox checkboxOverrideSilent;
+    private CheckBox checkboxVibrateOnAlert;
     private String audioPath; // Local representation of the path to the sound file
     private EditText alertMp3File; // Sound file title
     
@@ -76,6 +77,7 @@ public class MissedReadingActivity extends ActivityWithMenu {
         checkboxAllDay = (CheckBox) findViewById(R.id.missed_reading_all_day);
         checkboxEnableAlert = (CheckBox) findViewById(R.id.missed_reading_enable_alert);
         checkboxOverrideSilent = (CheckBox) findViewById(R.id.bg_missed_alerts_override_silent);
+        checkboxVibrateOnAlert = (CheckBox) findViewById(R.id.bg_missed_alerts_vibrate_on_alert);
         checkboxEnableReraise = (CheckBox) findViewById(R.id.missed_reading_enable_alerts_reraise);
         /** xDrip used to use the other alerts sound file for the missed readings alert.
          * To avoid causing an unexpected behavior for a previous user of xDrip, the missed reading alert
@@ -107,12 +109,14 @@ public class MissedReadingActivity extends ActivityWithMenu {
         boolean allDay = prefs.getBoolean("missed_readings_all_day",true);
         boolean enableReraise = prefs.getBoolean("bg_missed_alerts_enable_alerts_reraise",false);
         boolean overrideSilentMode = prefs.getBoolean("bg_missed_alerts_override_silent", false);
+        boolean vibrateOnAlert = prefs.getBoolean("bg_missed_alerts_vibrate_on_alert", true);
         audioPath = Pref.getString("bg_missed_alerts_sound", null);
         
         checkboxAllDay.setChecked(allDay);
         checkboxEnableAlert.setChecked(enableAlert);
         checkboxEnableReraise.setChecked(enableReraise);
         checkboxOverrideSilent.setChecked(overrideSilentMode);
+        checkboxVibrateOnAlert.setChecked(vibrateOnAlert);
         
         startHour = AlertType.time2Hours(startMinutes);
         startMinute = AlertType.time2Minutes(startMinutes);
@@ -147,6 +151,7 @@ public class MissedReadingActivity extends ActivityWithMenu {
         prefs.edit().putBoolean("missed_readings_all_day", checkboxAllDay.isChecked()).apply();
         prefs.edit().putBoolean("bg_missed_alerts_enable_alerts_reraise", checkboxEnableReraise.isChecked()).apply();
         prefs.edit().putBoolean("bg_missed_alerts_override_silent", checkboxOverrideSilent.isChecked()).apply();
+        prefs.edit().putBoolean("bg_missed_alerts_vibrate_on_alert", checkboxVibrateOnAlert.isChecked()).apply();
 
         MissedReadingService.delayedLaunch();
       //  context.startService(new Intent(context, MissedReadingService.class));
@@ -163,6 +168,7 @@ public class MissedReadingActivity extends ActivityWithMenu {
         checkboxAllDay.setEnabled(enabled);
         checkboxEnableReraise.setEnabled(enabled);
         checkboxOverrideSilent.setEnabled(enabled);
+        checkboxVibrateOnAlert.setEnabled(enabled);
         bgMissedMinutes.setEnabled(enabled);
         bgMissedSnoozeMin.setEnabled(enabled);
         bgMissedReraiseSec.setEnabled(enabled);
@@ -218,6 +224,13 @@ public class MissedReadingActivity extends ActivityWithMenu {
         });
 
         checkboxOverrideSilent.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            // @Override
+            public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+                enableAllControls();
+            }
+        });
+
+        checkboxVibrateOnAlert.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             // @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
                 enableAllControls();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -997,6 +997,10 @@ public class Notifications extends IntentService {
         Boolean otherAlertsOverrideSilent = prefs.getBoolean("other_alerts_override_silent", false);
         Boolean extraAlertsOverrideSilent = prefs.getBoolean(type+"_override_silent", otherAlertsOverrideSilent); // Inherit from other alerts if the alert itself does not have a dedicated setting
 
+        // For bg_rise_alert and bg_fall_alert, the 'type' does not represent a real setting.
+        // In those cases, use the shared "other_alerts_vibrate_on_alert" preference instead.
+        boolean extraAlertsVibrateOnAlert = type.equals("bg_rise_alert") || type.equals("bf_fall_alert") ? prefs.getBoolean("other_alerts_vibrate_on_alert", true) : prefs.getBoolean(type+"_vibrate_on_alert", true);
+
         Log.d(TAG,"OtherAlert called " + type + " " + message + " reraiseSec = " + reraiseSec);
         UserNotification userNotification = UserNotification.GetNotificationByType(type); //"bg_unclear_readings_alert"
         if ((userNotification == null) || userNotification.timestamp <= new Date().getTime() ) {
@@ -1032,7 +1036,9 @@ public class Notifications extends IntentService {
                 deleteIntent.putExtra("raisedTimeStamp", JoH.tsl());
                 mBuilder.setDeleteIntent(PendingIntent.getService(context, 0, deleteIntent, PendingIntent.FLAG_UPDATE_CURRENT));
             }
-            mBuilder.setVibrate(vibratePattern);
+            if (extraAlertsVibrateOnAlert) {
+                mBuilder.setVibrate(vibratePattern);
+            }
             mBuilder.setLights(0xff00ff00, 300, 1000);
             if (AlertPlayer.notSilencedDueToCall()) {
                 if (extraAlertsOverrideSilent) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -997,9 +997,9 @@ public class Notifications extends IntentService {
         Boolean otherAlertsOverrideSilent = prefs.getBoolean("other_alerts_override_silent", false);
         Boolean extraAlertsOverrideSilent = prefs.getBoolean(type+"_override_silent", otherAlertsOverrideSilent); // Inherit from other alerts if the alert itself does not have a dedicated setting
 
-        // For bg_rise_alert and bg_fall_alert, the 'type' does not represent a real setting.
-        // In those cases, use the shared "other_alerts_vibrate_on_alert" preference instead.
-        boolean extraAlertsVibrateOnAlert = type.equals("bg_rise_alert") || type.equals("bf_fall_alert") ? prefs.getBoolean("other_alerts_vibrate_on_alert", true) : prefs.getBoolean(type+"_vibrate_on_alert", true);
+        // Let's create a local variable representing if there should be vibration for this alert or not.
+        // If 'type' does not correspond to a real setting, which will be the case for "other alerts", the Other_alerts_vibrate_on_alert setting will be used.
+        Boolean extraAlertsVibrateOnAlert = prefs.getBoolean(type+"_vibrate_on_alert", prefs.getBoolean("other_alerts_vibrate_on_alert", true));
 
         Log.d(TAG,"OtherAlert called " + type + " " + message + " reraiseSec = " + reraiseSec);
         UserNotification userNotification = UserNotification.GetNotificationByType(type); //"bg_unclear_readings_alert"

--- a/app/src/main/res/layout/activity_missed_readings.xml
+++ b/app/src/main/res/layout/activity_missed_readings.xml
@@ -314,6 +314,17 @@
                         android:layout_marginLeft="10dp"
                         android:gravity="left" />
 
+                    <CheckBox
+                        android:id="@+id/bg_missed_alerts_vibrate_on_alert"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/vibrate_on_alert"
+                        android:textSize="15sp"
+                        android:padding="5dp"
+                        android:layout_gravity="left"
+                        android:layout_marginLeft="10dp"
+                        android:gravity="left" />
+
                 </LinearLayout>
 
             </LinearLayout>

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -292,6 +292,10 @@
                         android:defaultValue="false"
                         android:key="other_alerts_override_silent"
                         android:title="@string/override_silent_mode_these" />
+                    <CheckBoxPreference
+                        android:defaultValue="true"
+                        android:key="other_alerts_vibrate_on_alert"
+                        android:title="@string/vibrate_on_alert" />
                 </PreferenceCategory>
             </PreferenceScreen>
             <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
@@ -347,6 +351,10 @@
                         android:defaultValue="false"
                         android:key="persistent_high_alert_override_silent"
                         android:title="@string/override_silent_mode" />
+                    <CheckBoxPreference
+                        android:defaultValue="true"
+                        android:key="persistent_high_alert_vibrate_on_alert"
+                        android:title="@string/vibrate_on_alert" />
                 </PreferenceScreen>
                 <PreferenceScreen
                     android:key="@string/forecasted_low_alert"
@@ -396,6 +404,10 @@
                         android:defaultValue="false"
                         android:key="bg_predict_alert_override_silent"
                         android:title="@string/override_silent_mode" />
+                    <CheckBoxPreference
+                        android:defaultValue="true"
+                        android:key="bg_predict_alert_vibrate_on_alert"
+                        android:title="@string/vibrate_on_alert" />
                 </PreferenceScreen>
                 <PreferenceScreen
                     android:key="@string/title_sens_expiry"


### PR DESCRIPTION
You can disable vibration only for glucose level alerts.
If you want to disable vibration for any of the extra alerts or for any member of 'other alerts' group, you will need to rely on notification channels.

This PR adds settings so that you can disable or enable vibration for any alert through xDrip settings.  
<br/>  

**How  to enable/disable vibration for each alert:**    
| Alert | Before | After | Setting |  
| ----- | ------- | ------ | ------------- |  
| Glucose level | Existing setting | Existing setting<br/> (no change) | ![Screenshot_20251016-152631](https://github.com/user-attachments/assets/f0dffda4-1441-4fd2-8069-66c293c2e68d) |  
| Missed reading | **Notification channel** | New setting | ![Screenshot_20251016-100320](https://github.com/user-attachments/assets/1e383198-1321-4d9f-a7d0-8b641d8cf4ca) |  
| Other alerts | **Notification channel** | New setting | ![Screenshot_20251016-152154](https://github.com/user-attachments/assets/37d2f967-da17-406c-aadc-e321f1199c6f) |  
| Persistent high | **Notification channel** | New setting | ![Screenshot_20251016-151823](https://github.com/user-attachments/assets/7f1fbea9-84b8-4b62-bacd-0d93fa6146dd) |  
| Forecasted low | **Notification channel** | New setting | ![Screenshot_20251016-154040](https://github.com/user-attachments/assets/a5eb345c-d57c-439d-a8b1-f4df4ee009dc) |  
<br/>  
  
This does not mean that you cannot use notification channels any longer.  It means you won't have to any longer.   