### PR TITLE
Fixes #3792

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
@@ -241,6 +241,10 @@ public class NightscoutUploader {
     }
 
     public static String uuid_to_id(String uuid) {
+        if (uuid.contains(":")) {
+            // convert non-standard uuids to compatible ones
+            return CipherUtils.getMD5(uuid).substring(0, 24);
+        }
         if (uuid.length() == 24) return uuid; // already converted
         if (uuid.length() < 24) {
             // convert non-standard uuids to compatible ones


### PR DESCRIPTION
Fixes the issue via addition of additional checks to confirm that uuid_to_id has been correctly converted when delivered insulin from NFC Novo Pen is more that 10 units