### PR TITLE
Check for update dialog

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -3607,7 +3607,7 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         if (JoH.ratelimit("manual-update-check", 5)) {
             toast(getString(R.string.checking_for_update));
             UpdateActivity.last_check_time = -1;
-            UpdateActivity.checkForAnUpdate(getApplicationContext(), true);
+            UpdateActivity.checkForAnUpdate(this, true);
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/UpdateActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/UpdateActivity.java
@@ -3,6 +3,7 @@ package com.eveningoutpost.dexdrip.utilitymodels;
 // jamorham
 
 import android.Manifest;
+import android.app.Activity;
 import android.app.DownloadManager;
 import android.content.Context;
 import android.content.Intent;
@@ -15,6 +16,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
@@ -184,7 +186,17 @@ public class UpdateActivity extends BaseAppCompatActivity {
                                 } else {
                                     Log.i(TAG, "Our current version is the most recent: " + versionnumber + " vs " + newversion);
                                     if (fromUi) { // Only for manual update check
-                                        JoH.static_toast_long(xdrip.gs(R.string.current_version_is_up_to_date));
+                                        if (channel.equals("nightly")) {
+                                            JoH.static_toast_long(xdrip.gs(R.string.current_version_is_up_to_date));
+                                        } else {
+                                            ((Activity) context).runOnUiThread(() -> {
+                                                AlertDialog.Builder builder = new AlertDialog.Builder(context);
+                                                builder.setTitle(context.getString(R.string.title_dialog_check_for_update, channel));
+                                                builder.setMessage(context.getString(R.string.message_dialog_check_for_update));
+                                                builder.setPositiveButton(R.string.close, null);
+                                                builder.show();
+                                            });
+                                        }
                                     }
                                 }
                             } catch (Exception e) {
@@ -283,16 +295,14 @@ public class UpdateActivity extends BaseAppCompatActivity {
     }
 
     private boolean checkPermissions() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (ContextCompat.checkSelfPermission(getApplicationContext(),
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    != PackageManager.PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(getApplicationContext(),
+                Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
 
-                ActivityCompat.requestPermissions(this,
-                        new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                        MY_PERMISSIONS_REQUEST_STORAGE_DOWNLOAD);
-                return false;
-            }
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    MY_PERMISSIONS_REQUEST_STORAGE_DOWNLOAD);
+            return false;
         }
         return true;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,7 +201,9 @@
     <string name="libre_last_x_minutes_graph">Libre last %d minutes graph</string>
     <string name="share_config_via_qr_code">Share config via QR code</string>
     <string name="check_for_updated_version">Check for updated version</string>
-    <string name="current_version_is_up_to_date">No update in the selected channel</string>
+    <string name="current_version_is_up_to_date">You have the most recent xDrip version</string>
+    <string name="title_dialog_check_for_update">No update in %1$s channel</string>
+    <string name="message_dialog_check_for_update">A newer version may exist in other channels.</string>
     <string name="send_feedback_to_developer">Send Feedback to developers</string>
     <string name="home_screen">Home Screen</string>
     <string name="event_logs">Event Logs</string>


### PR DESCRIPTION
Everyday, there is a post in facebook asking for help by someone who needs to update.
When they are told to update, they say they are using the latest version.
After a lot of time is spent asking them to show the status page, it turns out they are using the stable release.

This PR adds a dialog that comes up only if the user is not using the Nightly channel and there is no update.  It stays on the screen until the user taps on close.
This should inform the user that even though there is no update in their current channel, they may still be able to get an update using other channels. 

If the user is using the Nightly channel and there is no update, this is the toast message they will see:
<img width="259" height="518" alt="Screenshot_20260213-000950" src="https://github.com/user-attachments/assets/0f02343c-a2ea-4109-b480-9703a1ee0bcd" />

If the user is on a channel other than Nightly and there is no update, this is the dialog they will see:
<img width="259" height="518" alt="Screenshot_20260213-001044" src="https://github.com/user-attachments/assets/aa89d78f-d0c5-441c-9b55-b321c600402a" />
  
In other words, there is no change if there is an update or if the user is in the Nightly channel.  In the latter case, the toast message is slightly changed.  
Only if the user is not in the Nightly channel and only if there is no update, there will be no toast message.  Instead there will be a dialog the user will have to tap on to close.  