### PR TITLE
Status page cleanup

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/SensorSanity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/SensorSanity.java
@@ -4,6 +4,7 @@ import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollecto
 
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
+import com.eveningoutpost.dexdrip.services.TransmitterRereadHelper;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
@@ -46,6 +47,14 @@ public class SensorSanity {
         if (allowTestingWithDeadSensor()) {
             if (JoH.pratelimit("dead-sensor-sanity-passing", 3600)) {
                 UserError.Log.e(TAG, "Allowing any value due to Allow Dead Sensor being enabled");
+            }
+            return true;
+        }
+
+        if (TransmitterRereadHelper.isTxRereadActive()) {
+            // Allow readings on the main screen even though we temporarily have no firmware!
+            if (JoH.pratelimit("reread-transmitter-sanity-passing", 30 * 60)) {
+                UserError.Log.e(TAG, "Allowing any value due to transmitter reread.");
             }
             return true;
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -2336,7 +2336,7 @@ public class Ob1G5CollectionService extends G5BaseService {
                 if (vr1.version_code != 3 && get_engineering_mode()) {
                     l.add(new StatusItem("Compat Version", "" + vr1.version_code, NORMAL));
                 }
-                if (vr1.max_runtime_days != 110 && vr1.max_runtime_days != 112 && vr1.max_runtime_days != 0) {
+                if (vr1.max_runtime_days != 110 && vr1.max_runtime_days != 112 && vr1.max_runtime_days != 180 && vr1.max_runtime_days != 0) {
                     l.add(new StatusItem("Transmitter Life", "" + vr1.max_runtime_days + " " + gs(R.string.days)));
                 }
 
@@ -2351,7 +2351,7 @@ public class Ob1G5CollectionService extends G5BaseService {
 
         try {
             if (vr2 != null) {
-                if (vr2.typicalSensorDays != 10 && vr2.typicalSensorDays != 7 && vr2.typicalSensorDays != 15) {
+                if (vr2.typicalSensorDays != 10 && vr2.typicalSensorDays != 15 && vr2.typicalSensorDays != 60) {
                     l.add(new StatusItem("Sensor Period", niceTimeScalar(vr2.typicalSensorDays * DAY_IN_MS), Highlight.NOTICE));
                 }
 
@@ -2379,7 +2379,7 @@ public class Ob1G5CollectionService extends G5BaseService {
 
         try {
             if (vr3 != null) {
-                if (vr3.warmupSeconds != 7200 && vr3.warmupSeconds != 3600) {
+                if (vr3.warmupSeconds != 7200 && vr3.warmupSeconds != 3600 && !isTransmitterModified(getTransmitterID())) {
                     l.add(new StatusItem("Warm Up Time", niceTimeScalar(vr3.warmupSeconds * SECOND_IN_MS), Highlight.NOTICE));
                 }
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/TransmitterRereadHelper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/TransmitterRereadHelper.java
@@ -1,0 +1,45 @@
+package com.eveningoutpost.dexdrip.services;
+
+import static com.eveningoutpost.dexdrip.services.G5BaseService.G5_FIRMWARE_MARKER;
+import static com.eveningoutpost.dexdrip.services.Ob1G5CollectionService.getTransmitterID;
+import static com.eveningoutpost.dexdrip.utilitymodels.Constants.MINUTE_IN_MS;
+
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.models.UserError;
+import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
+
+/**
+ * Navid200 - February 10, 2026
+ *
+ * Helper for rereading the details of the currently connected transmitter.
+ *
+ * Normally, xDrip captures transmitter details only once per device.
+ * This class exists to handle the unusual case where we need to force
+ * xDrip to reread the details from a transmitter.
+ */
+public class TransmitterRereadHelper {
+
+    private static boolean txRereadActive = false;
+    private static long txRereadEndTime = 0;
+
+    private static final String TAG = "TransmitterRereadHelper";
+
+    public static void requestTxReread() { // Clear cache for the current transmitter
+        try {
+            for (int t = 1; t <= 3; t++) {
+                PersistentStore.removeItem(G5_FIRMWARE_MARKER + getTransmitterID() + "-" + t);
+            }
+            txRereadEndTime = JoH.tsl() + 16 * MINUTE_IN_MS;
+            txRereadActive = true;
+        } catch (Exception e) {
+            UserError.Log.w(TAG, "Failed to clear transmitter details", e);
+        }
+    }
+
+    public static boolean isTxRereadActive() {
+        if (JoH.tsl() > txRereadEndTime) {
+            txRereadActive = false;
+        }
+        return txRereadActive;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/MicroStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/MicroStatus.java
@@ -14,4 +14,6 @@ public interface MicroStatus {
 
     boolean sessionStartTime(); // Show session start time on the classic status page only when true (not G7)
 
+    boolean rereadTx();
+
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/MicroStatusImpl.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/MicroStatusImpl.java
@@ -4,10 +4,12 @@ package com.eveningoutpost.dexdrip.ui;
  * Created by jamorham on 29/09/2017.
  */
 
+import static com.eveningoutpost.dexdrip.services.Ob1G5CollectionService.getTransmitterID;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.getBestCollectorHardwareName;
 
 import androidx.databinding.BaseObservable;
 
+import com.eveningoutpost.dexdrip.g5model.FirmwareCapability;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 
 public class MicroStatusImpl extends BaseObservable implements MicroStatus {
@@ -42,6 +44,11 @@ public class MicroStatusImpl extends BaseObservable implements MicroStatus {
     @Override
     public boolean xmitterBattery() {
         return DexCollectionType.usesClassicTransmitterBattery();
+    }
+
+    @Override
+    public boolean rereadTx() {
+        return getBestCollectorHardwareName().equals("G6 Native") && FirmwareCapability.isTransmitterModified(getTransmitterID());
     }
 
 }

--- a/app/src/main/res/layout/activity_system_status.xml
+++ b/app/src/main/res/layout/activity_system_status.xml
@@ -232,7 +232,8 @@
                         style="?android:attr/buttonStyleSmall"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
-                        android:text="@string/restart_collector" />
+                        android:text="@string/restart_collector"
+                        android:textAllCaps="false"/>
 
                     <Button
                         android:id="@+id/forget_device"
@@ -240,7 +241,8 @@
                         style="?android:attr/buttonStyleSmall"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
-                        android:text="@string/forget_device" />
+                        android:text="@string/forget_device"
+                        android:textAllCaps="false"/>
                 </LinearLayout>
 
                 <LinearLayout
@@ -279,7 +281,22 @@
                         style="?android:attr/buttonStyleSmall"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/delete_future_data" />
+                        android:text="@string/delete_future_data"
+                        android:textAllCaps="false"/>
+                </LinearLayout>
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal|bottom"
+                    android:layout_marginTop="40dp">
+                    <Button
+                        android:id="@+id/reread_transmitter"
+                        app:showIfTrue="@{ms.rereadTx()}"
+                        style="?android:attr/buttonStyleSmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/re_read_transmitter"
+                        android:textAllCaps="false"/>
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -939,6 +939,9 @@
     <string name="only_stop_your_sensor_when_you_actually_plan">Only stop your sensor when you actually plan to remove it, otherwise leave it running!</string>
     <string name="restart_collector">Restart Collector</string>
     <string name="forget_device">Forget Device</string>
+    <string name="re_read_transmitter">Reread transmitter</string>
+    <string name="tx_reread_confirmation_title">Refresh transmitter details</string>
+    <string name="tx_reread_confirmation_message">Forces xDrip to reread transmitter characteristics. No benefit if the transmitter has not changed; temporary status page changes may occur. Best used between sensor sessions.</string>
     <string name="other_notes">Other Notes:</string>
     <string name="delete_future_data">Delete Future Data</string>
     <string name="show_only_untranslated">Show only untranslated</string>


### PR DESCRIPTION
Adds a button that can be used to reread transmitter.
Avoids showing expected parameters on the status page the same as other devices.  

The following shows the classic and Dex status pages after.

<img width="280" height="561" alt="Screenshot_20260218-182113" src="https://github.com/user-attachments/assets/a9e0cd90-390b-4959-8eae-a6f5e1d2b468" /> <img width="280" height="561" alt="Screenshot_20260218-183252" src="https://github.com/user-attachments/assets/cc436b91-23f0-49e8-a714-bbc11563c381" />

