### PR TITLE
Glucose retention default

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/DailyIntentService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/DailyIntentService.java
@@ -117,7 +117,7 @@ public class DailyIntentService extends IntentService {
                 }
 
                 try {
-                    final int bg_retention_days = Pref.getStringToInt("retention_days_bg_reading", 0);
+                    final int bg_retention_days = Pref.getStringToInt("retention_days_bg_reading", 180);
                     if (bg_retention_days > 0) {
                         BgReading.cleanup(bg_retention_days);
                         try {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1110,7 +1110,7 @@
     <string name="title_Batterylog">Batterylog</string>
     <string name="summary_Choose_to_display_the_bridge_battery_level">Choose to display the bridge battery level</string>
     <string name="title_Glucose_Retention">Glucose Retention</string>
-    <string name="summary_Erase_data_older_than_this_many_days">Erase data older than this many days. 0 = don\'t erase anything</string>
+    <string name="summary_Erase_data_older_than_this_many_days">Erase data older than this many days. Setting 0 will keep all data, but xDrip should not be used as a repository — use Nightscout or Tidepool for long-term storage.</string>
     <string name="title_Other_misc_options">Other misc. options</string>
     <string name="summary_allow_testing_with_dead_sensor">allow testing with dead sensor</string>
     <string name="title_NOT_FOR_PRODUCTION_USE">NOT FOR PRODUCTION USE</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1527,7 +1527,7 @@
                 android:summary="@string/allow_daily_db_save"
                 android:title="@string/daily_save_db" />
             <EditTextPreference
-                android:defaultValue="0"
+                android:defaultValue="180"
                 android:key="retention_days_bg_reading"
                 android:max="366"
                 android:numeric="integer"


### PR DESCRIPTION
There are many users who have no idea this setting exists.  Yet, they will retain their data forever.
This is not a good idea.  We should use a Cloud service as a repository instead of xDrip.
The data in xDrip should be thought of as an already backed-up data so that losing it would not be a catastrophe.

If this is approved and merged, I will announce it so that old-time users are aware of the change.
We are not changing anything really.  Anyone could still choose to set it to 0.  

Before and after are shown below.
<img width="302" height="672" alt="Screenshot_20260215-215417" src="https://github.com/user-attachments/assets/f4e98188-9001-4cf4-a421-0b199653427d" /> <img width="302" height="672" alt="Screenshot_20260215-215519" src="https://github.com/user-attachments/assets/c63165b6-00e2-4085-a0e4-1146c67db225" />

I chose 6 months.  But, I can change it if you prefer a different value.  As long as it is not 0 and more than 90 days, we should be OK.  Please let me know.  