### PR TITLE
test: add Nightscout service integration tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -243,7 +243,6 @@ dependencies {
     wearApp project(':wear')
     //weapApp files('../wear/build/outputs/apk/wear_release.apk')
     //testimplementation 'com.squareup.okhttp:mockwebserver:2.5.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.13'
     implementation('com.github.nightscout:android-uploader:CORE_FOR_XDRIP') {
         transitive = false
     }
@@ -358,6 +357,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation "org.robolectric:robolectric:4.11.1"
     testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.13'
 
     testImplementation 'org.mockito:mockito-inline:2.13.0'
     testImplementation 'org.mockito:mockito-core:4.11.0'

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutServiceIntegrationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutServiceIntegrationTest.java
@@ -3,12 +3,18 @@ package com.eveningoutpost.dexdrip.utilitymodels;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.cgm.nsfollow.GzipRequestInterceptor;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
 
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -51,7 +57,9 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
 
     @After
     public void tearDown() throws IOException {
-        server.shutdown();
+        if (server != null) {
+            server.shutdown();
+        }
     }
 
     @Test
@@ -242,5 +250,53 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
         assertThat(request.getPath()).isEqualTo("/api/v1/activity");
         assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
         assertThat(request.getBody().readUtf8()).isEqualTo("{\"mills\":1234567890}");
+    }
+
+    @Test
+    public void upload_withGzipInterceptor_compressesRequestBody() throws Exception {
+        // :: Setup
+        final MockWebServer gzipServer = new MockWebServer();
+        gzipServer.start();
+        gzipServer.enqueue(new MockResponse().setResponseCode(200));
+
+        final OkHttpClient gzipClient = new OkHttpClient.Builder()
+                .addInterceptor(new GzipRequestInterceptor())
+                .build();
+        final Retrofit gzipRetrofit = new Retrofit.Builder()
+                .baseUrl(gzipServer.url("/api/v1/"))
+                .client(gzipClient)
+                .build();
+        final NightscoutUploader.NightscoutService gzipService =
+                gzipRetrofit.create(NightscoutUploader.NightscoutService.class);
+
+        final String payload = "[{\"sgv\":120,\"type\":\"sgv\",\"direction\":\"Flat\"}]";
+        final RequestBody body = RequestBody.create(JSON, payload);
+
+        // :: Act
+        final Response<ResponseBody> response = gzipService.upload(API_SECRET, body).execute();
+        final RecordedRequest request = gzipServer.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getHeader("Content-Encoding")).isEqualTo("gzip");
+        assertThat(decompress(request.getBody().readByteArray())).isEqualTo(payload);
+
+        gzipServer.shutdown();
+    }
+
+    /**
+     * Decompresses a GZIP-compressed byte array to a String.
+     */
+    private static String decompress(byte[] compressed) throws IOException {
+        try (final GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(compressed));
+             final Reader reader = new InputStreamReader(gis, StandardCharsets.UTF_8)) {
+            final StringBuilder sb = new StringBuilder();
+            final char[] buffer = new char[1024];
+            int len;
+            while ((len = reader.read(buffer)) != -1) {
+                sb.append(buffer, 0, len);
+            }
+            return sb.toString();
+        }
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutServiceIntegrationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutServiceIntegrationTest.java
@@ -1,0 +1,246 @@
+package com.eveningoutpost.dexdrip.utilitymodels;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+
+/**
+ * Integration tests for {@link NightscoutUploader.NightscoutService} using MockWebServer.
+ * Verifies that the Retrofit 2 interface contract matches Nightscout API expectations.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig {
+
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    private static final String API_SECRET = "test-api-secret-hash";
+
+    private MockWebServer server;
+    private NightscoutUploader.NightscoutService service;
+
+    @Before
+    public void setUpService() throws IOException {
+        // :: Setup
+        server = new MockWebServer();
+        server.start();
+
+        final Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(server.url("/api/v1/"))
+                .client(new OkHttpClient())
+                .build();
+
+        service = retrofit.create(NightscoutUploader.NightscoutService.class);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    public void upload_withApiSecret_postsToEntries() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final RequestBody body = RequestBody.create(JSON, "[{\"sgv\":120}]");
+
+        // :: Act
+        final Response<ResponseBody> response = service.upload(API_SECRET, body).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath()).isEqualTo("/api/v1/entries");
+        assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
+        assertThat(request.getBody().readUtf8()).isEqualTo("[{\"sgv\":120}]");
+    }
+
+    @Test
+    public void upload_withoutApiSecret_postsToEntries() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final RequestBody body = RequestBody.create(JSON, "[{\"sgv\":120}]");
+
+        // :: Act
+        final Response<ResponseBody> response = service.upload(body).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath()).isEqualTo("/api/v1/entries");
+        assertThat(request.getHeader("api-secret")).isNull();
+        assertThat(request.getBody().readUtf8()).isEqualTo("[{\"sgv\":120}]");
+    }
+
+    @Test
+    public void uploadDeviceStatus_withoutApiSecret_postsToDevicestatus() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final RequestBody body = RequestBody.create(JSON, "{\"device\":\"xDrip\"}");
+
+        // :: Act
+        final Response<ResponseBody> response = service.uploadDeviceStatus(body).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath()).isEqualTo("/api/v1/devicestatus");
+        assertThat(request.getHeader("api-secret")).isNull();
+    }
+
+    @Test
+    public void uploadDeviceStatus_withApiSecret_postsToDevicestatus() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final RequestBody body = RequestBody.create(JSON, "{\"device\":\"xDrip\"}");
+
+        // :: Act
+        final Response<ResponseBody> response = service.uploadDeviceStatus(API_SECRET, body).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath()).isEqualTo("/api/v1/devicestatus");
+        assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
+    }
+
+    @Test
+    public void getStatus_sendsGetToStatusJson() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"status\":\"ok\"}"));
+
+        // :: Act
+        final Response<ResponseBody> response = service.getStatus(API_SECRET).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath()).isEqualTo("/api/v1/status.json");
+        assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
+    }
+
+    @Test
+    public void uploadTreatments_postsToTreatments() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final RequestBody body = RequestBody.create(JSON, "{\"eventType\":\"Correction Bolus\"}");
+
+        // :: Act
+        final Response<ResponseBody> response = service.uploadTreatments(API_SECRET, body).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath()).isEqualTo("/api/v1/treatments");
+        assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
+    }
+
+    @Test
+    public void upsertTreatments_putsToTreatments() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final RequestBody body = RequestBody.create(JSON, "{\"eventType\":\"Correction Bolus\"}");
+
+        // :: Act
+        final Response<ResponseBody> response = service.upsertTreatments(API_SECRET, body).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("PUT");
+        assertThat(request.getPath()).isEqualTo("/api/v1/treatments");
+        assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
+    }
+
+    @Test
+    public void downloadTreatments_sendsGetWithIfModifiedSinceHeader() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("[]"));
+        final String ifModified = "2024-01-01T00:00:00Z";
+
+        // :: Act
+        final Response<ResponseBody> response = service.downloadTreatments(API_SECRET, ifModified).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath()).isEqualTo("/api/v1/treatments");
+        assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
+        assertThat(request.getHeader("BROKEN-If-Modified-Since")).isEqualTo(ifModified);
+    }
+
+    @Test
+    public void findTreatmentByUUID_sendsGetWithQueryParam() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("[]"));
+        final String uuid = "abc-123-def";
+
+        // :: Act
+        final Response<ResponseBody> response = service.findTreatmentByUUID(API_SECRET, uuid).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath()).isEqualTo("/api/v1/treatments.json?find%5Buuid%5D=abc-123-def");
+        assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
+    }
+
+    @Test
+    public void deleteTreatment_sendsDeleteWithPathParam() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final String treatmentId = "5f1234567890abcdef123456";
+
+        // :: Act
+        final Response<ResponseBody> response = service.deleteTreatment(API_SECRET, treatmentId).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("DELETE");
+        assertThat(request.getPath()).isEqualTo("/api/v1/treatments/5f1234567890abcdef123456");
+        assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
+    }
+
+    @Test
+    public void uploadActivity_postsToActivity() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final RequestBody body = RequestBody.create(JSON, "{\"mills\":1234567890}");
+
+        // :: Act
+        final Response<ResponseBody> response = service.uploadActivity(API_SECRET, body).execute();
+        final RecordedRequest request = server.takeRequest();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath()).isEqualTo("/api/v1/activity");
+        assertThat(request.getHeader("api-secret")).isEqualTo(API_SECRET);
+        assertThat(request.getBody().readUtf8()).isEqualTo("{\"mills\":1234567890}");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploaderCallerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploaderCallerTest.java
@@ -1,0 +1,267 @@
+package com.eveningoutpost.dexdrip.utilitymodels;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.models.BgReading;
+import com.eveningoutpost.dexdrip.models.BloodTest;
+import com.eveningoutpost.dexdrip.models.Calibration;
+import com.google.common.base.Charsets;
+import com.google.common.hash.Hashing;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * Caller-level integration tests for {@link NightscoutUploader} using MockWebServer.
+ * Exercises the actual production code paths including secret hashing,
+ * payload building, error handling, and the disabled-upload guard.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class NightscoutUploaderCallerTest extends RobolectricTestWithConfig {
+
+    private static final String SECRET = "my-api-secret";
+    private static final String EXPECTED_HASHED_SECRET =
+            Hashing.sha1().hashBytes(SECRET.getBytes(Charsets.UTF_8)).toString();
+
+    private MockWebServer server;
+    private SharedPreferences prefs;
+
+    @Before
+    public void setUpServer() throws IOException {
+        super.setUp();
+        server = new MockWebServer();
+        server.start();
+        prefs = PreferenceManager.getDefaultSharedPreferences(
+                org.robolectric.RuntimeEnvironment.application);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void uploadRest_hashesSecretWithSha1_andSendsAsApiSecretHeader() throws Exception {
+        // :: Setup
+        final String baseUrl = "http://" + SECRET + "@" + server.getHostName()
+                + ":" + server.getPort() + "/api/v1/";
+        prefs.edit()
+                .putBoolean("cloud_storage_api_enable", true)
+                .putString("cloud_storage_api_base", baseUrl)
+                .putBoolean("cloud_storage_api_download_enable", false)
+                .apply();
+
+        final BgReading bg = createBgReading(120.0, System.currentTimeMillis());
+
+        // Enqueue enough responses: status + entries + devicestatus (battery)
+        enqueueSuccessResponses(5);
+
+        final NightscoutUploader uploader = new NightscoutUploader(
+                org.robolectric.RuntimeEnvironment.application);
+
+        // :: Act
+        final boolean result = uploader.uploadRest(
+                Collections.singletonList(bg),
+                Collections.emptyList(),
+                Collections.emptyList());
+
+        // :: Verify
+        assertThat(result).isTrue();
+
+        // Find the entries POST request among all requests
+        RecordedRequest entriesRequest = findRequestByPath("/api/v1/entries");
+        assertThat(entriesRequest).isNotNull();
+        assertThat(entriesRequest.getHeader("api-secret")).isEqualTo(EXPECTED_HASHED_SECRET);
+    }
+
+    @Test
+    public void uploadRest_buildsBgEntryPayloadWithExpectedFields() throws Exception {
+        // :: Setup
+        final long timestamp = 1700000000000L;
+        final double bgValue = 185.0;
+        final String baseUrl = "http://" + SECRET + "@" + server.getHostName()
+                + ":" + server.getPort() + "/api/v1/";
+        prefs.edit()
+                .putBoolean("cloud_storage_api_enable", true)
+                .putString("cloud_storage_api_base", baseUrl)
+                .putBoolean("cloud_storage_api_download_enable", false)
+                .apply();
+
+        final BgReading bg = createBgReading(bgValue, timestamp);
+
+        enqueueSuccessResponses(5);
+
+        final NightscoutUploader uploader = new NightscoutUploader(
+                org.robolectric.RuntimeEnvironment.application);
+
+        // :: Act
+        uploader.uploadRest(
+                Collections.singletonList(bg),
+                Collections.emptyList(),
+                Collections.emptyList());
+
+        // :: Verify
+        final RecordedRequest entriesRequest = findRequestByPath("/api/v1/entries");
+        assertThat(entriesRequest).isNotNull();
+
+        final String body = decompressIfNeeded(entriesRequest);
+        final JSONArray arr = new JSONArray(body);
+        assertThat(arr.length()).isEqualTo(1);
+
+        final JSONObject entry = arr.getJSONObject(0);
+        assertThat(entry.getInt("sgv")).isEqualTo((int) bgValue);
+        assertThat(entry.getLong("date")).isEqualTo(timestamp);
+        assertThat(entry.getString("type")).isEqualTo("sgv");
+        assertThat(entry.getInt("rssi")).isEqualTo(100);
+        assertThat(entry.has("direction")).isTrue();
+        assertThat(entry.has("dateString")).isTrue();
+        assertThat(entry.has("sysTime")).isTrue();
+        assertThat(entry.getString("device")).startsWith("xDrip-");
+    }
+
+    @Test
+    public void uploadRest_whenServerReturns500_returnsFalse() throws Exception {
+        // :: Setup
+        final String baseUrl = "http://" + SECRET + "@" + server.getHostName()
+                + ":" + server.getPort() + "/api/v1/";
+        prefs.edit()
+                .putBoolean("cloud_storage_api_enable", true)
+                .putString("cloud_storage_api_base", baseUrl)
+                .putBoolean("cloud_storage_api_download_enable", false)
+                .apply();
+
+        final BgReading bg = createBgReading(120.0, System.currentTimeMillis());
+
+        // Status may succeed, but entries upload fails with 500
+        server.enqueue(new MockResponse().setResponseCode(200)
+                .setBody("{\"status\":\"ok\",\"version\":\"14.0\"}"));
+        server.enqueue(new MockResponse().setResponseCode(500).setBody("Internal Server Error"));
+
+        final NightscoutUploader uploader = new NightscoutUploader(
+                org.robolectric.RuntimeEnvironment.application);
+
+        // :: Act
+        final boolean result = uploader.uploadRest(
+                Collections.singletonList(bg),
+                Collections.emptyList(),
+                Collections.emptyList());
+
+        // :: Verify
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void uploadRest_whenDisabled_sendsNoHttpRequests() throws Exception {
+        // :: Setup
+        prefs.edit()
+                .putBoolean("cloud_storage_api_enable", false)
+                .putString("cloud_storage_api_base", "http://secret@localhost/api/v1/")
+                .apply();
+
+        final BgReading bg = createBgReading(120.0, System.currentTimeMillis());
+
+        final NightscoutUploader uploader = new NightscoutUploader(
+                org.robolectric.RuntimeEnvironment.application);
+
+        // :: Act
+        final boolean result = uploader.uploadRest(
+                Collections.singletonList(bg),
+                Collections.emptyList(),
+                Collections.emptyList());
+
+        // :: Verify
+        assertThat(result).isFalse();
+        assertThat(server.getRequestCount()).isEqualTo(0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static BgReading createBgReading(double calculatedValue, long timestamp) {
+        final BgReading bg = new BgReading();
+        bg.calculated_value = calculatedValue;
+        bg.filtered_calculated_value = calculatedValue;
+        bg.timestamp = timestamp;
+        bg.raw_data = calculatedValue;
+        bg.age_adjusted_raw_value = calculatedValue;
+        bg.filtered_data = calculatedValue;
+        bg.noise = "1";
+        bg.calculated_value_slope = 0;
+        bg.hide_slope = false;
+        return bg;
+    }
+
+    private void enqueueSuccessResponses(int count) {
+        for (int i = 0; i < count; i++) {
+            server.enqueue(new MockResponse().setResponseCode(200)
+                    .setBody("{\"status\":\"ok\",\"version\":\"14.0\"}"));
+        }
+    }
+
+    /**
+     * Finds the first request whose path matches the given prefix.
+     * Drains up to 10 requests from the server within a short timeout.
+     */
+    private RecordedRequest findRequestByPath(String pathPrefix) throws InterruptedException {
+        RecordedRequest match = null;
+        for (int i = 0; i < 10; i++) {
+            final RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
+            if (req == null) break;
+            if (req.getPath() != null && req.getPath().startsWith(pathPrefix) && "POST".equals(req.getMethod())) {
+                if (match == null) {
+                    match = req;
+                }
+            }
+        }
+        return match;
+    }
+
+    /**
+     * Decompresses the request body if gzip-encoded, otherwise returns it as-is.
+     */
+    private static String decompressIfNeeded(RecordedRequest request) throws IOException {
+        final String encoding = request.getHeader("Content-Encoding");
+        if ("gzip".equals(encoding)) {
+            return decompress(request.getBody().readByteArray());
+        }
+        return request.getBody().readUtf8();
+    }
+
+    private static String decompress(byte[] compressed) throws IOException {
+        try (final GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(compressed));
+             final Reader reader = new InputStreamReader(gis, StandardCharsets.UTF_8)) {
+            final StringBuilder sb = new StringBuilder();
+            final char[] buffer = new char[1024];
+            int len;
+            while ((len = reader.read(buffer)) != -1) {
+                sb.append(buffer, 0, len);
+            }
+            return sb.toString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add MockWebServer test dependency (`okhttp3:mockwebserver:3.12.13`)
- Add integration tests for all 11 NightscoutService interface methods
- Verify HTTP contracts: paths, methods, headers, body content
- Test GZIP compression via GzipRequestInterceptor

## Test plan
- [x] All 12 tests pass (`NightscoutServiceIntegrationTest`)
- [x] Full test suite passes

Relates to #1812

🤖 Generated with [Claude Code](https://claude.com/claude-code)