### PR TITLE
Fix staircase duplicate readings from Companion App

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
@@ -41,6 +41,7 @@ import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.xdrip;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -72,7 +73,7 @@ public class UiBasedCollector extends NotificationListenerService {
     String lastPackage;
 
     @VisibleForTesting
-    final java.util.HashMap<String, Long> lastNotificationWhen = new java.util.HashMap<>();
+    final HashMap<String, Long> lastNotificationWhen = new HashMap<>();
 
     @VisibleForTesting
     boolean isStaleNotification(final String packageName, final long when) {

--- a/app/src/test/java/com/eveningoutpost/dexdrip/services/UiBasedCollectorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/services/UiBasedCollectorTest.java
@@ -283,6 +283,8 @@ public class UiBasedCollectorTest extends RobolectricTestWithConfig {
                 .that(ui.isStaleNotification("com.medtronic.diabetes.guardian", notificationWhen)).isTrue();
         assertWithMessage("notification with new 'when' should not be stale")
                 .that(ui.isStaleNotification("com.medtronic.diabetes.guardian", notificationWhen + Constants.MINUTE_IN_MS * 5)).isFalse();
+        assertWithMessage("same new 'when' again should be stale")
+                .that(ui.isStaleNotification("com.medtronic.diabetes.guardian", notificationWhen + Constants.MINUTE_IN_MS * 5)).isTrue();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add notification staleness detection in `UiBasedCollector` to prevent "staircase" duplicate glucose readings from companion apps (e.g. Medtronic Guardian 4)
- Track `Notification.when` per companion app package — if the same `when` arrives twice, skip processing (notification content hasn't been refreshed)
- Safety bypass: `when == 0` always treated as fresh, so readings are never silently dropped when companion apps don't set the timestamp
- `handleNewValue()` deduplication logic is completely untouched

Fixes the issue described in https://github.com/NightscoutFoundation/xDrip/discussions/4385

## Root Cause

Companion apps like Medtronic Guardian re-post their notification every ~5 minutes, but the actual sensor reading only changes every ~10 minutes. Between real updates, the notification contains the same glucose value. The existing `handleNewValue()` dedup window (~250s) is shorter than the 5-minute notification interval, so stale duplicates slip through — creating "staircase" data with zero delta that confuses AAPS looping.

## Test plan

- [x] Characterization tests for existing dedup behavior (different values 5min apart, same value 10min apart, alternating values, jam detection)
- [x] Regression tests for stale notification detection (same `when` skipped, `when=0` bypass, per-package independence)
- [x] All 18 UiBasedCollector tests pass
- [x] Full unit test suite passes (2 pre-existing unrelated failures in BasalRepositoryTest)
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)