### PR TITLE
Database restore warning improvement

### DIFF
--- a/app/src/main/res/layout/import_db_warning.xml
+++ b/app/src/main/res/layout/import_db_warning.xml
@@ -5,7 +5,11 @@
 
     <LinearLayout
         android:layout_width="fill_parent"
-        android:layout_height="fill_parent" >
+        android:layout_height="fill_parent"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp">
 
         <TextView
             android:id="@+id/textmsg"

--- a/app/src/main/res/values/internal.xml
+++ b/app/src/main/res/values/internal.xml
@@ -4,12 +4,13 @@
     <string name="pref_I_understand_title"> I UNDERSTAND AND AGREE</string>
     <string name="pref_I_understand_summery" translatable="false">xDrip+ MUST NOT BE USED TO MAKE MEDICAL DECISIONS. IT IS A RESEARCH TOOL ONLY AND IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</string>
     <string name="import_db_warning">
-        WARNING: Database restore is rarely necessary and may cause SEVERE DATA LOSS.\n
-        Protect your data by uploading to Nightscout or Tidepool.\n
-        When switching phones, import settings (alerts, colors, etc.) — do not restore the database.\n\n
-        Instructions:\n
-        Place the database in the \'xdrip\' folder. If it doesn\’t exist, perform an export once to create it.\n
-        Restart this restore routine.  Select the correct database and follow the on-screen instructions.
+        WARNING: Database restore is rarely necessary and may cause SEVERE DATA LOSS.\n\n
+        Protect your data by uploading to Nightscout or Tidepool.\n\n
+        When switching phones, importing settings (alerts, colors, etc.) is usually sufficient. Restoring the database is typically unnecessary unless you need short-term access to historical data (for example, before a medical visit).\n\n\n
+        Instructions:\n\n
+        - Place the database in the \'xdrip\' folder. If it doesn\’t exist, perform an export once to create it.\n\n
+        - Restart this restore routine.\n\n
+        - Select the correct database and follow the on-screen instructions.
     </string>
 
     <string name="importanttext">Do NOT use or rely on this software or any associated materials for any medical purpose or decision.\n\nDo NOT rely on this system for any real-time alarms or time critical data.\n\nDo NOT use or rely on this system for treatment decisions or use as a substitute for professional healthcare judgement.\n\nAll software and materials have been provided for informational purposes only as a proof of concept to assist possibilities for further research.\n\nNo claims at all are made about fitness for any purpose and everything is provided \"AS IS\". Any part of the system can fail at any time.\n\nAlways seek the advice of a qualified healthcare professional for any medical questions.\n\nAlways follow your glucose-sensor or other device manufacturers\' instructions when using any equipment; do not discontinue use of accompanying reader or receiver, other than as advised by your doctor.\n\nThis software is not associated with or endorsed by any equipment manufacturer and all trademarks are those of their respective owners.\n\nYour use of this software is entirely at your own risk.\n\nNo charge has been made by the developers for the use of this software.\n\nThis is an open-source project which has been created by volunteers. The source code is published free and open-source for you to inspect and evaluate.\n\nBy using this software and/or website you agree that you are over 18 years of age and have read, understood and agree to all of the above.\n</string>


### PR DESCRIPTION
This conversation reminded me that we need to better inform users that xDrip is not the best place for maintaining the data:  
https://github.com/NightscoutFoundation/xDrip/discussions/4386 

The following shows before and after side by side.
<img width="259" height="576" alt="Screenshot_20260215-181538" src="https://github.com/user-attachments/assets/6e9e84cc-ef51-45e5-b02b-b8c3c226f64a" /> <img width="259" height="576" alt="Screenshot_20260223-224017" src="https://github.com/user-attachments/assets/5a1f3a31-20fb-485f-b1a1-94f229def88d" />




Currently, the text is so long that some may not even bother reading it all.  
Please let me know if you want me to fine-tune this more or emphasize any particular aspect better.  

It is my hope that we can add to the Google Drive backup feature the ability to only backup or only restore settings.  But, that would be a different PR.  