### PR TITLE
Identifying xDrip toast

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
@@ -252,7 +252,8 @@ public class Treatments extends Model {
         final long future_seconds = (timestamp - JoH.tsl()) / 1000;
         // if treatment more than 1 hour in the future
         if (future_seconds > (60 * 60)) {
-            JoH.static_toast_long("Refusing to create a treatement more than 1 hours in the future!");
+            JoH.static_toast_long(xdrip.gs(R.string.toast_treatment_more_than_one_hour_in_the_future));
+            UserError.Log.e(TAG, "Refusing to create a treatment more than 1 hour in the future!");
             return null;
         }
         // if treatment more than 3 minutes in the future

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1641,6 +1641,7 @@
     <string name="calibrate">Calibrate</string>
     <string name="confirm_delete">Confirm Delete</string>
     <string name="are_you_sure_you_want_to_delete_this_treatment">Are you sure you want to delete this Treatment?</string>
+    <string name="toast_treatment_more_than_one_hour_in_the_future">xDrip cannot accept treatments more than one hour in the future.</string>
     <string name="no_data_received_from_master_yet">No data received from master yet</string>
     <string name="last_from_master_">Last from master: </string>
     <string name="prepare_to_test">Prepare to test!</string>


### PR DESCRIPTION
When a user updates the times on their devices inconsistently, treatments coming from the pump could seem to be in the future triggering this toast message:
![572216657_25750115321279549_4367384002501104853_n](https://github.com/user-attachments/assets/cfbdd604-7dcd-4ad4-a398-d9f048bdd1af)  
  
This PR adds xDrip to the toast so that it would be clear which app it is from.
It also adds it for translation.
It also creates a corresponding log so that the user can see the entire text in case they cannot read the entire toast since the toast is visible for a very short amount of time.