### PR TITLE
Fix Pebble watchface install

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/watchface/InstallPebbleWatchFace.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/watchface/InstallPebbleWatchFace.java
@@ -137,7 +137,7 @@ public class InstallPebbleWatchFace extends BaseAppCompatActivity {
             Intent intent = new Intent(Intent.ACTION_VIEW);
             Uri uri = FileProvider.getUriForFile(this.getApplicationContext(), this.getPackageName() + ".provider", new File(dest_filename));
             intent.setDataAndType(uri, "application/octet-stream");
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
             startActivity(intent);
 
         } catch (Exception e) {


### PR DESCRIPTION
The new Pebble app crashes with `SecurityException: Permission Denial` when trying to install a Pebble watchface from xDrip.

This change allows Pebble to actually read the watchface file we're providing it. Now the Pebble integration flow works pretty good, you enable Pebble, say yes to the install, and it "just works."

I still haven't gotten all watchfaces to run. Might have to do with target hardware platforms or something. One step at a time :)

---

Three out of the four watchfaces available in xDrip work on my setup now:

* [x] Standard Watchface (old) -> works!
* [x] Color Trend Watchface -> works!
* [x] Pebble Classic Trend Watchface -> works, and has graph!
* [ ] Pebble Trend Clay Version (test) -> does not work, "loading" screen forever