### PR TITLE
Raise max from 400 to 500mg/dL

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
@@ -23,6 +23,7 @@ import com.activeandroid.util.SQLiteUtils;
 import com.eveningoutpost.dexdrip.BestGlucose;
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
+import com.eveningoutpost.dexdrip.calibrations.PluggableCalibration;
 import com.eveningoutpost.dexdrip.importedlibraries.dexcom.records.EGVRecord;
 import com.eveningoutpost.dexdrip.importedlibraries.dexcom.records.SensorRecord;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
@@ -81,8 +82,8 @@ public class BgReading extends Model implements ShareUploadableBg {
 
     public static final int BG_READING_ERROR_VALUE = 38; // error marker
     public static final int BG_READING_MINIMUM_VALUE = 39;
-    public static final int BG_READING_MAXIMUM_VALUE = 400;
-
+    private static final int BG_READING_MAXIMUM_VALUE = 500; // xDrip will only display values below this boundary.
+    private static final int BG_READING_MAXIMUM_VALUE_SAFE = 400; // xDrip will only display unverified values below this boundary.
     private static volatile long earliest_backfill = 0;
 
     @Column(name = "sensor", index = true)
@@ -195,6 +196,14 @@ public class BgReading extends Model implements ShareUploadableBg {
     @Expose
     @Column(name = "source_info")
     public volatile String source_info;
+
+    public static int getBgReadingMaximumValue() {
+        if (Pref.getBooleanDefaultFalse("display_glucose_from_plugin") || PluggableCalibration.getCalibrationPluginFromPreferences() != null) {
+            return BG_READING_MAXIMUM_VALUE_SAFE;
+        } else {
+            return BG_READING_MAXIMUM_VALUE;
+        }
+    }
 
     public synchronized static void updateDB() {
         final String[] updates = new String[]{"ALTER TABLE BgReadings ADD COLUMN dg_mgdl REAL;",
@@ -654,7 +663,7 @@ public class BgReading extends Model implements ShareUploadableBg {
             bgReading.calculated_value = BG_READING_ERROR_VALUE;
             bgReading.hide_slope = true;
         } else {
-            bgReading.calculated_value = Math.min(BG_READING_MAXIMUM_VALUE, Math.max(BG_READING_MINIMUM_VALUE, bgReading.calculated_value));
+            bgReading.calculated_value = Math.min(getBgReadingMaximumValue(), Math.max(BG_READING_MINIMUM_VALUE, bgReading.calculated_value));
         }
         Log.i(TAG, "NEW VALUE CALCULATED AT: " + bgReading.calculated_value);
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -361,7 +361,7 @@ public class BgGraphBuilder {
     private float clampNonGlucoseY(float y) {
         // Prevent drawing outside the glucose chart range
         y = Math.max(0f, y); // 0 is the smallest acceptable value for the vertical position of a non-glucose item.
-        y = Math.min(y, BgReading.BG_READING_MAXIMUM_VALUE); // BG_READING_MAXIMUM_VALUE is the largest acceptable value for the vertical position of a non-glucose item.
+        y = Math.min(y, BgReading.getBgReadingMaximumValue()); // BG_READING_MAXIMUM_VALUE is the largest acceptable value for the vertical position of a non-glucose item.
         return y;
     }
 
@@ -476,7 +476,7 @@ public class BgGraphBuilder {
 
                 int count = aplist.size();
                 for (APStatus item : aplist) {
-                    val sanitized_percent = Math.min(BgReading.BG_READING_MAXIMUM_VALUE, Math.max(0, item.basal_percent)); // percent value plotted on glucose axis; capped to prevent Y-axis growth
+                    val sanitized_percent = Math.min(BgReading.getBgReadingMaximumValue(), Math.max(0, item.basal_percent)); // percent value plotted on glucose axis; capped to prevent Y-axis growth
                     if (--count == 0 || (sanitized_percent != last_percent)) {
                         float this_ypos = (sanitized_percent * yscale) / 100f;
                         this_ypos = clampNonGlucoseY(this_ypos + panCompensationOffset);
@@ -1369,26 +1369,26 @@ public class BgGraphBuilder {
                 }
 
                 if ((show_filtered) && (bgReading.filtered_calculated_value > 0) && (bgReading.filtered_calculated_value != bgReading.calculated_value)) {
-                    filteredValues.add(new HPointValue((double) ((bgReading.timestamp - timeshift) / FUZZER), (float) unitized(Math.min(bgReading.filtered_calculated_value, BgReading.BG_READING_MAXIMUM_VALUE))));
+                    filteredValues.add(new HPointValue((double) ((bgReading.timestamp - timeshift) / FUZZER), (float) unitized(Math.min(bgReading.filtered_calculated_value, BgReading.getBgReadingMaximumValue()))));
                 } else if (show_pseudo_filtered) {
                     // TODO differentiate between filtered and pseudo-filtered when both may be in play at different times
                     final double rollingValue = rollingAverage.put(bgReading.calculated_value);
                     if (rollingAverage.reachedPeak()) {
-                        filteredValues.add(new HPointValue((double) ((bgReading.timestamp + rollingOffset) / FUZZER), (float) unitized(Math.min(rollingValue, BgReading.BG_READING_MAXIMUM_VALUE))));
+                        filteredValues.add(new HPointValue((double) ((bgReading.timestamp + rollingOffset) / FUZZER), (float) unitized(Math.min(rollingValue, BgReading.getBgReadingMaximumValue()))));
                     }
                 }
                 if ((interpret_raw && (bgReading.raw_calculated > 0))) {
-                    rawInterpretedValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(Math.min(bgReading.raw_calculated, BgReading.BG_READING_MAXIMUM_VALUE))));
+                    rawInterpretedValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(Math.min(bgReading.raw_calculated, BgReading.getBgReadingMaximumValue()))));
                 }
                 if ((!glucose_from_plugin) && (plugin != null) && (cd != null)) {
-                    pluginValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(Math.min(plugin.getGlucoseFromBgReading(bgReading, cd), BgReading.BG_READING_MAXIMUM_VALUE))));
+                    pluginValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(Math.min(plugin.getGlucoseFromBgReading(bgReading, cd), BgReading.getBgReadingMaximumValue()))));
                 }
                 if (bgReading.ignoreForStats) {
                     if (unitized(bgReading.calculated_value) <= defaultMaxY) { // Don't display value marked as bad if greater than the default Max (defaultMaxY)
                         badValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
                     }
-                } else if (bgReading.calculated_value >= BgReading.BG_READING_MAXIMUM_VALUE) {
-                    highValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(BgReading.BG_READING_MAXIMUM_VALUE)));
+                } else if (bgReading.calculated_value >= BgReading.getBgReadingMaximumValue()) {
+                    highValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(BgReading.getBgReadingMaximumValue())));
                 } else if (unitized(bgReading.calculated_value) >= highMark) {
                     highValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
                 } else if (unitized(bgReading.calculated_value) >= lowMark) {
@@ -2178,7 +2178,7 @@ public class BgGraphBuilder {
         yAxis.setAutoGenerated(false);
         List<AxisValue> axisValues = new ArrayList<AxisValue>();
 
-        for (int j = 1; j <= 12; j += 1) {
+        for (int j = 1; j <= 14; j += 1) {
             if (doMgdl) {
                 axisValues.add(new AxisValue(j * 50));
             } else {
@@ -2309,7 +2309,7 @@ public class BgGraphBuilder {
 
     public static String unitized_string(double value, boolean doMgdl) {
         final DecimalFormat df = new DecimalFormat("#");
-        if (value >= 400) {
+        if (value >= BgReading.getBgReadingMaximumValue()) {
             return "HIGH";
         } else if (value >= 40) {
             if (doMgdl) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -515,6 +515,7 @@
         <item>40</item>
     </string-array>
     <string-array name="ymax_entries">
+        <item>500 mg/dl (27.8 mmol/l)</item>
         <item>400 mg/dl (22.2 mmol/l)</item>
         <item>300 mg/dl (16.7 mmol/l)</item>
         <item>250 mg/dl (13.9 mmol/l) ></item>
@@ -522,6 +523,7 @@
         <item>210 mg/dl (11.7 mmol/l)</item>
     </string-array>
     <string-array name="ymax_values">
+        <item>500</item>
         <item>400</item>
         <item>300</item>
         <item>250</item>


### PR DESCRIPTION
xDrip currently shows HIGH for any value that is equal to or greater than 400 mg/dL.

There are sensors that show values greater than 400.  

This PR changes that and sets the maximum to 500 mg/dL.
The max remains at 400 if the user uses plugins.  

I have tested this with fake data source and see that it clips at 500.
I am currently using this as my xDrip.