### PR TITLE
Add schedule option for Speak Readings and Speak Alerts

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
@@ -35,6 +35,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.pebble.PebbleWatchSync;
 import com.eveningoutpost.dexdrip.eassist.AlertTracker;
 import com.eveningoutpost.dexdrip.ui.FlashLight;
 import com.eveningoutpost.dexdrip.ui.helpers.AudioFocusType;
+import com.eveningoutpost.dexdrip.utils.BgToSpeech;
 import com.eveningoutpost.dexdrip.utils.PowerStateReceiver;
 import com.eveningoutpost.dexdrip.watch.lefun.LeFun;
 import com.eveningoutpost.dexdrip.watch.lefun.LeFunEntry;
@@ -628,8 +629,8 @@ public class AlertPlayer {
             BroadcastEntry.sendAlert(Const.BG_ALERT_TYPE, highlow + " " + bgValue);
         }
 
-        // speak alert
-        if (Pref.getBooleanDefaultFalse("speak_alerts")) {
+        // speak alert (respects speak readings schedule if enabled)
+        if (Pref.getBooleanDefaultFalse("speak_alerts") && BgToSpeech.isWithinSchedule()) {
             SpeechUtil.say(highlow + ", " + bgValue, 3000);
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -46,6 +46,7 @@ import com.eveningoutpost.dexdrip.services.MissedReadingService;
 import com.eveningoutpost.dexdrip.services.SnoozeOnNotificationDismissService;
 import com.eveningoutpost.dexdrip.evaluators.PersistentHigh;
 import com.eveningoutpost.dexdrip.ui.NumberGraphic;
+import com.eveningoutpost.dexdrip.utils.BgToSpeech;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.utils.PowerStateReceiver;
 import com.eveningoutpost.dexdrip.wearintegration.Amazfitservice;
@@ -937,7 +938,7 @@ public class Notifications extends IntentService {
         if (on) {
             if ((Pref.getLong("alerts_disabled_until", 0) < JoH.tsl()) && (Pref.getLong("low_alerts_disabled_until", 0) < JoH.tsl())) {
                 OtherAlert(context, type, msg, lowPredictAlertNotificationId, NotificationChannels.BG_PREDICTED_LOW_CHANNEL, false, 20 * 60);
-                if (Pref.getBooleanDefaultFalse("speak_alerts")) {
+                if (Pref.getBooleanDefaultFalse("speak_alerts") && BgToSpeech.isWithinSchedule()) {
                    if (JoH.pratelimit("low-predict-speak", 1800)) SpeechUtil.say(msg, 4000);
                 }
             } else {
@@ -963,7 +964,7 @@ public class Notifications extends IntentService {
                 if (snooze_time < 1) snooze_time = 1;       // not less than 1 minute
                 if (snooze_time > 1440) snooze_time = 1440; // not more than 1 day
                 OtherAlert(context, type, msg, persistentHighAlertNotificationId, NotificationChannels.BG_PERSISTENT_HIGH_CHANNEL, false, snooze_time * 60);
-                if (Pref.getBooleanDefaultFalse("speak_alerts")) {
+                if (Pref.getBooleanDefaultFalse("speak_alerts") && BgToSpeech.isWithinSchedule()) {
                     if (JoH.pratelimit("persist-high-speak", 1800)) {
                         SpeechUtil.say(msg, 4000);
                     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/BgToSpeech.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/BgToSpeech.java
@@ -14,6 +14,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.VehicleMode;
 import com.eveningoutpost.dexdrip.xdrip;
 
 import java.text.DecimalFormat;
+import java.util.Calendar;
 
 import static com.eveningoutpost.dexdrip.utilitymodels.SpeechUtil.TWICE_DELIMITER;
 
@@ -55,6 +56,11 @@ public class BgToSpeech implements NamedSliderProcessor {
             return;
         }
 
+        // If a schedule is enabled, ensure current time is within range
+        if (!isWithinSchedule()) {
+            return;
+        }
+
         // check constraints
         final long change_time = getMinutesSliderValue(Pref.getInt("speak_readings_change_time", 0)) * Constants.MINUTE_IN_MS;
 
@@ -79,6 +85,59 @@ public class BgToSpeech implements NamedSliderProcessor {
         updateLastSpokenSince();
         realSpeakNow(value, timestamp, delta_name);
 
+    }
+
+    /**
+     * Check if the current time falls within the configured speak readings schedule.
+     * Returns true if no schedule is set (i.e. speak all day) or if the current time is within the scheduled range.
+     * Also used by speak alerts to respect the same schedule.
+     */
+    public static boolean isWithinSchedule() {
+        try {
+            if (Pref.getBooleanDefaultFalse("speak_readings_schedule_enabled")) {
+                long startMillis = Pref.getLong("speak_readings_schedule_start", 0);
+                long endMillis = Pref.getLong("speak_readings_schedule_end", 0);
+                if (startMillis != 0 || endMillis != 0) {
+                    Calendar now = Calendar.getInstance();
+                    int nowMinutes = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE);
+
+                    int startMinutes = 0; // default: midnight
+                    if (startMillis != 0) {
+                        Calendar cs = Calendar.getInstance();
+                        cs.setTimeInMillis(startMillis);
+                        startMinutes = cs.get(Calendar.HOUR_OF_DAY) * 60 + cs.get(Calendar.MINUTE);
+                    }
+
+                    int endMinutes = 24 * 60; // default: end of day
+                    if (endMillis != 0) {
+                        Calendar ce = Calendar.getInstance();
+                        ce.setTimeInMillis(endMillis);
+                        endMinutes = ce.get(Calendar.HOUR_OF_DAY) * 60 + ce.get(Calendar.MINUTE);
+                    }
+
+                    // Same start and end means all day (no restriction)
+                    if (startMinutes == endMinutes) {
+                        return true;
+                    }
+
+                    boolean inRange;
+                    if (startMinutes < endMinutes) {
+                        inRange = nowMinutes >= startMinutes && nowMinutes < endMinutes;
+                    } else {
+                        // range spans midnight
+                        inRange = nowMinutes >= startMinutes || nowMinutes < endMinutes;
+                    }
+
+                    if (!inRange) {
+                        UserError.Log.d(TAG, "Not speaking due to schedule: now " + nowMinutes + " not in " + startMinutes + "-" + endMinutes);
+                        return false;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            UserError.Log.e(TAG, "Error reading schedule preferences, falling back to speaking: " + e);
+        }
+        return true;
     }
 
     private static final String LAST_SPOKEN_TIME = "last-spoken-reading-time";

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -2220,6 +2220,45 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             bindPreferenceSummaryAppendToIntegerValueFromLogSlider(findPreference("speak_readings_change_time"), processor, "time", false);
             bindPreferenceSummaryAppendToIntegerValueFromLogSlider(findPreference("speak_readings_change_threshold"), processor, "threshold", true);
 
+            // Hide/show schedule preferences based on whether speech features are enabled
+            // The schedule applies to both Speak Readings and Speak Alerts
+            try {
+                final PreferenceScreen speakScreen = (PreferenceScreen) findPreference("xdrip_speak_readings_settings");
+                final CheckBoxPreference scheduleEnabled = (CheckBoxPreference) findPreference("speak_readings_schedule_enabled");
+                final Preference scheduleStart = findPreference("speak_readings_schedule_start");
+                final Preference scheduleEnd = findPreference("speak_readings_schedule_end");
+
+                if (speakScreen != null && scheduleEnabled != null && scheduleStart != null && scheduleEnd != null) {
+                    // Hide the entire schedule section if neither Speak Readings nor Speak Alerts is on
+                    final boolean speechActive = Pref.getBooleanDefaultFalse("bg_to_speech")
+                            || Pref.getBooleanDefaultFalse("speak_alerts");
+                    if (!speechActive) {
+                        speakScreen.removePreference(scheduleEnabled);
+                        speakScreen.removePreference(scheduleStart);
+                        speakScreen.removePreference(scheduleEnd);
+                    } else if (!scheduleEnabled.isChecked()) {
+                        speakScreen.removePreference(scheduleStart);
+                        speakScreen.removePreference(scheduleEnd);
+                    }
+
+                    scheduleEnabled.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                        @Override
+                        public boolean onPreferenceChange(Preference preference, Object newValue) {
+                            boolean enabled = (Boolean) newValue;
+                            if (enabled) {
+                                speakScreen.addPreference(scheduleStart);
+                                speakScreen.addPreference(scheduleEnd);
+                            } else {
+                                speakScreen.removePreference(scheduleStart);
+                                speakScreen.removePreference(scheduleEnd);
+                            }
+                            return true;
+                        }
+                    });
+                }
+            } catch (Exception e) {
+                // ignore if preferences not found
+            }
 
             final NamedSliderProcessor tidepoolProcessor = new UploadChunk();
             bindPreferenceTitleAppendToIntegerValueFromLogSlider(findPreference("tidepool_window_latency"), tidepoolProcessor, "latency", false);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,6 +323,10 @@
     <string name="older_gratuitous_wakelocks">Older gratuitous wakelocks which can drain extra battery but might be needed for NightWatch or Android Wear</string>
     <string name="use_excessive_wakelocks">Use Excessive Wakelocks</string>
     <string name="speak_readings">Speak Readings</string>
+    <string name="speak_readings_schedule">Use schedule</string>
+    <string name="speak_readings_schedule_summary">Only speak readings and alerts during a specified time range</string>
+    <string name="speak_readings_schedule_start">Schedule start</string>
+    <string name="speak_readings_schedule_end">Schedule end</string>
     <string name="extra_status_line">Extra Status Line</string>
     <string name="dexcom_share_server_upload">Dex Share</string>
     <string name="upload_data_to_dex_servers">Upload data to Dex Share Servers</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -939,6 +939,17 @@
                 android:title="@string/Speech_pitch" />
             <CheckBoxPreference
                 android:defaultValue="false"
+                android:key="speak_readings_schedule_enabled"
+                android:summary="@string/speak_readings_schedule_summary"
+                android:title="@string/speak_readings_schedule" />
+            <com.eveningoutpost.dexdrip.utils.TimePreference
+                android:key="speak_readings_schedule_start"
+                android:title="@string/speak_readings_schedule_start" />
+            <com.eveningoutpost.dexdrip.utils.TimePreference
+                android:key="speak_readings_schedule_end"
+                android:title="@string/speak_readings_schedule_end" />
+            <CheckBoxPreference
+                android:defaultValue="false"
                 android:key="bg_to_speech_shortcut"
                 android:summary="@string/short_speak_readings_shortcut"
                 android:title="@string/speak_readings_shortcut" />


### PR DESCRIPTION
## Summary

Adds a configurable time schedule for the Speak Readings feature, as requested in #4372.

- **New "Use schedule" checkbox** under Speak Readings settings that lets users restrict spoken glucose readings to a specified time window (e.g. 8 AM – 10 PM)
- **Schedule start / end time pickers** appear only when "Use schedule" is enabled; hidden otherwise for a clean UI
- **Speak Alerts also respect the schedule** — spoken alerts in `AlertPlayer` (high/low alerts) and `Notifications` (low-predict and persistent-high alerts) are gated by the same `isWithinSchedule()` check
- **Midnight-spanning ranges** are handled correctly (e.g. 10 PM – 6 AM)

### Files changed

| File | Change |
|------|--------|
| `BgToSpeech.java` | New `isWithinSchedule()` public static method; schedule check in `speak()` |
| `Preferences.java` | Programmatic hide/show of time pickers based on checkbox state |
| `AlertPlayer.java` | Speak alerts gated by `BgToSpeech.isWithinSchedule()` |
| `Notifications.java` | Low-predict and persistent-high spoken alerts gated by schedule |
| `pref_advanced_settings.xml` | New `CheckBoxPreference` + two `TimePreference` entries |
| `strings.xml` | Four new user-facing strings for the schedule UI |

## Test plan

- [ ] Enable "Speak Readings", verify "Use schedule" checkbox appears
- [ ] Toggle "Use schedule" — time pickers should appear/disappear
- [ ] Set a schedule range that includes the current time → inject a reading → verify it is spoken
- [ ] Set a schedule range that excludes the current time → inject a reading → verify it is **not** spoken
- [ ] Test a midnight-spanning range (e.g. 22:00 – 06:00)
- [ ] Disable "Use schedule" → readings should always be spoken regardless of time
- [ ] Verify "Speak Alerts" also respects the schedule when enabled

Closes #4372


Made with [Cursor](https://cursor.com)