### PR TITLE
Companion: Read IoB from german MiniMed Mobile EU companion app

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
@@ -149,6 +149,8 @@ public class UiBasedCollector extends NotificationListenerService {
         companionAppIoBRegexes.add(Pattern.compile("IOB: ([\\d\\.,]+) U"));
         // MiniMed Mobile (EU): "Active Insulin" label and "1.234 U" value in separate TextViews
         companionAppIoBRegexes.add(Pattern.compile("^([\\d\\.]+) U$"));
+        // MiniMed Mobile (EU): "Aktives Insulin" label and "1,234 IE" value in separate TextViews
+        companionAppIoBRegexes.add(Pattern.compile("^([\\d\\,]+) IE$"));
     }
 
     @Override


### PR DESCRIPTION
The notification of the MiniMed Mobile EU companion app will be translated using the system locale. For german the IoB value will be shown as "Actives Insulin 1.234 IE".
Extend the companion app IoB regex to also read the IoB value in this case.

see https://github.com/NightscoutFoundation/xDrip/discussions/4316