### PR TITLE
Y axis auto range control

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
@@ -57,6 +57,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -970,6 +971,26 @@ public class BgReading extends Model implements ShareUploadableBg {
                 .orderBy("timestamp asc")
                 .limit(number)
                 .execute();
+    }
+
+    public static List<BgReading> latestForGraphAscNewest(int number, long startTime, long endTime) {
+        // If the number of readings in the specified period exceeds the limit, keep the most recent readings.
+        List<BgReading> list = new Select()
+                .from(BgReading.class)
+                .where("timestamp >= " + Math.max(startTime, 0))
+                .where("timestamp <= " + endTime)
+                .where("calculated_value != 0")
+                .where("raw_data != 0")
+                .orderBy("timestamp desc") // get newest first
+                .limit(number)
+                .execute();
+
+        // Restore ascending order for graph logic
+        if (list != null) {
+            Collections.reverse(list);
+        }
+
+        return list;
     }
 
     public static BgReading readingNearTimeStamp(long startTime) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
@@ -79,5 +79,6 @@ public class Constants {
     public static final int LIBREPRO_HEADER1_SIZE = 40;
     public static final int LIBREPRO_HEADER2_SIZE = 32;
     public static final int LIBREPRO_HEADER3_SIZE = 104;
+    public static final int MAX_READINGS_PER_HOUR = 60; // Upper bound on readings per hour xDrip may receive
 
 }


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/2173  
  
Goes through all the readings of the last 3 hours in sequence and anchors the vertical window to the latest local max or min.  
Uses the delta between the user-specified Ymin and Ymax as span.  Creates the graph limited to the anchor and the span in the opposite direction.  
Readings that are beyond the extent of span are left out and not shown on screen by default.  

If the distance between local max and min is more than span, gives priority to the latest.
If the distance between the latest min/max and the latest reading is greater than span, gives priority to the latest reading.  
If there have been any readings beyond the Ymax-Ymin range during the past 24 hours, vertical panning becomes possible limited to the smallest and greatest readings during the past 24 hours.  

Manual vertical panning is automatically undone exactly at the same time manual horizontal panning is undone.  

| Master 2025.12.13 Nightly <br/> min: 60, max: 210 | Follower 2025.12.13 + this PR <br/> min: 60, max: 210 | Same follower <br/> min: 70, max: 210 |  Same follower <br/> min: 70, max: 210 <br/>  Manual pan up |  
| ----------------------------- | --------------------------------- | --------------------------------- | ------- |  
| <img width="270" height="575" alt="m1" src="https://github.com/user-attachments/assets/add72057-534b-48c8-9f5f-e3c06e2442d8" /> | <img width="270" height="540" alt="f1" src="https://github.com/user-attachments/assets/97792ccc-e18c-4e74-9791-aff1105a66b3" /> | | |  
| <img width="270" height="575" alt="2m" src="https://github.com/user-attachments/assets/7cf3ff9d-f03b-45d0-a0b9-e3dc3dde707e" /> | <img width="270" height="540" alt="2f" src="https://github.com/user-attachments/assets/a05de8e2-04e7-4600-8eb3-fba11e2b6e8e" /> | | |  
| <img width="270" height="575" alt="3m" src="https://github.com/user-attachments/assets/336b1971-2b96-4fba-abdb-336b58d78a53" /> | <img width="270" height="540" alt="f3" src="https://github.com/user-attachments/assets/95d66c30-5c21-4106-a719-20596f6e1c0e" /> | <img width="270" height="540" alt="f3b" src="https://github.com/user-attachments/assets/5fef9403-e7a8-4861-bf6e-823626f9412d" /> | |   
| <img width="270" height="575" alt="m4" src="https://github.com/user-attachments/assets/46625004-e9be-4558-ae5d-1f8f1e61b8e6" /> | <img width="270" height="540" alt="f4" src="https://github.com/user-attachments/assets/a04269c0-55d4-4970-8c27-764736a14d67" /> | <img width="270" height="540" alt="f4b" src="https://github.com/user-attachments/assets/961830bc-50d7-4ee6-a608-19ece3ac7d21" /> | |  
| <img width="270" height="575" alt="m5" src="https://github.com/user-attachments/assets/400fe9fb-2676-4fab-a9a0-806de58d7930" /> | <img width="270" height="540" alt="f5" src="https://github.com/user-attachments/assets/881ce694-f5c5-4d4b-ad13-9ab8b14784a9" /> | | <img width="270" height="540" alt="f5b" src="https://github.com/user-attachments/assets/ebaabd9d-1266-4866-805c-0271b7b2b1dd" /> |  


