### PR TITLE
Silencing the alert-in-the-past log

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -37,7 +37,6 @@ import com.eveningoutpost.dexdrip.models.Calibration;
 import com.eveningoutpost.dexdrip.models.CalibrationRequest;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.Sensor;
-import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import com.eveningoutpost.dexdrip.models.UserNotification;
 import com.eveningoutpost.dexdrip.R;
@@ -452,7 +451,7 @@ public class Notifications extends IntentService {
                 if (wakeTimeBg < now) {
                     // next alert should be at least one minute from now.
                     wakeTimeBg = now + 60000;
-                    UserError.Log.d(TAG, "setting next alert to 1 minute from now (no problem right now, but needs a fix someplace else)");
+                    Log.d(TAG, "setting next alert to 1 minute from now (no problem right now, but needs a fix someplace else)");
                 }
                 
             }


### PR DESCRIPTION
This log appears occasionally.

I wish I could say I have figured out why and have stopped it from happening.
All I know is that the user cannot do anything about it.  Yet, the log is seen by many and some ask why:
<img width="697" height="301" alt="Screenshot 2025-12-07 182937" src="https://github.com/user-attachments/assets/e8b4911a-a19e-4bfa-9c38-5817d5402dae" />
  
This PR changes the log to silent so that it is not visible by default.  .