### PR TITLE
Avoid JitPack SNAPSHOT

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -308,7 +308,7 @@ dependencies {
     implementation ("androidx.health.connect:connect-client:1.1.0-alpha06") {
         exclude group: 'androidx.core', module: 'core'
     }
-    implementation 'com.github.jamorham:amazfitcommunication:master-SNAPSHOT'
+    implementation 'com.github.jamorham:amazfitcommunication:1.0'
     implementation 'io.reactivex:rxjava:1.3.3'
     implementation "com.polidea.rxandroidble2:rxandroidble:1.12.1"
     implementation 'com.google.guava:guava:24.1-android'


### PR DESCRIPTION
Build currently fails because the JitPack master-SNAPSHOT artifact for
com.github.jamorham:amazfitcommunication can no longer be resolved.  

<img width="1084" height="121" alt="Screenshot 2025-12-28 105559" src="https://github.com/user-attachments/assets/46626e8c-2bf2-443b-a6c3-2dcafcfb5645" />
 
This change pins the dependency to a released version so the project can be compiled again.  