### PR TITLE
chore: remove OkHttp2 and Retrofit 1 dependencies (migration 5/5)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -242,7 +242,6 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     wearApp project(':wear')
     //weapApp files('../wear/build/outputs/apk/wear_release.apk')
-    //testimplementation 'com.squareup.okhttp:mockwebserver:2.5.0'
     implementation('com.github.nightscout:android-uploader:CORE_FOR_XDRIP') {
         transitive = false
     }
@@ -293,7 +292,6 @@ dependencies {
     implementation "com.google.android.gms:play-services-oss-licenses:15.0.0"
     implementation "com.google.protobuf:protobuf-java:4.34.0"
     implementation 'com.squareup.wire:wire-runtime:2.2.0'
-    implementation 'com.squareup.okhttp:okhttp:2.7.5'
     implementation 'com.squareup.okhttp3:okhttp:3.12.13'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.13'
     //implementation 'com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0'
@@ -303,7 +301,6 @@ dependencies {
     implementation 'com.squareup.moshi:moshi:1.9.2'
     //implementation 'org.influxdb:influxdb-java:2.6'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.squareup.retrofit:converter-gson:2.0.0-beta2'
     implementation 'com.getpebble:pebblekit:4.0.1'
     implementation ("androidx.health.connect:connect-client:1.1.0-alpha06") {
         exclude group: 'androidx.core', module: 'core'


### PR DESCRIPTION
## Summary

Final step of the OkHttp2 → OkHttp3 migration series. With all callers migrated in the preceding PRs, the legacy dependencies are no longer needed and can be removed from `app/build.gradle`:

- **`com.squareup.okhttp:okhttp:2.7.5`** — replaced by `com.squareup.okhttp3:okhttp:3.12.13`
- **`com.squareup.retrofit:converter-gson:2.0.0-beta2`** (Retrofit 1) — replaced by `com.squareup.retrofit2:converter-gson:2.4.0`
- **`//testimplementation 'com.squareup.okhttp:mockwebserver:2.5.0'`** — stale commented line, OkHttp3 mockwebserver already in use

Removing the dependencies enforces the migration at compile time — any accidental reintroduction of OkHttp2 usage will now be caught by the compiler.

## Depends on

> **Must be merged after #4437 and #4443**

- #4437 — Migrate all HTTP clients to shared OkHttp3 client
- #4443 — Migrate Dexcom Share from Retrofit 1 to Retrofit 2

## Test plan

- [x] `./gradlew assembleProdDebug` — BUILD SUCCESSFUL (verified on top of #4443)
- [x] `./gradlew :app:testProdDebugUnitTest` — all tests pass
- [x] Zero remaining `com.squareup.okhttp.` imports in `app/src/main/java/` (excluding `okhttp3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)