### PR TITLE
Store companion app IoB in PumpStatus

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
@@ -22,9 +22,9 @@ import com.eveningoutpost.dexdrip.g5model.DexSessionKeeper;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.services.SyncService;
-import com.eveningoutpost.dexdrip.services.UiBasedCollector;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+import com.eveningoutpost.dexdrip.utilitymodels.PumpStatus;
 import com.eveningoutpost.dexdrip.utilitymodels.UndoRedo;
 import com.eveningoutpost.dexdrip.utilitymodels.UploaderQueue;
 import com.eveningoutpost.dexdrip.insulin.Insulin;
@@ -1313,9 +1313,8 @@ public class Treatments extends Model {
     }
 
     public static Double getCurrentIoBFromCompanionApp() {
-        Double iob = UiBasedCollector.getCurrentIoB();
-
-        return iob;
+        // UiBasedCollector reads IoB data from companion apps and saves it to PumpStatus.
+        return PumpStatus.getBolusIoB();
     }
 
     public static Double getCurrentIoBFromGraphCalculation() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
@@ -35,6 +35,7 @@ import com.eveningoutpost.dexdrip.models.Sensor;
 import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
+import com.eveningoutpost.dexdrip.utilitymodels.PumpStatus;
 import com.eveningoutpost.dexdrip.utilitymodels.Unitized;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.xdrip;
@@ -58,8 +59,6 @@ public class UiBasedCollector extends NotificationListenerService {
     private static final String UI_BASED_STORE_LAST_VALUE = "UI_BASED_STORE_LAST_VALUE";
     private static final String UI_BASED_STORE_LAST_REPEAT = "UI_BASED_STORE_LAST_REPEAT";
     private static final String COMPANION_APP_IOB_ENABLED_PREFERENCE_KEY = "fetch_iob_from_companion_app";
-    private static final Persist.DoubleTimeout iob_store =
-            new Persist.DoubleTimeout("COMPANION_APP_IOB_VALUE", Constants.MINUTE_IN_MS * 5);
     private static final String ENABLED_NOTIFICATION_LISTENERS = "enabled_notification_listeners";
     private static final String ACTION_NOTIFICATION_LISTENER_SETTINGS = "android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS";
 
@@ -194,7 +193,7 @@ public class UiBasedCollector extends NotificationListenerService {
 
             if (iob != null) {
                 if (debug) UserError.Log.d(TAG, "Inserting new IoB value extracted from title: " + iob);
-                iob_store.set(iob);
+                PumpStatus.setBolusIoB(iob);
             }
         } catch (Exception e) {
             UserError.Log.e(TAG, "exception in processCompanionAppIoBNotificationTitle: " + e);
@@ -222,7 +221,7 @@ public class UiBasedCollector extends NotificationListenerService {
 
             if (iob != null) {
                 if (debug) UserError.Log.d(TAG, "Inserting new IoB value extracted from CV: " + iob);
-                iob_store.set(iob);
+                PumpStatus.setBolusIoB(iob);
             }
         } catch (Exception e) {
             UserError.Log.e(TAG, "exception in processCompanionAppIoBNotificationCV: " + e);
@@ -241,10 +240,6 @@ public class UiBasedCollector extends NotificationListenerService {
         }
 
         return null;
-    }
-
-    public static Double getCurrentIoB() {
-        return iob_store.get();
     }
 
     @Override

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/PumpStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/PumpStatus.java
@@ -55,7 +55,7 @@ public class PumpStatus {
         setValue(PUMP_BOLUSIOB, value);
     }
 
-    private static double getBolusIoB() {
+    public static double getBolusIoB() {
         return getValue(PUMP_BOLUSIOB);
     }
 


### PR DESCRIPTION
I previously added IoB fetching from the Minimed companion app in https://github.com/NightscoutFoundation/xDrip/pull/4287. IoB from the Omnipod app was already supported. The IoB was stored inside the UiBasedCollector class.

I suppose it's likely that all companion app IoB sources are pumps, so I think this change is reasonable. Maybe if someone makes an insulin pen with an app, I'll have to reconsider.

This change saves companion app IoB data to PumpStatus instead. That makes it possible to display it on the home screen with the existing "extra status line pump status" setting:

<img width="405" height="648" alt="image" src="https://github.com/user-attachments/assets/e71d0b42-a65c-4c35-9719-08bc4c64a47e" />
