### PR TITLE
test: add Nightscout follower integration tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -243,7 +243,6 @@ dependencies {
     wearApp project(':wear')
     //weapApp files('../wear/build/outputs/apk/wear_release.apk')
     //testimplementation 'com.squareup.okhttp:mockwebserver:2.5.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.13'
     implementation('com.github.nightscout:android-uploader:CORE_FOR_XDRIP') {
         transitive = false
     }
@@ -358,6 +357,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation "org.robolectric:robolectric:4.11.1"
     testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.13'
 
     testImplementation 'org.mockito:mockito-inline:2.13.0'
     testImplementation 'org.mockito:mockito-core:4.11.0'

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowCallerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowCallerTest.java
@@ -1,0 +1,106 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.cgm.nsfollow.messages.Entry;
+import com.eveningoutpost.dexdrip.utils.framework.RetrofitService;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import retrofit2.Response;
+
+/**
+ * Caller-level integration tests for NightscoutFollow.Nightscout via RetrofitService.
+ * <p>
+ * Exercises the full production stack: RetrofitService.getRetrofitInstance() with its
+ * interceptors (HttpLogging, InfoInterceptor, GzipRequestInterceptor) and custom GSON
+ * (UNRELIABLE_INTEGER_FACTORY), verifying that the Nightscout client works end-to-end.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class NightscoutFollowCallerTest extends RobolectricTestWithConfig {
+
+    private static final String ENTRIES_JSON =
+            "[{\"_id\":\"69b6b587\",\"sgv\":180,\"date\":1773581680168,\"direction\":\"SingleDown\",\"device\":\"G7\",\"type\":\"sgv\",\"filtered\":0,\"unfiltered\":0},"
+                    + "{\"_id\":\"69b6b588\",\"sgv\":204,\"date\":1773581380168,\"direction\":\"Flat\",\"device\":\"Unknown\",\"type\":\"sgv\"}]";
+
+    private MockWebServer server;
+
+    @Before
+    public void setUpServer() throws Exception {
+        RetrofitService.clear();
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        RetrofitService.clear();
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void retrofitService_createsWorkingNightscoutClient() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .setBody(ENTRIES_JSON)
+                .addHeader("Content-Type", "application/json"));
+
+        String baseUrl = server.url("/").toString();
+        NightscoutFollow.Nightscout api = RetrofitService
+                .getRetrofitInstance(baseUrl, "NightscoutFollow", true)
+                .create(NightscoutFollow.Nightscout.class);
+
+        // :: Act
+        Response<List<Entry>> response = api.getEntries("test-secret", 10, "12345").execute();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+
+        List<Entry> entries = response.body();
+        assertThat(entries).hasSize(2);
+
+        Entry first = entries.get(0);
+        assertThat(first.sgv).isEqualTo(180);
+        assertThat(first.direction).isEqualTo("SingleDown");
+        assertThat(first.device).isEqualTo("G7");
+        assertThat(first.date).isWithin(0.1).of(1773581680168.0);
+
+        Entry second = entries.get(1);
+        assertThat(second.sgv).isEqualTo(204);
+        assertThat(second.direction).isEqualTo("Flat");
+
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getHeader("api-secret")).isEqualTo("test-secret");
+        assertThat(request.getPath()).contains("/api/v1/entries.json");
+        assertThat(request.getPath()).contains("count=10");
+    }
+
+    @Test
+    public void retrofitService_handlesServerErrorGracefully() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        String baseUrl = server.url("/").toString();
+        NightscoutFollow.Nightscout api = RetrofitService
+                .getRetrofitInstance(baseUrl, "NightscoutFollow", true)
+                .create(NightscoutFollow.Nightscout.class);
+
+        // :: Act
+        Response<List<Entry>> response = api.getEntries("test-secret", 10, "12345").execute();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isFalse();
+        assertThat(response.code()).isEqualTo(500);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowCallerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowCallerTest.java
@@ -36,6 +36,7 @@ public class NightscoutFollowCallerTest extends RobolectricTestWithConfig {
 
     @Before
     public void setUpServer() throws Exception {
+        super.setUp();
         RetrofitService.clear();
         server = new MockWebServer();
         server.start();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowIntegrationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.cgm.nsfollow.messages.Entry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+/**
+ * Integration tests for the NightscoutFollow.Nightscout Retrofit interface.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class NightscoutFollowIntegrationTest extends RobolectricTestWithConfig {
+
+    private static final String ENTRIES_JSON =
+            "[{\"_id\":\"69b6b587\",\"sgv\":180,\"date\":1773581680168,\"direction\":\"SingleDown\",\"device\":\"G7\",\"type\":\"sgv\",\"filtered\":0,\"unfiltered\":0},"
+                    + "{\"_id\":\"69b6b588\",\"sgv\":204,\"date\":1773581380168,\"direction\":\"Flat\",\"device\":\"Unknown\",\"type\":\"sgv\"}]";
+
+    private static final String TREATMENTS_JSON =
+            "[{\"_id\":\"69b6b5b3\",\"eventType\":\"Temp Basal\",\"rate\":0,\"duration\":60,\"date\":1773581725647}]";
+
+    private MockWebServer server;
+    private NightscoutFollow.Nightscout api;
+
+    @Before
+    public void setUpServer() throws Exception {
+        server = new MockWebServer();
+        server.start();
+
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(server.url("/"))
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
+
+        api = retrofit.create(NightscoutFollow.Nightscout.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void getEntries_sendsApiSecretAndQueryParams() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .setBody(ENTRIES_JSON)
+                .addHeader("Content-Type", "application/json"));
+
+        // :: Act
+        Response<List<Entry>> response = api.getEntries("test-secret", 10, "12345").execute();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath()).contains("/api/v1/entries.json");
+        assertThat(request.getPath()).contains("count=10");
+        assertThat(request.getPath()).contains("rr=12345");
+        assertThat(request.getHeader("api-secret")).isEqualTo("test-secret");
+    }
+
+    @Test
+    public void getEntries_parsesEntryArray() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .setBody(ENTRIES_JSON)
+                .addHeader("Content-Type", "application/json"));
+
+        // :: Act
+        Response<List<Entry>> response = api.getEntries("test-secret", 10, "12345").execute();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        List<Entry> entries = response.body();
+        assertThat(entries).hasSize(2);
+
+        Entry first = entries.get(0);
+        assertThat(first.sgv).isEqualTo(180);
+        assertThat(first.direction).isEqualTo("SingleDown");
+        assertThat(first.device).isEqualTo("G7");
+        assertThat(first.date).isWithin(0.1).of(1773581680168.0);
+
+        Entry second = entries.get(1);
+        assertThat(second.sgv).isEqualTo(204);
+        assertThat(second.direction).isEqualTo("Flat");
+        assertThat(second.device).isEqualTo("Unknown");
+    }
+
+    @Test
+    public void getTreatments_getsWithApiSecret() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .setBody(TREATMENTS_JSON)
+                .addHeader("Content-Type", "application/json"));
+
+        // :: Act
+        Response<ResponseBody> response = api.getTreatments("treatment-secret").execute();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath()).isEqualTo("/api/v1/treatments");
+        assertThat(request.getHeader("api-secret")).isEqualTo("treatment-secret");
+        assertThat(response.body().string()).contains("Temp Basal");
+    }
+}


### PR DESCRIPTION
## Summary
- Integration tests for NightscoutFollow.Nightscout interface
- Verifies entries query params, api-secret header, treatments download
- Tests Entry deserialization with real Nightscout response formats

## Test plan
- [x] All 3 tests pass (`NightscoutFollowIntegrationTest`)
- [x] Full test suite passes

Relates to #1812

🤖 Generated with [Claude Code](https://claude.com/claude-code)