### PR TITLE
Add unit tests for 6 utility/model classes

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/CircularArrayList.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/CircularArrayList.java
@@ -102,6 +102,8 @@ public class CircularArrayList<E>
         if (s == n - 1) {
             if (autoEvict) {
                 remove(0);
+                s = size();
+                i = Math.min(i, s);
             } else {
                 throw new IllegalStateException(
                         "CircularArrayList is filled to capacity. "

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/CircularArrayList.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/CircularArrayList.java
@@ -102,8 +102,8 @@ public class CircularArrayList<E>
         if (s == n - 1) {
             if (autoEvict) {
                 remove(0);
-                s = size();
-                i = Math.min(i, s);
+                s = size(); // recalculate after eviction
+                i = Math.min(i, s); // clamp index to new valid range
             } else {
                 throw new IllegalStateException(
                         "CircularArrayList is filled to capacity. "

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/GlucoseDataTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/GlucoseDataTest.java
@@ -1,0 +1,105 @@
+package com.eveningoutpost.dexdrip.models;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+public class GlucoseDataTest {
+
+    // -- mg/dL formatting: integer string --
+
+    @Test
+    public void glucose_mgdl_returnsWholeNumber() {
+        assertThat(GlucoseData.glucose(120, false)).isEqualTo("120");
+        assertThat(GlucoseData.glucose(80, false)).isEqualTo("80");
+    }
+
+    // -- mmol/L formatting: one decimal place --
+
+    @Test
+    public void glucose_mmol_returnsOneDecimal() {
+        // 120 mg/dL ~ 6.7 mmol/L
+        String result = GlucoseData.glucose(120, true);
+        double value = Double.parseDouble(result);
+        assertWithMessage("120 mg/dL in mmol/L")
+                .that(value).isWithin(0.1).of(6.7);
+    }
+
+    @Test
+    public void glucose_mmol_lowValue() {
+        // 54 mg/dL ~ 3.0 mmol/L
+        String result = GlucoseData.glucose(54, true);
+        double value = Double.parseDouble(result);
+        assertWithMessage("54 mg/dL in mmol/L")
+                .that(value).isWithin(0.1).of(3.0);
+    }
+
+    @Test
+    public void glucose_mmol_highValue() {
+        // 300 mg/dL ~ 16.7 mmol/L
+        String result = GlucoseData.glucose(300, true);
+        double value = Double.parseDouble(result);
+        assertWithMessage("300 mg/dL in mmol/L")
+                .that(value).isWithin(0.1).of(16.7);
+    }
+
+    // -- Instance method uses glucoseLevel field --
+
+    @Test
+    public void instanceGlucose_usesGlucoseLevel() {
+        GlucoseData gd = new GlucoseData();
+        gd.glucoseLevel = 180;
+        assertThat(gd.glucose(false)).isEqualTo("180");
+    }
+
+    // -- Chronological ordering via compareTo --
+
+    @Test
+    public void compareTo_ordersChronologically() {
+        GlucoseData early = new GlucoseData(100, 1000L);
+        GlucoseData late = new GlucoseData(100, 2000L);
+        assertThat(early.compareTo(late)).isLessThan(0);
+        assertThat(late.compareTo(early)).isGreaterThan(0);
+    }
+
+    @Test
+    public void compareTo_sameTime_returnsZero() {
+        GlucoseData a = new GlucoseData(100, 1000L);
+        GlucoseData b = new GlucoseData(200, 1000L);
+        assertThat(a.compareTo(b)).isEqualTo(0);
+    }
+
+    @Test
+    public void sorting_producesChronologicalOrder() {
+        GlucoseData a = new GlucoseData(100, 3000L);
+        GlucoseData b = new GlucoseData(100, 1000L);
+        GlucoseData c = new GlucoseData(100, 2000L);
+        List<GlucoseData> list = Arrays.asList(a, b, c);
+        Collections.sort(list);
+        assertThat(list.get(0).realDate).isEqualTo(1000L);
+        assertThat(list.get(1).realDate).isEqualTo(2000L);
+        assertThat(list.get(2).realDate).isEqualTo(3000L);
+    }
+
+    // -- Constructor sets fields --
+
+    @Test
+    public void constructor_setsRawGlucoseAndTimestamp() {
+        GlucoseData gd = new GlucoseData(250, 5000L);
+        assertThat(gd.glucoseLevelRaw).isEqualTo(250);
+        assertThat(gd.realDate).isEqualTo(5000L);
+    }
+
+    // -- Default glucoseLevel is -1 (not set) --
+
+    @Test
+    public void defaultGlucoseLevel_isMinusOne() {
+        GlucoseData gd = new GlucoseData();
+        assertThat(gd.glucoseLevel).isEqualTo(-1);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/GlucoseDataTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/GlucoseDataTest.java
@@ -9,12 +9,16 @@ import java.util.List;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+/**
+ * @author Asbjørn Aarrestad
+ */
 public class GlucoseDataTest {
 
     // -- mg/dL formatting: integer string --
 
     @Test
     public void glucose_mgdl_returnsWholeNumber() {
+        // :: Verify
         assertThat(GlucoseData.glucose(120, false)).isEqualTo("120");
         assertThat(GlucoseData.glucose(80, false)).isEqualTo("80");
     }
@@ -23,27 +27,30 @@ public class GlucoseDataTest {
 
     @Test
     public void glucose_mmol_returnsOneDecimal() {
-        // 120 mg/dL ~ 6.7 mmol/L
-        String result = GlucoseData.glucose(120, true);
-        double value = Double.parseDouble(result);
+        // :: Act — 120 mg/dL ~ 6.7 mmol/L
+        double value = Double.parseDouble(GlucoseData.glucose(120, true));
+
+        // :: Verify
         assertWithMessage("120 mg/dL in mmol/L")
                 .that(value).isWithin(0.1).of(6.7);
     }
 
     @Test
     public void glucose_mmol_lowValue() {
-        // 54 mg/dL ~ 3.0 mmol/L
-        String result = GlucoseData.glucose(54, true);
-        double value = Double.parseDouble(result);
+        // :: Act — 54 mg/dL ~ 3.0 mmol/L
+        double value = Double.parseDouble(GlucoseData.glucose(54, true));
+
+        // :: Verify
         assertWithMessage("54 mg/dL in mmol/L")
                 .that(value).isWithin(0.1).of(3.0);
     }
 
     @Test
     public void glucose_mmol_highValue() {
-        // 300 mg/dL ~ 16.7 mmol/L
-        String result = GlucoseData.glucose(300, true);
-        double value = Double.parseDouble(result);
+        // :: Act — 300 mg/dL ~ 16.7 mmol/L
+        double value = Double.parseDouble(GlucoseData.glucose(300, true));
+
+        // :: Verify
         assertWithMessage("300 mg/dL in mmol/L")
                 .that(value).isWithin(0.1).of(16.7);
     }
@@ -52,8 +59,11 @@ public class GlucoseDataTest {
 
     @Test
     public void instanceGlucose_usesGlucoseLevel() {
+        // :: Setup
         GlucoseData gd = new GlucoseData();
         gd.glucoseLevel = 180;
+
+        // :: Verify
         assertThat(gd.glucose(false)).isEqualTo("180");
     }
 
@@ -61,26 +71,37 @@ public class GlucoseDataTest {
 
     @Test
     public void compareTo_ordersChronologically() {
+        // :: Setup
         GlucoseData early = new GlucoseData(100, 1000L);
         GlucoseData late = new GlucoseData(100, 2000L);
+
+        // :: Verify
         assertThat(early.compareTo(late)).isLessThan(0);
         assertThat(late.compareTo(early)).isGreaterThan(0);
     }
 
     @Test
     public void compareTo_sameTime_returnsZero() {
+        // :: Setup
         GlucoseData a = new GlucoseData(100, 1000L);
         GlucoseData b = new GlucoseData(200, 1000L);
+
+        // :: Verify
         assertThat(a.compareTo(b)).isEqualTo(0);
     }
 
     @Test
     public void sorting_producesChronologicalOrder() {
+        // :: Setup
         GlucoseData a = new GlucoseData(100, 3000L);
         GlucoseData b = new GlucoseData(100, 1000L);
         GlucoseData c = new GlucoseData(100, 2000L);
         List<GlucoseData> list = Arrays.asList(a, b, c);
+
+        // :: Act
         Collections.sort(list);
+
+        // :: Verify
         assertThat(list.get(0).realDate).isEqualTo(1000L);
         assertThat(list.get(1).realDate).isEqualTo(2000L);
         assertThat(list.get(2).realDate).isEqualTo(3000L);
@@ -90,7 +111,10 @@ public class GlucoseDataTest {
 
     @Test
     public void constructor_setsRawGlucoseAndTimestamp() {
+        // :: Act
         GlucoseData gd = new GlucoseData(250, 5000L);
+
+        // :: Verify
         assertThat(gd.glucoseLevelRaw).isEqualTo(250);
         assertThat(gd.realDate).isEqualTo(5000L);
     }
@@ -99,7 +123,7 @@ public class GlucoseDataTest {
 
     @Test
     public void defaultGlucoseLevel_isMinusOne() {
-        GlucoseData gd = new GlucoseData();
-        assertThat(gd.glucoseLevel).isEqualTo(-1);
+        // :: Verify
+        assertThat(new GlucoseData().glucoseLevel).isEqualTo(-1);
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItemTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItemTest.java
@@ -14,6 +14,9 @@ import java.util.TimeZone;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+/**
+ * @author Asbjørn Aarrestad
+ */
 public class ProfileItemTest {
 
     private TimeZone oldTimeZone;
@@ -41,13 +44,19 @@ public class ProfileItemTest {
 
     @Test
     public void timePeriod_formatsAsHHMM() {
+        // :: Setup
         ProfileItem item = new ProfileItem(90, 150, 10.0, 50.0);
+
+        // :: Verify
         assertThat(item.getTimePeriod()).isEqualTo("01:30 -> 02:30");
     }
 
     @Test
     public void timePeriod_midnight() {
+        // :: Setup
         ProfileItem item = new ProfileItem(0, 1440, 10.0, 50.0);
+
+        // :: Verify
         assertThat(item.getTimeStart()).isEqualTo("00:00");
         assertThat(item.getTimeEnd()).isEqualTo("24:00");
     }
@@ -56,22 +65,28 @@ public class ProfileItemTest {
 
     @Test
     public void timeStampToMin_midnight_returnsZero() {
-        // 2026-01-01 00:00:00 UTC
+        // :: Setup — 2026-01-01 00:00:00 UTC
         long midnightUtc = 1767225600000L;
+
+        // :: Verify
         assertThat(ProfileItem.timeStampToMin(midnightUtc)).isEqualTo(0);
     }
 
     @Test
     public void timeStampToMin_noon_returns720() {
-        // 2026-01-01 12:00:00 UTC
+        // :: Setup — 2026-01-01 12:00:00 UTC
         long noonUtc = 1767225600000L + 12 * 3600 * 1000L;
+
+        // :: Verify
         assertThat(ProfileItem.timeStampToMin(noonUtc)).isEqualTo(720);
     }
 
     @Test
     public void timeStampToMin_1530_returns930() {
-        // 15:30 = 15*60 + 30 = 930 minutes
+        // :: Setup — 15:30 = 15*60 + 30 = 930 minutes
         long time1530 = 1767225600000L + (15 * 3600 + 30 * 60) * 1000L;
+
+        // :: Verify
         assertThat(ProfileItem.timeStampToMin(time1530)).isEqualTo(930);
     }
 
@@ -79,7 +94,10 @@ public class ProfileItemTest {
 
     @Test
     public void timeStampToMin_doubleAndLong_agree() {
-        long ts = 1767225600000L + 8 * 3600 * 1000L; // 08:00 UTC
+        // :: Setup — 08:00 UTC
+        long ts = 1767225600000L + 8 * 3600 * 1000L;
+
+        // :: Verify
         assertThat(ProfileItem.timeStampToMin((double) ts))
                 .isEqualTo(ProfileItem.timeStampToMin(ts));
     }
@@ -88,15 +106,21 @@ public class ProfileItemTest {
 
     @Test
     public void equals_sameValues_areEqual() {
+        // :: Setup — different time ranges but same ratio/sensitivity
         ProfileItem a = new ProfileItem(0, 60, 10.0, 50.0);
         ProfileItem b = new ProfileItem(120, 180, 10.0, 50.0);
+
+        // :: Verify
         assertThat(a).isEqualTo(b);
     }
 
     @Test
     public void equals_differentValues_notEqual() {
+        // :: Setup
         ProfileItem a = new ProfileItem(0, 60, 10.0, 50.0);
         ProfileItem b = new ProfileItem(0, 60, 12.0, 50.0);
+
+        // :: Verify
         assertThat(a).isNotEqualTo(b);
     }
 
@@ -104,8 +128,13 @@ public class ProfileItemTest {
 
     @Test
     public void clone_producesEqualCopy() {
+        // :: Setup
         ProfileItem orig = new ProfileItem(60, 120, 8.5, 45.0);
+
+        // :: Act
         ProfileItem copy = orig.clone();
+
+        // :: Verify
         assertThat(copy).isEqualTo(orig);
         assertThat(copy).isNotSameInstanceAs(orig);
     }
@@ -114,8 +143,13 @@ public class ProfileItemTest {
 
     @Test
     public void toJson_containsExposedFields() {
+        // :: Setup
         ProfileItem item = new ProfileItem(60, 120, 10.0, 50.0);
+
+        // :: Act
         String json = item.toJson();
+
+        // :: Verify
         assertThat(json).contains("\"start_min\":60");
         assertThat(json).contains("\"end_min\":120");
         assertThat(json).contains("\"carb_ratio\":10.0");
@@ -126,11 +160,16 @@ public class ProfileItemTest {
 
     @Test
     public void sorting_orderedByStartMin() {
+        // :: Setup
         ProfileItem a = new ProfileItem(120, 180, 10.0, 50.0);
         ProfileItem b = new ProfileItem(0, 60, 10.0, 50.0);
         ProfileItem c = new ProfileItem(60, 120, 10.0, 50.0);
         List<ProfileItem> items = Arrays.asList(a, b, c);
+
+        // :: Act
         Collections.sort(items);
+
+        // :: Verify
         assertThat(items.get(0).start_min).isEqualTo(0);
         assertThat(items.get(1).start_min).isEqualTo(60);
         assertThat(items.get(2).start_min).isEqualTo(120);

--- a/app/src/test/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItemTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/profileeditor/ProfileItemTest.java
@@ -1,0 +1,138 @@
+package com.eveningoutpost.dexdrip.profileeditor;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+public class ProfileItemTest {
+
+    private TimeZone oldTimeZone;
+
+    @Before
+    public void setUp() throws Exception {
+        oldTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        getHourMinConvert().setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        TimeZone.setDefault(oldTimeZone);
+        getHourMinConvert().setTimeZone(oldTimeZone);
+    }
+
+    private static SimpleDateFormat getHourMinConvert() throws Exception {
+        Field field = ProfileItem.class.getDeclaredField("hourMinConvert");
+        field.setAccessible(true);
+        return (SimpleDateFormat) field.get(null);
+    }
+
+    // -- Time period formatting --
+
+    @Test
+    public void timePeriod_formatsAsHHMM() {
+        ProfileItem item = new ProfileItem(90, 150, 10.0, 50.0);
+        assertThat(item.getTimePeriod()).isEqualTo("01:30 -> 02:30");
+    }
+
+    @Test
+    public void timePeriod_midnight() {
+        ProfileItem item = new ProfileItem(0, 1440, 10.0, 50.0);
+        assertThat(item.getTimeStart()).isEqualTo("00:00");
+        assertThat(item.getTimeEnd()).isEqualTo("24:00");
+    }
+
+    // -- timeStampToMin: converts epoch millis to minute-of-day --
+
+    @Test
+    public void timeStampToMin_midnight_returnsZero() {
+        // 2026-01-01 00:00:00 UTC
+        long midnightUtc = 1767225600000L;
+        assertThat(ProfileItem.timeStampToMin(midnightUtc)).isEqualTo(0);
+    }
+
+    @Test
+    public void timeStampToMin_noon_returns720() {
+        // 2026-01-01 12:00:00 UTC
+        long noonUtc = 1767225600000L + 12 * 3600 * 1000L;
+        assertThat(ProfileItem.timeStampToMin(noonUtc)).isEqualTo(720);
+    }
+
+    @Test
+    public void timeStampToMin_1530_returns930() {
+        // 15:30 = 15*60 + 30 = 930 minutes
+        long time1530 = 1767225600000L + (15 * 3600 + 30 * 60) * 1000L;
+        assertThat(ProfileItem.timeStampToMin(time1530)).isEqualTo(930);
+    }
+
+    // -- Double overload gives same result --
+
+    @Test
+    public void timeStampToMin_doubleAndLong_agree() {
+        long ts = 1767225600000L + 8 * 3600 * 1000L; // 08:00 UTC
+        assertThat(ProfileItem.timeStampToMin((double) ts))
+                .isEqualTo(ProfileItem.timeStampToMin(ts));
+    }
+
+    // -- Equality is value-based (carb_ratio, sensitivity, absorption_rate) --
+
+    @Test
+    public void equals_sameValues_areEqual() {
+        ProfileItem a = new ProfileItem(0, 60, 10.0, 50.0);
+        ProfileItem b = new ProfileItem(120, 180, 10.0, 50.0);
+        assertThat(a).isEqualTo(b);
+    }
+
+    @Test
+    public void equals_differentValues_notEqual() {
+        ProfileItem a = new ProfileItem(0, 60, 10.0, 50.0);
+        ProfileItem b = new ProfileItem(0, 60, 12.0, 50.0);
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    // -- Clone produces equal but distinct object --
+
+    @Test
+    public void clone_producesEqualCopy() {
+        ProfileItem orig = new ProfileItem(60, 120, 8.5, 45.0);
+        ProfileItem copy = orig.clone();
+        assertThat(copy).isEqualTo(orig);
+        assertThat(copy).isNotSameInstanceAs(orig);
+    }
+
+    // -- toJson serialization --
+
+    @Test
+    public void toJson_containsExposedFields() {
+        ProfileItem item = new ProfileItem(60, 120, 10.0, 50.0);
+        String json = item.toJson();
+        assertThat(json).contains("\"start_min\":60");
+        assertThat(json).contains("\"end_min\":120");
+        assertThat(json).contains("\"carb_ratio\":10.0");
+        assertThat(json).contains("\"sensitivity\":50.0");
+    }
+
+    // -- Sorting uses start_min --
+
+    @Test
+    public void sorting_orderedByStartMin() {
+        ProfileItem a = new ProfileItem(120, 180, 10.0, 50.0);
+        ProfileItem b = new ProfileItem(0, 60, 10.0, 50.0);
+        ProfileItem c = new ProfileItem(60, 120, 10.0, 50.0);
+        List<ProfileItem> items = Arrays.asList(a, b, c);
+        Collections.sort(items);
+        assertThat(items.get(0).start_min).isEqualTo(0);
+        assertThat(items.get(1).start_min).isEqualTo(60);
+        assertThat(items.get(2).start_min).isEqualTo(120);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/LibreUtilsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/LibreUtilsTest.java
@@ -1,0 +1,141 @@
+package com.eveningoutpost.dexdrip.utilitymodels;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+public class LibreUtilsTest extends RobolectricTestWithConfig {
+
+    // -- computeCRC16: deterministic --
+
+    @Test
+    public void computeCRC16_sameInput_sameOutput() {
+        byte[] data = new byte[]{0x00, 0x00, 0x10, 0x20, 0x30, 0x40};
+        long first = LibreUtils.computeCRC16(data, 0, data.length);
+        long second = LibreUtils.computeCRC16(data, 0, data.length);
+        assertThat(first).isEqualTo(second);
+    }
+
+    // -- computeCRC16: different data gives different CRC --
+
+    @Test
+    public void computeCRC16_differentData_differentCrc() {
+        byte[] a = new byte[]{0x00, 0x00, 0x10, 0x20, 0x30};
+        byte[] b = new byte[]{0x00, 0x00, 0x10, 0x20, 0x31};
+        long crcA = LibreUtils.computeCRC16(a, 0, a.length);
+        long crcB = LibreUtils.computeCRC16(b, 0, b.length);
+        assertThat(crcA).isNotEqualTo(crcB);
+    }
+
+    // -- computeCRC16: known value from existing test --
+
+    @Test
+    public void computeCRC16_knownTestVector() {
+        byte[] data = new byte[]{0x3e, 0x49, (byte) 0x91, (byte) 0xb4,
+                (byte) 0x8b, (byte) 0xcb, (byte) 0x1b, (byte) 0xd9,
+                (byte) 0xd3, (byte) 0xc4, (byte) 0xc1, (byte) 0x4a,
+                (byte) 0x1f, (byte) 0x24, (byte) 0xc4, 0x15,
+                (byte) 0xde, (byte) 0xab, (byte) 0xa4, 0x66};
+        long crc = LibreUtils.computeCRC16(data, 0, data.length - 2);
+        assertThat(crc).isEqualTo(19459);
+    }
+
+    // -- isSensorReady: ready states --
+
+    @Test
+    public void isSensorReady_starting_isReady() {
+        assertThat(LibreUtils.isSensorReady((byte) 0x02)).isTrue();
+    }
+
+    @Test
+    public void isSensorReady_ready_isReady() {
+        assertThat(LibreUtils.isSensorReady((byte) 0x03)).isTrue();
+    }
+
+    // -- isSensorReady: not-ready states --
+
+    @Test
+    public void isSensorReady_notStarted_isNotReady() {
+        assertThat(LibreUtils.isSensorReady((byte) 0x01)).isFalse();
+    }
+
+    @Test
+    public void isSensorReady_expired_isNotReady() {
+        assertThat(LibreUtils.isSensorReady((byte) 0x04)).isFalse();
+    }
+
+    @Test
+    public void isSensorReady_shutdown_isNotReady() {
+        assertThat(LibreUtils.isSensorReady((byte) 0x05)).isFalse();
+    }
+
+    @Test
+    public void isSensorReady_failure_isNotReady() {
+        assertThat(LibreUtils.isSensorReady((byte) 0x06)).isFalse();
+    }
+
+    @Test
+    public void isSensorReady_unknownStatus_isNotReady() {
+        assertThat(LibreUtils.isSensorReady((byte) 0xFF)).isFalse();
+    }
+
+    // -- validatePatchInfo --
+
+    @Test
+    public void validatePatchInfo_validBytes_returnsTrue() {
+        byte[] buf = new byte[11];
+        buf[9] = 0x07;
+        buf[10] = (byte) 0xE0;
+        assertThat(LibreUtils.validatePatchInfo(buf)).isTrue();
+    }
+
+    @Test
+    public void validatePatchInfo_tooShort_returnsFalse() {
+        byte[] buf = new byte[10];
+        assertThat(LibreUtils.validatePatchInfo(buf)).isFalse();
+    }
+
+    @Test
+    public void validatePatchInfo_wrongBytes_returnsFalse() {
+        byte[] buf = new byte[11];
+        buf[9] = 0x07;
+        buf[10] = 0x00;
+        assertThat(LibreUtils.validatePatchInfo(buf)).isFalse();
+    }
+
+    // -- decodeSerialNumber: deterministic --
+
+    @Test
+    public void decodeSerialNumber_sameInput_sameOutput() {
+        byte[] uid = new byte[11];
+        uid[3] = 0x01; uid[4] = 0x02; uid[5] = 0x03;
+        uid[6] = 0x04; uid[7] = 0x05; uid[8] = 0x06;
+        uid[9] = 0x07; uid[10] = 0x08;
+        String first = LibreUtils.decodeSerialNumber(uid);
+        String second = LibreUtils.decodeSerialNumber(uid);
+        assertThat(first).isEqualTo(second);
+    }
+
+    // -- decodeSerialNumber: starts with '0' --
+
+    @Test
+    public void decodeSerialNumber_startsWithZero() {
+        byte[] uid = new byte[11];
+        String serial = LibreUtils.decodeSerialNumber(uid);
+        assertThat(serial).startsWith("0");
+    }
+
+    // -- decodeSerialNumber: length is 11 (prefix '0' + 10 encoded chars) --
+
+    @Test
+    public void decodeSerialNumber_hasExpectedLength() {
+        byte[] uid = new byte[11];
+        uid[3] = 0x12; uid[4] = 0x34; uid[5] = 0x56;
+        uid[6] = 0x78; uid[7] = (byte) 0x9A; uid[8] = (byte) 0xBC;
+        String serial = LibreUtils.decodeSerialNumber(uid);
+        assertThat(serial.length()).isEqualTo(11);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/LibreUtilsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/LibreUtilsTest.java
@@ -7,15 +7,23 @@ import org.junit.Test;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+/**
+ * @author Asbjørn Aarrestad
+ */
 public class LibreUtilsTest extends RobolectricTestWithConfig {
 
     // -- computeCRC16: deterministic --
 
     @Test
     public void computeCRC16_sameInput_sameOutput() {
+        // :: Setup
         byte[] data = new byte[]{0x00, 0x00, 0x10, 0x20, 0x30, 0x40};
+
+        // :: Act
         long first = LibreUtils.computeCRC16(data, 0, data.length);
         long second = LibreUtils.computeCRC16(data, 0, data.length);
+
+        // :: Verify
         assertThat(first).isEqualTo(second);
     }
 
@@ -23,10 +31,15 @@ public class LibreUtilsTest extends RobolectricTestWithConfig {
 
     @Test
     public void computeCRC16_differentData_differentCrc() {
+        // :: Setup
         byte[] a = new byte[]{0x00, 0x00, 0x10, 0x20, 0x30};
         byte[] b = new byte[]{0x00, 0x00, 0x10, 0x20, 0x31};
+
+        // :: Act
         long crcA = LibreUtils.computeCRC16(a, 0, a.length);
         long crcB = LibreUtils.computeCRC16(b, 0, b.length);
+
+        // :: Verify
         assertThat(crcA).isNotEqualTo(crcB);
     }
 
@@ -34,12 +47,17 @@ public class LibreUtilsTest extends RobolectricTestWithConfig {
 
     @Test
     public void computeCRC16_knownTestVector() {
+        // :: Setup
         byte[] data = new byte[]{0x3e, 0x49, (byte) 0x91, (byte) 0xb4,
                 (byte) 0x8b, (byte) 0xcb, (byte) 0x1b, (byte) 0xd9,
                 (byte) 0xd3, (byte) 0xc4, (byte) 0xc1, (byte) 0x4a,
                 (byte) 0x1f, (byte) 0x24, (byte) 0xc4, 0x15,
                 (byte) 0xde, (byte) 0xab, (byte) 0xa4, 0x66};
+
+        // :: Act
         long crc = LibreUtils.computeCRC16(data, 0, data.length - 2);
+
+        // :: Verify
         assertThat(crc).isEqualTo(19459);
     }
 
@@ -47,11 +65,13 @@ public class LibreUtilsTest extends RobolectricTestWithConfig {
 
     @Test
     public void isSensorReady_starting_isReady() {
+        // :: Verify
         assertThat(LibreUtils.isSensorReady((byte) 0x02)).isTrue();
     }
 
     @Test
     public void isSensorReady_ready_isReady() {
+        // :: Verify
         assertThat(LibreUtils.isSensorReady((byte) 0x03)).isTrue();
     }
 
@@ -59,26 +79,31 @@ public class LibreUtilsTest extends RobolectricTestWithConfig {
 
     @Test
     public void isSensorReady_notStarted_isNotReady() {
+        // :: Verify
         assertThat(LibreUtils.isSensorReady((byte) 0x01)).isFalse();
     }
 
     @Test
     public void isSensorReady_expired_isNotReady() {
+        // :: Verify
         assertThat(LibreUtils.isSensorReady((byte) 0x04)).isFalse();
     }
 
     @Test
     public void isSensorReady_shutdown_isNotReady() {
+        // :: Verify
         assertThat(LibreUtils.isSensorReady((byte) 0x05)).isFalse();
     }
 
     @Test
     public void isSensorReady_failure_isNotReady() {
+        // :: Verify
         assertThat(LibreUtils.isSensorReady((byte) 0x06)).isFalse();
     }
 
     @Test
     public void isSensorReady_unknownStatus_isNotReady() {
+        // :: Verify
         assertThat(LibreUtils.isSensorReady((byte) 0xFF)).isFalse();
     }
 
@@ -86,23 +111,29 @@ public class LibreUtilsTest extends RobolectricTestWithConfig {
 
     @Test
     public void validatePatchInfo_validBytes_returnsTrue() {
+        // :: Setup
         byte[] buf = new byte[11];
         buf[9] = 0x07;
         buf[10] = (byte) 0xE0;
+
+        // :: Verify
         assertThat(LibreUtils.validatePatchInfo(buf)).isTrue();
     }
 
     @Test
     public void validatePatchInfo_tooShort_returnsFalse() {
-        byte[] buf = new byte[10];
-        assertThat(LibreUtils.validatePatchInfo(buf)).isFalse();
+        // :: Verify
+        assertThat(LibreUtils.validatePatchInfo(new byte[10])).isFalse();
     }
 
     @Test
     public void validatePatchInfo_wrongBytes_returnsFalse() {
+        // :: Setup
         byte[] buf = new byte[11];
         buf[9] = 0x07;
         buf[10] = 0x00;
+
+        // :: Verify
         assertThat(LibreUtils.validatePatchInfo(buf)).isFalse();
     }
 
@@ -110,12 +141,17 @@ public class LibreUtilsTest extends RobolectricTestWithConfig {
 
     @Test
     public void decodeSerialNumber_sameInput_sameOutput() {
+        // :: Setup
         byte[] uid = new byte[11];
         uid[3] = 0x01; uid[4] = 0x02; uid[5] = 0x03;
         uid[6] = 0x04; uid[7] = 0x05; uid[8] = 0x06;
         uid[9] = 0x07; uid[10] = 0x08;
+
+        // :: Act
         String first = LibreUtils.decodeSerialNumber(uid);
         String second = LibreUtils.decodeSerialNumber(uid);
+
+        // :: Verify
         assertThat(first).isEqualTo(second);
     }
 
@@ -123,8 +159,10 @@ public class LibreUtilsTest extends RobolectricTestWithConfig {
 
     @Test
     public void decodeSerialNumber_startsWithZero() {
-        byte[] uid = new byte[11];
-        String serial = LibreUtils.decodeSerialNumber(uid);
+        // :: Act
+        String serial = LibreUtils.decodeSerialNumber(new byte[11]);
+
+        // :: Verify
         assertThat(serial).startsWith("0");
     }
 
@@ -132,10 +170,15 @@ public class LibreUtilsTest extends RobolectricTestWithConfig {
 
     @Test
     public void decodeSerialNumber_hasExpectedLength() {
+        // :: Setup
         byte[] uid = new byte[11];
         uid[3] = 0x12; uid[4] = 0x34; uid[5] = 0x56;
         uid[6] = 0x78; uid[7] = (byte) 0x9A; uid[8] = (byte) 0xBC;
+
+        // :: Act
         String serial = LibreUtils.decodeSerialNumber(uid);
+
+        // :: Verify
         assertThat(serial.length()).isEqualTo(11);
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utils/CRC16ccittTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utils/CRC16ccittTest.java
@@ -1,0 +1,83 @@
+package com.eveningoutpost.dexdrip.utils;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+public class CRC16ccittTest extends RobolectricTestWithConfig {
+
+    // -- Known test vector: "123456789" with initial 0xFFFF --
+    // Standard CRC-16/CCITT for "123456789" is 0x29B1
+
+    @Test
+    public void knownInput_producesExpectedChecksum() {
+        byte[] data = "123456789".getBytes();
+        byte[] result = CRC16ccitt.crc16ccitt(data, false, false);
+        int crc = (result[1] & 0xFF) << 8 | (result[0] & 0xFF);
+        assertWithMessage("CRC of '123456789'").that(crc).isEqualTo(0x29B1);
+    }
+
+    // -- skip_last_two excludes final 2 bytes --
+
+    @Test
+    public void skipLastTwo_excludesFinalBytes() {
+        byte[] data = {0x01, 0x02, 0x03, 0x04, 0x05};
+        byte[] withoutSkip = CRC16ccitt.crc16ccitt(
+                new byte[]{0x01, 0x02, 0x03}, false, false);
+        byte[] withSkip = CRC16ccitt.crc16ccitt(data, true, false);
+        assertThat(withSkip).isEqualTo(withoutSkip);
+    }
+
+    // -- skip_first excludes first byte --
+
+    @Test
+    public void skipFirst_changesCrc() {
+        byte[] data = {0x01, 0x02, 0x03, 0x04};
+        byte[] skipFirstResult = CRC16ccitt.crc16ccitt(data, false, true);
+        byte[] processAllResult = CRC16ccitt.crc16ccitt(data, false, false);
+        assertThat(skipFirstResult).isNotEqualTo(processAllResult);
+    }
+
+    // -- Empty effective input returns initial value --
+
+    @Test
+    public void singleByte_skipFirst_returnsInitialValue() {
+        byte[] data = {0x42};
+        byte[] result = CRC16ccitt.crc16ccitt(data, false, true);
+        int crc = (result[1] & 0xFF) << 8 | (result[0] & 0xFF);
+        assertWithMessage("No bytes processed should give initial value")
+                .that(crc).isEqualTo(0xFFFF);
+    }
+
+    // -- Result is always 2 bytes (little-endian) --
+
+    @Test
+    public void result_isAlwaysTwoBytes() {
+        byte[] data = {0x01, 0x02, 0x03};
+        byte[] result = CRC16ccitt.crc16ccitt(data, false, false);
+        assertThat(result.length).isEqualTo(2);
+    }
+
+    // -- Custom initial value changes result --
+
+    @Test
+    public void customInitialValue_changesCrc() {
+        byte[] data = {0x01, 0x02, 0x03};
+        byte[] defaultInit = CRC16ccitt.crc16ccitt(data, false, false, 0xFFFF);
+        byte[] customInit = CRC16ccitt.crc16ccitt(data, false, false, 0x0000);
+        assertThat(defaultInit).isNotEqualTo(customInit);
+    }
+
+    // -- Same input always gives same output --
+
+    @Test
+    public void sameInput_givesSameOutput() {
+        byte[] data = {(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF};
+        byte[] first = CRC16ccitt.crc16ccitt(data, false, false);
+        byte[] second = CRC16ccitt.crc16ccitt(data, false, false);
+        assertThat(first).isEqualTo(second);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utils/CRC16ccittTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utils/CRC16ccittTest.java
@@ -7,16 +7,21 @@ import org.junit.Test;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+/**
+ * @author Asbjørn Aarrestad
+ */
 public class CRC16ccittTest extends RobolectricTestWithConfig {
 
     // -- Known test vector: "123456789" with initial 0xFFFF --
-    // Standard CRC-16/CCITT for "123456789" is 0x29B1
 
     @Test
     public void knownInput_producesExpectedChecksum() {
+        // :: Act
         byte[] data = "123456789".getBytes();
         byte[] result = CRC16ccitt.crc16ccitt(data, false, false);
         int crc = (result[1] & 0xFF) << 8 | (result[0] & 0xFF);
+
+        // :: Verify — standard CRC-16/CCITT for "123456789" is 0x29B1
         assertWithMessage("CRC of '123456789'").that(crc).isEqualTo(0x29B1);
     }
 
@@ -24,10 +29,15 @@ public class CRC16ccittTest extends RobolectricTestWithConfig {
 
     @Test
     public void skipLastTwo_excludesFinalBytes() {
+        // :: Setup
         byte[] data = {0x01, 0x02, 0x03, 0x04, 0x05};
+
+        // :: Act
         byte[] withoutSkip = CRC16ccitt.crc16ccitt(
                 new byte[]{0x01, 0x02, 0x03}, false, false);
         byte[] withSkip = CRC16ccitt.crc16ccitt(data, true, false);
+
+        // :: Verify
         assertThat(withSkip).isEqualTo(withoutSkip);
     }
 
@@ -35,9 +45,14 @@ public class CRC16ccittTest extends RobolectricTestWithConfig {
 
     @Test
     public void skipFirst_changesCrc() {
+        // :: Setup
         byte[] data = {0x01, 0x02, 0x03, 0x04};
+
+        // :: Act
         byte[] skipFirstResult = CRC16ccitt.crc16ccitt(data, false, true);
         byte[] processAllResult = CRC16ccitt.crc16ccitt(data, false, false);
+
+        // :: Verify
         assertThat(skipFirstResult).isNotEqualTo(processAllResult);
     }
 
@@ -45,9 +60,11 @@ public class CRC16ccittTest extends RobolectricTestWithConfig {
 
     @Test
     public void singleByte_skipFirst_returnsInitialValue() {
-        byte[] data = {0x42};
-        byte[] result = CRC16ccitt.crc16ccitt(data, false, true);
+        // :: Act
+        byte[] result = CRC16ccitt.crc16ccitt(new byte[]{0x42}, false, true);
         int crc = (result[1] & 0xFF) << 8 | (result[0] & 0xFF);
+
+        // :: Verify
         assertWithMessage("No bytes processed should give initial value")
                 .that(crc).isEqualTo(0xFFFF);
     }
@@ -56,8 +73,10 @@ public class CRC16ccittTest extends RobolectricTestWithConfig {
 
     @Test
     public void result_isAlwaysTwoBytes() {
-        byte[] data = {0x01, 0x02, 0x03};
-        byte[] result = CRC16ccitt.crc16ccitt(data, false, false);
+        // :: Act
+        byte[] result = CRC16ccitt.crc16ccitt(new byte[]{0x01, 0x02, 0x03}, false, false);
+
+        // :: Verify
         assertThat(result.length).isEqualTo(2);
     }
 
@@ -65,9 +84,14 @@ public class CRC16ccittTest extends RobolectricTestWithConfig {
 
     @Test
     public void customInitialValue_changesCrc() {
+        // :: Setup
         byte[] data = {0x01, 0x02, 0x03};
+
+        // :: Act
         byte[] defaultInit = CRC16ccitt.crc16ccitt(data, false, false, 0xFFFF);
         byte[] customInit = CRC16ccitt.crc16ccitt(data, false, false, 0x0000);
+
+        // :: Verify
         assertThat(defaultInit).isNotEqualTo(customInit);
     }
 
@@ -75,9 +99,14 @@ public class CRC16ccittTest extends RobolectricTestWithConfig {
 
     @Test
     public void sameInput_givesSameOutput() {
+        // :: Setup
         byte[] data = {(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF};
+
+        // :: Act
         byte[] first = CRC16ccitt.crc16ccitt(data, false, false);
         byte[] second = CRC16ccitt.crc16ccitt(data, false, false);
+
+        // :: Verify
         assertThat(first).isEqualTo(second);
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utils/CircularArrayListTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utils/CircularArrayListTest.java
@@ -1,0 +1,122 @@
+package com.eveningoutpost.dexdrip.utils;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+public class CircularArrayListTest {
+
+    // -- Capacity and emptiness --
+
+    @Test
+    public void newBuffer_isEmpty() {
+        CircularArrayList<Integer> buf = new CircularArrayList<>(5);
+        assertThat(buf.size()).isEqualTo(0);
+        assertThat(buf.capacity()).isEqualTo(5);
+    }
+
+    // -- Adding and retrieving elements --
+
+    @Test
+    public void addElements_retrievableInOrder() {
+        CircularArrayList<String> buf = new CircularArrayList<>(3);
+        buf.add("a");
+        buf.add("b");
+        buf.add("c");
+        assertThat(buf.get(0)).isEqualTo("a");
+        assertThat(buf.get(1)).isEqualTo("b");
+        assertThat(buf.get(2)).isEqualTo("c");
+        assertThat(buf.size()).isEqualTo(3);
+    }
+
+    // -- Head and tail access --
+
+    @Test
+    public void headAndTail_returnFirstAndLastElement() {
+        CircularArrayList<Integer> buf = new CircularArrayList<>(5);
+        buf.add(10);
+        buf.add(20);
+        buf.add(30);
+        assertThat(buf.head()).isEqualTo(10);
+        assertThat(buf.tail()).isEqualTo(30);
+    }
+
+    @Test
+    public void tail_withOffset_returnsFromEnd() {
+        CircularArrayList<Integer> buf = new CircularArrayList<>(5);
+        buf.add(10);
+        buf.add(20);
+        buf.add(30);
+        assertThat(buf.tail(0)).isEqualTo(30);
+        assertThat(buf.tail(1)).isEqualTo(20);
+        assertThat(buf.tail(2)).isEqualTo(10);
+    }
+
+    // -- Full buffer without autoEvict throws --
+
+    @Test(expected = IllegalStateException.class)
+    public void addBeyondCapacity_withoutAutoEvict_throws() {
+        CircularArrayList<Integer> buf = new CircularArrayList<>(2);
+        buf.add(1);
+        buf.add(2);
+        buf.add(3);
+    }
+
+    // -- Remove shifts correctly --
+
+    @Test
+    public void removeFirst_shiftsRemaining() {
+        CircularArrayList<Integer> buf = new CircularArrayList<>(5);
+        buf.add(10);
+        buf.add(20);
+        buf.add(30);
+        int removed = buf.remove(0);
+        assertThat(removed).isEqualTo(10);
+        assertThat(buf.size()).isEqualTo(2);
+        assertThat(buf.head()).isEqualTo(20);
+    }
+
+    // -- Wraparound behavior --
+
+    @Test
+    public void wraparound_afterRemoveAndAdd_worksCorrectly() {
+        CircularArrayList<Integer> buf = new CircularArrayList<>(3);
+        buf.add(1);
+        buf.add(2);
+        buf.add(3);
+        buf.remove(0);
+        buf.add(4);
+        assertThat(buf.size()).isEqualTo(3);
+        assertThat(buf.get(0)).isEqualTo(2);
+        assertThat(buf.get(1)).isEqualTo(3);
+        assertThat(buf.get(2)).isEqualTo(4);
+    }
+
+    // -- Bounds checking --
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void getNegativeIndex_throws() {
+        CircularArrayList<Integer> buf = new CircularArrayList<>(3);
+        buf.add(1);
+        buf.get(-1);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void getIndexBeyondSize_throws() {
+        CircularArrayList<Integer> buf = new CircularArrayList<>(5);
+        buf.add(1);
+        buf.get(1);
+    }
+
+    // -- Set replaces value --
+
+    @Test
+    public void set_replacesExistingElement() {
+        CircularArrayList<String> buf = new CircularArrayList<>(3);
+        buf.add("a");
+        buf.add("b");
+        buf.set(1, "x");
+        assertThat(buf.get(1)).isEqualTo("x");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utils/CircularArrayListTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utils/CircularArrayListTest.java
@@ -5,13 +5,19 @@ import org.junit.Test;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+/**
+ * @author Asbjørn Aarrestad
+ */
 public class CircularArrayListTest {
 
     // -- Capacity and emptiness --
 
     @Test
     public void newBuffer_isEmpty() {
+        // :: Act
         CircularArrayList<Integer> buf = new CircularArrayList<>(5);
+
+        // :: Verify
         assertThat(buf.size()).isEqualTo(0);
         assertThat(buf.capacity()).isEqualTo(5);
     }
@@ -20,10 +26,15 @@ public class CircularArrayListTest {
 
     @Test
     public void addElements_retrievableInOrder() {
+        // :: Setup
         CircularArrayList<String> buf = new CircularArrayList<>(3);
+
+        // :: Act
         buf.add("a");
         buf.add("b");
         buf.add("c");
+
+        // :: Verify
         assertThat(buf.get(0)).isEqualTo("a");
         assertThat(buf.get(1)).isEqualTo("b");
         assertThat(buf.get(2)).isEqualTo("c");
@@ -34,20 +45,26 @@ public class CircularArrayListTest {
 
     @Test
     public void headAndTail_returnFirstAndLastElement() {
+        // :: Setup
         CircularArrayList<Integer> buf = new CircularArrayList<>(5);
         buf.add(10);
         buf.add(20);
         buf.add(30);
+
+        // :: Verify
         assertThat(buf.head()).isEqualTo(10);
         assertThat(buf.tail()).isEqualTo(30);
     }
 
     @Test
     public void tail_withOffset_returnsFromEnd() {
+        // :: Setup
         CircularArrayList<Integer> buf = new CircularArrayList<>(5);
         buf.add(10);
         buf.add(20);
         buf.add(30);
+
+        // :: Verify
         assertThat(buf.tail(0)).isEqualTo(30);
         assertThat(buf.tail(1)).isEqualTo(20);
         assertThat(buf.tail(2)).isEqualTo(10);
@@ -57,9 +74,12 @@ public class CircularArrayListTest {
 
     @Test(expected = IllegalStateException.class)
     public void addBeyondCapacity_withoutAutoEvict_throws() {
+        // :: Setup
         CircularArrayList<Integer> buf = new CircularArrayList<>(2);
         buf.add(1);
         buf.add(2);
+
+        // :: Act
         buf.add(3);
     }
 
@@ -67,12 +87,17 @@ public class CircularArrayListTest {
 
     @Test
     public void addBeyondCapacity_withAutoEvict_dropsOldest() {
+        // :: Setup
         CircularArrayList<Integer> buf = new CircularArrayList<>(3);
         buf.setAutoEvict(true);
         buf.add(1);
         buf.add(2);
         buf.add(3);
+
+        // :: Act
         buf.add(4);
+
+        // :: Verify
         assertThat(buf.size()).isEqualTo(3);
         assertThat(buf.head()).isEqualTo(2);
         assertThat(buf.tail()).isEqualTo(4);
@@ -82,11 +107,16 @@ public class CircularArrayListTest {
 
     @Test
     public void removeFirst_shiftsRemaining() {
+        // :: Setup
         CircularArrayList<Integer> buf = new CircularArrayList<>(5);
         buf.add(10);
         buf.add(20);
         buf.add(30);
+
+        // :: Act
         int removed = buf.remove(0);
+
+        // :: Verify
         assertThat(removed).isEqualTo(10);
         assertThat(buf.size()).isEqualTo(2);
         assertThat(buf.head()).isEqualTo(20);
@@ -96,12 +126,17 @@ public class CircularArrayListTest {
 
     @Test
     public void wraparound_afterRemoveAndAdd_worksCorrectly() {
+        // :: Setup
         CircularArrayList<Integer> buf = new CircularArrayList<>(3);
         buf.add(1);
         buf.add(2);
         buf.add(3);
+
+        // :: Act
         buf.remove(0);
         buf.add(4);
+
+        // :: Verify
         assertThat(buf.size()).isEqualTo(3);
         assertThat(buf.get(0)).isEqualTo(2);
         assertThat(buf.get(1)).isEqualTo(3);
@@ -112,15 +147,21 @@ public class CircularArrayListTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void getNegativeIndex_throws() {
+        // :: Setup
         CircularArrayList<Integer> buf = new CircularArrayList<>(3);
         buf.add(1);
+
+        // :: Act
         buf.get(-1);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void getIndexBeyondSize_throws() {
+        // :: Setup
         CircularArrayList<Integer> buf = new CircularArrayList<>(5);
         buf.add(1);
+
+        // :: Act
         buf.get(1);
     }
 
@@ -128,10 +169,15 @@ public class CircularArrayListTest {
 
     @Test
     public void set_replacesExistingElement() {
+        // :: Setup
         CircularArrayList<String> buf = new CircularArrayList<>(3);
         buf.add("a");
         buf.add("b");
+
+        // :: Act
         buf.set(1, "x");
+
+        // :: Verify
         assertThat(buf.get(1)).isEqualTo("x");
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utils/CircularArrayListTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utils/CircularArrayListTest.java
@@ -63,6 +63,21 @@ public class CircularArrayListTest {
         buf.add(3);
     }
 
+    // -- AutoEvict drops oldest element --
+
+    @Test
+    public void addBeyondCapacity_withAutoEvict_dropsOldest() {
+        CircularArrayList<Integer> buf = new CircularArrayList<>(3);
+        buf.setAutoEvict(true);
+        buf.add(1);
+        buf.add(2);
+        buf.add(3);
+        buf.add(4);
+        assertThat(buf.size()).isEqualTo(3);
+        assertThat(buf.head()).isEqualTo(2);
+        assertThat(buf.tail()).isEqualTo(4);
+    }
+
     // -- Remove shifts correctly --
 
     @Test


### PR DESCRIPTION
## Summary
- Add unit tests for `LogSlider`, `CircularArrayList`, `CRC16ccitt`, `ProfileItem`, `GlucoseData`, and `LibreUtils`
- Fix `CircularArrayList.autoEvict` bug: `add()` crashed with `IndexOutOfBoundsException` when buffer was full due to stale size/index after eviction
- 54 new tests total, all following Test Desiderata principles (behavioral, structure-insensitive, isolated)

## Test plan
- [x] All new tests pass individually
- [x] Full test suite passes (only pre-existing `BasalRepositoryTest` timezone failures)
- [x] Reviewer verifies tests are readable and test behavior, not implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)