### PR TITLE
Partially get the Pebble integration running again

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayStandard.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayStandard.java
@@ -104,17 +104,12 @@ public class PebbleDisplayStandard extends PebbleDisplayAbstract {
 
 
     public void sendDownload() {
-        if (PebbleKit.isWatchConnected(this.context)) {
+        PebbleDictionary dictionary = buildDictionary();
 
-            PebbleDictionary dictionary = buildDictionary();
-
-            if (dictionary != null && this.context != null) {
-                Log.d(TAG, "sendDownload: Sending data to pebble");
-                sendDataToPebble(dictionary);
-                last_time_seen = JoH.ts();
-            }
-        } else {
-            watchdog();
+        if (dictionary != null && this.context != null) {
+            Log.d(TAG, "sendDownload: Sending data to pebble");
+            sendDataToPebble(dictionary);
+            last_time_seen = JoH.ts();
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayTrend.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayTrend.java
@@ -516,58 +516,55 @@ public class PebbleDisplayTrend extends PebbleDisplayAbstract {
         try {
             if (lock.tryLock(60, TimeUnit.SECONDS)) {
                 try {
+                    if (d) Log.d(TAG, "Sendstep: " + sendStep);
+                    if (sendStep == 5) {
+                        sendStep = 0;
+                        done = false;
+                        clearDictionary();
+                    }
 
-                    if (PebbleKit.isWatchConnected(this.context)) {
-                        if (d) Log.d(TAG, "Sendstep: " + sendStep);
-                        if (sendStep == 5) {
-                            sendStep = 0;
-                            done = false;
-                            clearDictionary();
+                    if (d)
+                        Log.i(TAG, "sendData: messageInTransit= " + messageInTransit + ", transactionFailed= " + transactionFailed + ", sendStep= " + sendStep);
+                    if (sendStep == 0 && !messageInTransit && !transactionOk && !transactionFailed) {
+
+                        if (use_best_glucose) {
+                            this.dg = BestGlucose.getDisplayGlucose();
+                            } else {
+                            this.bgReading = BgReading.last();
                         }
 
+                        sendingData = true;
+                        buildDictionary();
+                        sendDownload();
+                    }
+
+
+                    if (sendStep == 0 && !messageInTransit && transactionOk && !transactionFailed) {
+                        if (d) Log.i(TAG, "sendData: sendStep 0 complete, clearing dictionary");
+                        clearDictionary();
+                        transactionOk = false;
+                        sendStep = 1;
+                    }
+                    if (sendStep > 0 && sendStep < 5) {
+                        if (!doWeDisplayTrendData()) {
+                            if (didTrend) {
+                                sendTrendToPebble(true); // clear trend image
+                            } else {
+                                sendStep = 5;
+                            }
+                        } else {
+                            sendTrendToPebble(false);
+                        }
+                    }
+
+                    if (sendStep == 5) {
                         if (d)
-                            Log.i(TAG, "sendData: messageInTransit= " + messageInTransit + ", transactionFailed= " + transactionFailed + ", sendStep= " + sendStep);
-                        if (sendStep == 0 && !messageInTransit && !transactionOk && !transactionFailed) {
-
-                            if (use_best_glucose) {
-                                this.dg = BestGlucose.getDisplayGlucose();
-                            } else {
-                                this.bgReading = BgReading.last();
-                            }
-
-                            sendingData = true;
-                            buildDictionary();
-                            sendDownload();
-                        }
-
-
-                        if (sendStep == 0 && !messageInTransit && transactionOk && !transactionFailed) {
-                            if (d) Log.i(TAG, "sendData: sendStep 0 complete, clearing dictionary");
-                            clearDictionary();
-                            transactionOk = false;
-                            sendStep = 1;
-                        }
-                        if (sendStep > 0 && sendStep < 5) {
-                            if (!doWeDisplayTrendData()) {
-                                if (didTrend) {
-                                    sendTrendToPebble(true); // clear trend image
-                                } else {
-                                    sendStep = 5;
-                                }
-                            } else {
-                                sendTrendToPebble(false);
-                            }
-                        }
-
-                        if (sendStep == 5) {
-                            if (d)
-                                Log.i(TAG, "sendData: finished sending.  sendStep = " + sendStep);
-                            done = true;
-                            transactionFailed = false;
-                            transactionOk = false;
-                            messageInTransit = false;
-                            sendingData = false;
-                        }
+                            Log.i(TAG, "sendData: finished sending.  sendStep = " + sendStep);
+                        done = true;
+                        transactionFailed = false;
+                        transactionOk = false;
+                        messageInTransit = false;
+                        sendingData = false;
                     }
 
                 } catch (Exception e) {


### PR DESCRIPTION
`PebbleKit.isWatchConnected` seems to just return false even with a watch connected. Removing the check makes the Pebble integration work again, at least on some watches and for some watchfaces.

I'm using a Pebble 2 Duo watch (fw v4.9.91) and the new Pebble app (1.0.6.9):

<img width="600" alt="image" src="https://github.com/user-attachments/assets/5d478903-1e86-414f-b58c-846feeabbdae" />

I'm not sure if there's any drawbacks to removing the check.

When enabling the Pebble integration in xDrip settings, it prompts to install the corresponding watchface. Accepting just crashes the Pebble app, so instead, I've installed the watchface manually `pebble install --phone 192.168.1.40 app/src/main/res/raw/xdrip_pebble.bin` which works fine. I'll probably look into that later.

The indentation change makes the diff look huge but it's actually just -8 lines, such as:

<img width="1778" height="808" alt="image" src="https://github.com/user-attachments/assets/c4b86992-4a15-4f86-a7e3-8a0f0d864b47" />

I intend to keep hacking to see if I can get more stuff running like glucose graph watchfaces.