### PR TITLE
[pattern] Replace resources.getColor with ContextCompat.getColor in PercentileView

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/PercentileView.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/PercentileView.java
@@ -12,6 +12,8 @@ import android.graphics.Path;
 import android.preference.PreferenceManager;
 import android.util.DisplayMetrics;
 
+import androidx.core.content.ContextCompat;
+
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import android.view.View;
 
@@ -47,40 +49,40 @@ public class PercentileView extends View {
 
         float textSize = dp2px(14);
         outerPaint = new Paint();
-        outerPaint.setColor(resources.getColor(R.color.percentile_outer));
+        outerPaint.setColor(ContextCompat.getColor(getContext(), R.color.percentile_outer));
         outerPaint.setStyle(Paint.Style.FILL_AND_STROKE);
         outerPaint.setPathEffect(new CornerPathEffect(dp2px(10)));
         outerPaint.setStrokeWidth(dp2px(1));
 
 
         outerPaintLabel = new Paint();
-        outerPaintLabel.setColor(resources.getColor(R.color.percentile_outer));
+        outerPaintLabel.setColor(ContextCompat.getColor(getContext(), R.color.percentile_outer));
         outerPaintLabel.setStyle(Paint.Style.FILL_AND_STROKE);
         outerPaintLabel.setPathEffect(new CornerPathEffect(dp2px(10)));
         outerPaintLabel.setTextSize(textSize);
 
         innerPaint = new Paint();
-        innerPaint.setColor(resources.getColor(R.color.percentile_inner));
+        innerPaint.setColor(ContextCompat.getColor(getContext(), R.color.percentile_inner));
         innerPaint.setStyle(Paint.Style.FILL_AND_STROKE);
         innerPaint.setPathEffect(new CornerPathEffect(dp2px(10)));
         innerPaint.setStrokeWidth(dp2px(1));
 
         innerPaintLabel = new Paint();
-        innerPaintLabel.setColor(resources.getColor(R.color.percentile_inner));
+        innerPaintLabel.setColor(ContextCompat.getColor(getContext(), R.color.percentile_inner));
         innerPaintLabel.setStyle(Paint.Style.FILL_AND_STROKE);
         innerPaintLabel.setPathEffect(new CornerPathEffect(dp2px(10)));
         innerPaintLabel.setTextSize(textSize);
 
 
         medianPaint = new Paint();
-        medianPaint.setColor(resources.getColor(R.color.percentile_median));
+        medianPaint.setColor(ContextCompat.getColor(getContext(), R.color.percentile_median));
         medianPaint.setStyle(Paint.Style.STROKE);
         medianPaint.setPathEffect(new CornerPathEffect(dp2px(10)));
         medianPaint.setStrokeWidth(dp2px(1));
 
 
         medianPaintLabel = new Paint();
-        medianPaintLabel.setColor(resources.getColor(R.color.percentile_median));
+        medianPaintLabel.setColor(ContextCompat.getColor(getContext(), R.color.percentile_median));
         medianPaintLabel.setStyle(Paint.Style.STROKE);
         medianPaintLabel.setPathEffect(new CornerPathEffect(dp2px(10)));
         medianPaintLabel.setTextSize(textSize);

--- a/app/src/test/java/com/eveningoutpost/dexdrip/stats/PercentileViewTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/stats/PercentileViewTest.java
@@ -1,0 +1,99 @@
+package com.eveningoutpost.dexdrip.stats;
+
+import android.graphics.Paint;
+
+import androidx.core.content.ContextCompat;
+
+import com.eveningoutpost.dexdrip.R;
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Characterization tests for {@link PercentileView}.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class PercentileViewTest extends RobolectricTestWithConfig {
+
+    // --- Constructor ---
+
+    /** Characterization: outerPaint color is initialized from percentile_outer resource */
+    @Test
+    public void constructor_setsOuterPaintColor() throws Exception {
+        // :: Act
+        PercentileView view = new PercentileView(xdrip.getAppContext());
+
+        // :: Verify
+        int expected = ContextCompat.getColor(xdrip.getAppContext(), R.color.percentile_outer);
+        assertThat(paintColor(view, "outerPaint")).isEqualTo(expected);
+    }
+
+    /** Characterization: outerPaintLabel color is initialized from percentile_outer resource */
+    @Test
+    public void constructor_setsOuterPaintLabelColor() throws Exception {
+        // :: Act
+        PercentileView view = new PercentileView(xdrip.getAppContext());
+
+        // :: Verify
+        int expected = ContextCompat.getColor(xdrip.getAppContext(), R.color.percentile_outer);
+        assertThat(paintColor(view, "outerPaintLabel")).isEqualTo(expected);
+    }
+
+    /** Characterization: innerPaint color is initialized from percentile_inner resource */
+    @Test
+    public void constructor_setsInnerPaintColor() throws Exception {
+        // :: Act
+        PercentileView view = new PercentileView(xdrip.getAppContext());
+
+        // :: Verify
+        int expected = ContextCompat.getColor(xdrip.getAppContext(), R.color.percentile_inner);
+        assertThat(paintColor(view, "innerPaint")).isEqualTo(expected);
+    }
+
+    /** Characterization: innerPaintLabel color is initialized from percentile_inner resource */
+    @Test
+    public void constructor_setsInnerPaintLabelColor() throws Exception {
+        // :: Act
+        PercentileView view = new PercentileView(xdrip.getAppContext());
+
+        // :: Verify
+        int expected = ContextCompat.getColor(xdrip.getAppContext(), R.color.percentile_inner);
+        assertThat(paintColor(view, "innerPaintLabel")).isEqualTo(expected);
+    }
+
+    /** Characterization: medianPaint color is initialized from percentile_median resource */
+    @Test
+    public void constructor_setsMedianPaintColor() throws Exception {
+        // :: Act
+        PercentileView view = new PercentileView(xdrip.getAppContext());
+
+        // :: Verify
+        int expected = ContextCompat.getColor(xdrip.getAppContext(), R.color.percentile_median);
+        assertThat(paintColor(view, "medianPaint")).isEqualTo(expected);
+    }
+
+    /** Characterization: medianPaintLabel color is initialized from percentile_median resource */
+    @Test
+    public void constructor_setsMedianPaintLabelColor() throws Exception {
+        // :: Act
+        PercentileView view = new PercentileView(xdrip.getAppContext());
+
+        // :: Verify
+        int expected = ContextCompat.getColor(xdrip.getAppContext(), R.color.percentile_median);
+        assertThat(paintColor(view, "medianPaintLabel")).isEqualTo(expected);
+    }
+
+    // --- Helpers ---
+
+    private int paintColor(PercentileView view, String fieldName) throws Exception {
+        Field field = PercentileView.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return ((Paint) field.get(view)).getColor();
+    }
+}


### PR DESCRIPTION
## Summary

- Replace 6x deprecated `resources.getColor(int)` calls with `ContextCompat.getColor(getContext(), int)` in `stats/PercentileView.java`
- Add characterization tests covering all 6 paint color initializations before the change
- Add `docs/cleanup/context-resources.md` migration note for future cleanup PRs in this category

This is the **pattern PR** for Category 1 of the deprecated API cleanup plan. The only file in this category is `PercentileView.java`, so this single PR completes Category 1.

No functional changes — pure API modernization.

## Test Plan

- [x] All 6 `PercentileViewTest` characterization tests pass before and after the replacement
- [x] No functional regressions — paint colors are identical at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)