### PR TITLE
Libre: add Libre2 source info identifier to processed L2 readings for oop as well.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/LibreAlarmReceiver.java
@@ -74,7 +74,7 @@ public class LibreAlarmReceiver extends BroadcastReceiver {
 
     private static void createBGfromGD(GlucoseData gd, boolean use_smoothed_data, boolean quick) {
         final double converted;
-        String sourceInfo = "";
+        String sourceInfo = null;
         if (useGlucoseAsRaw()) {
             // if treating converted value as raw
             if (gd.glucoseLevel > 0) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
@@ -484,7 +484,7 @@ public class BgReading extends Model implements ShareUploadableBg {
     }
 
     public static BgReading create(double raw_data, double filtered_data, Context context, Long timestamp, boolean quick) {
-        return create(raw_data, filtered_data, context, timestamp, quick, "");
+        return create(raw_data, filtered_data, context, timestamp, quick, null);
     }
 
     public static BgReading create(double raw_data, double filtered_data, Context context, Long timestamp, boolean quick, String source_info) {


### PR DESCRIPTION
This is following Commit f6bd8e5

See https://github.com/NightscoutFoundation/xDrip/issues/3841 for background