### PR TITLE
Add a Traditional Chinese language option

### DIFF
--- a/app/src/main/res/values/locales.xml
+++ b/app/src/main/res/values/locales.xml
@@ -23,6 +23,7 @@
         <item>עברית</item>
         <item>한국어</item>
         <item>Українська</item>
+        <item>繁體中文</item>
     </string-array>
     <string-array name="LocaleChoicesValues">
         <item>bg</item>
@@ -47,5 +48,6 @@
         <item>iw</item>
         <item>ko</item>
         <item>uk</item>
+        <item>zh-TW</item>
     </string-array>
 </resources>


### PR DESCRIPTION


Following up on the discussion in #3498, The Chinese Traditional localization has been completed in [Crowdin](https://crowdin.com/project/xdrip/zh-TW), and I have submitted a PR to add the zh-TW option. 
(The test image at the bottom shows the newly added language for this update.)

![Screenshot_20260127_221436](https://github.com/user-attachments/assets/0291c370-859a-4edb-9d85-b217344e2e4f)
