### PR TITLE
Bluetooth page cleanup

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -169,6 +169,10 @@ public class IdempotentMigrations {
         Pref.setString("bridge_battery_alert_level", "30");
         Pref.setBoolean("parakeet_status_alerts", false);
         Pref.setBoolean("parakeet_charge_silent", false);
+        Pref.setBoolean("g5_bluetooth_watchdog", true);
+        Pref.setBoolean("bluetooth_frequent_reset", false);
+        Pref.setBoolean("use_transmiter_pl_bluetooth", false);
+        Pref.setBoolean("use_rfduino_bluetooth", false);
 
     }
 

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1347,11 +1347,6 @@
                     android:defaultValue="20"
                     android:dependency="bluetooth_watchdog" />
                 <CheckBoxPreference
-                    android:defaultValue="true"
-                    android:key="g5_bluetooth_watchdog"
-                    android:summary="@string/reset_bluetooth_g5"
-                    android:title="@string/g5_bluetooth_watchdog" />
-                <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="close_gatt_on_ble_disconnect"
                     android:summary="@string/close_gatt"
@@ -1386,21 +1381,6 @@
                     android:key="bluetooth_excessive_wakelocks"
                     android:summary="@string/older_bluetooth_wakelocks"
                     android:title="@string/bluetooth_wakelocks" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="bluetooth_frequent_reset"
-                    android:summary="@string/reset_bluetooth_on_off"
-                    android:title="@string/constantly_reset_bluetooth" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="use_transmiter_pl_bluetooth"
-                    android:summary="@string/experimental_transmitter_fpv_uav"
-                    android:title="@string/transmitter_pl_support" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="use_rfduino_bluetooth"
-                    android:summary="@string/experimental_rdfuino_support"
-                    android:title="@string/rfduino_support" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_dex_collection_polling"


### PR DESCRIPTION
The Bluetooth settings page is too cluttered.
This PR removes 4 of the 18 settings.

Before and after are shown below.

| Before | After |  
| ------- | ------ |  
| <img width="216" height="806" alt="Screenshot_20260417-230833" src="https://github.com/user-attachments/assets/7570c913-f1a3-4c07-9455-b1915d66ecde" /> | <img width="237" height="667" alt="Screenshot_20260417-230600" src="https://github.com/user-attachments/assets/9bd58359-aa83-42ce-a65b-850b87d8003e" /> |  

The Dex Bluetooth watchdog is not used anywhere in the code.
The Bluetooth frequent reset is not used anywhere in the phone code.  It is transferred to Wear.  But, the setting does not affect anything on the phone.  If this causes a problem on a watch, I will fix it.  I mean xDrip does not support G5 any longer.  So, what sensor is the watch directly communicating with that needs to be reset continuously?
The other 2 settings are related to experimental devices, which I doubt any user is using.  

The page will still need cleanup work.  
I am hoping this will be easy and go through easily.  Then, I will open other PRs to hopefully address some other settings on this same page.  

**Testing**  
I am currently running this as my main active xDrip, a collector from G7.