### PR TITLE
Fix timezone-dependent BasalRepositoryTest failures

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItem.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItem.java
@@ -15,7 +15,7 @@ public class ProfileItem implements Comparable<ProfileItem>{
 
     final private static SimpleDateFormat hourMinConvert = new SimpleDateFormat("HHmm", Locale.ENGLISH);
 
-    public static void updateTimeZone() {
+    static void updateTimeZone() {
         hourMinConvert.setTimeZone(TimeZone.getDefault());
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItem.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItem.java
@@ -6,13 +6,18 @@ import com.google.gson.annotations.Expose;
 
 import java.text.SimpleDateFormat;
 import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * Created by jamorham on 21/06/2016.
  */
 public class ProfileItem implements Comparable<ProfileItem>{
 
-    final static SimpleDateFormat hourMinConvert = new SimpleDateFormat("HHmm", Locale.ENGLISH);
+    final private static SimpleDateFormat hourMinConvert = new SimpleDateFormat("HHmm", Locale.ENGLISH);
+
+    public static void updateTimeZone() {
+        hourMinConvert.setTimeZone(TimeZone.getDefault());
+    }
 
     private String title;
     @Expose

--- a/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItem.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItem.java
@@ -12,7 +12,7 @@ import java.util.Locale;
  */
 public class ProfileItem implements Comparable<ProfileItem>{
 
-    final private static SimpleDateFormat hourMinConvert = new SimpleDateFormat("HHmm", Locale.ENGLISH);
+    final static SimpleDateFormat hourMinConvert = new SimpleDateFormat("HHmm", Locale.ENGLISH);
 
     private String title;
     @Expose

--- a/app/src/test/java/com/eveningoutpost/dexdrip/profileeditor/BasalRepositoryTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/profileeditor/BasalRepositoryTest.java
@@ -31,7 +31,7 @@ public class BasalRepositoryTest extends RobolectricTestWithConfig {
     public void setup() {
         oldTimeZone = TimeZone.getDefault();
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-        ProfileItem.hourMinConvert.setTimeZone(TimeZone.getTimeZone("UTC"));
+        ProfileItem.updateTimeZone();
         final List<Double> segments = new LinkedList<>();
         for (int i = 1; i < 25; i++) {
             segments.add(i / 10d);
@@ -42,7 +42,7 @@ public class BasalRepositoryTest extends RobolectricTestWithConfig {
     @After
     public void tearDown() {
         TimeZone.setDefault(oldTimeZone);
-        ProfileItem.hourMinConvert.setTimeZone(oldTimeZone);
+        ProfileItem.updateTimeZone();
     }
 
     @Test

--- a/app/src/test/java/com/eveningoutpost/dexdrip/profileeditor/BasalRepositoryTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/profileeditor/BasalRepositoryTest.java
@@ -31,6 +31,7 @@ public class BasalRepositoryTest extends RobolectricTestWithConfig {
     public void setup() {
         oldTimeZone = TimeZone.getDefault();
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        ProfileItem.hourMinConvert.setTimeZone(TimeZone.getTimeZone("UTC"));
         final List<Double> segments = new LinkedList<>();
         for (int i = 1; i < 25; i++) {
             segments.add(i / 10d);
@@ -41,6 +42,7 @@ public class BasalRepositoryTest extends RobolectricTestWithConfig {
     @After
     public void tearDown() {
         TimeZone.setDefault(oldTimeZone);
+        ProfileItem.hourMinConvert.setTimeZone(oldTimeZone);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fix `getActiveRateTest` and `getRateByTimeStampTest` failing in non-UTC timezones (e.g. CEST)
- Root cause: `ProfileItem.hourMinConvert` is a static `SimpleDateFormat` that caches the timezone at class-load time — `TimeZone.setDefault("UTC")` in the test has no effect on the already-cached formatter
- Fix: explicitly set the formatter's timezone to UTC in `setUp()` and restore it in `tearDown()`; widen visibility from `private` to package-private for test access

## Test plan

- [x] `BasalRepositoryTest` — all 6 tests pass in non-UTC timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)