### PR TITLE
Snooze glucose alerts with volume buttons, also from lock screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
     <uses-permission android:name="android.permission.FLASHLIGHT" />
     <uses-permission-sdk-23 android:name="android.permission.CAMERA" />
@@ -71,7 +72,7 @@
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.SET_WALLPAPER" />
-    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.MANAGE_HEALTH_DATA" />
     <uses-permission android:name="android.permission.MANAGE_HEALTH_PERMISSIONS" />
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />

--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -37,6 +37,7 @@ import android.widget.TextView;
 import android.widget.TimePicker;
 import android.widget.Toast;
 
+import com.eveningoutpost.dexdrip.models.ActiveBgAlert;
 import com.eveningoutpost.dexdrip.models.AlertType;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
@@ -575,7 +576,12 @@ public class EditAlertActivity extends ActivityWithMenu {
                             if (uuid == null) {
                                 Log.wtf(TAG, "Error remove pressed, while we were adding an alert");
                             } else {
+                                final ActiveBgAlert aba = ActiveBgAlert.getOnly();
+                                if (aba != null && uuid.equals(aba.alert_uuid)) {
+                                    AlertPlayer.getPlayer().stopAlert(mContext, true, false);
+                                }
                                 AlertType.remove_alert(uuid);
+                                SnoozeActivity.recheckAlerts();
                                 startWatchUpdaterService(mContext, WatchUpdaterService.ACTION_SYNC_ALERTTYPE, TAG);
                             }
                             Intent returnIntent = new Intent();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -202,6 +202,10 @@ import lombok.val;
 public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPermissionsResultCallback {
     private final static String TAG = "jamorham " + Home.class.getSimpleName();
     private final static boolean d = false;
+    private static final long VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS = 1500;
+    private long volumeDownFirstPressTime = 0;
+    private long volumeUpFirstPressTime = 0;
+    private long volumeMuteFirstPressTime = 0;
     private static final int MAX_INSULIN_PROFILES = 3;
     public final int maxInsulinProfiles = MultipleInsulins.isEnabled() ? MAX_INSULIN_PROFILES : 0;
     public final static String START_SPEECH_RECOGNITION = "START_APP_SPEECH_RECOGNITION";
@@ -3644,15 +3648,59 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         switch (event.getKeyCode()) {
             case KeyEvent.KEYCODE_VOLUME_DOWN:
+                if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
+                    if (ActiveBgAlert.getOnly() != null) {
+                        final long now = System.currentTimeMillis();
+                        if (now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                            volumeDownFirstPressTime = 0;
+                            AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), -1);
+                            SnoozeActivity.recheckAlerts();
+                            JoH.static_toast_long(getString(R.string.snoozing_due_volume_down_button_press));
+                            UserError.Log.ueh(TAG, "Snoozing alert due to double volume DOWN button press");
+                        } else {
+                            volumeDownFirstPressTime = now;
+                            JoH.static_toast_long(getString(R.string.volume_down_confirm_snooze));
+                        }
+                        return true;
+                    } else {
+                        if (d) UserError.Log.d(TAG, "no active alert to snooze");
+                    }
+                } else {
+                    if (d) UserError.Log.d(TAG, "No action as preference is disabled");
+                }
+                break;
             case KeyEvent.KEYCODE_VOLUME_UP:
+                if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
+                    if (ActiveBgAlert.getOnly() != null) {
+                        final long now = System.currentTimeMillis();
+                        if (now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                            volumeUpFirstPressTime = 0;
+                            AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), -1);
+                            SnoozeActivity.recheckAlerts();
+                            JoH.static_toast_long(getString(R.string.snoozing_due_volume_up_button_press));
+                            UserError.Log.ueh(TAG, "Snoozing alert due to double volume UP button press");
+                        } else {
+                            volumeUpFirstPressTime = now;
+                            JoH.static_toast_long(getString(R.string.volume_up_confirm_snooze));
+                        }
+                        return true;
+                    } else {
+                        if (d) UserError.Log.d(TAG, "no active alert to snooze");
+                    }
+                } else {
+                    if (d) UserError.Log.d(TAG, "No action as preference is disabled");
+                }
+                break;
             case KeyEvent.KEYCODE_VOLUME_MUTE:
                 if (JoH.quietratelimit("button-press", 5)) {
                     if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
                         final ActiveBgAlert activeBgAlert = ActiveBgAlert.getOnly();
                         if (activeBgAlert != null) {
                             AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), -1);
-                            JoH.static_toast_long(getString(R.string.snoozing_due_button_press));
-                            UserError.Log.ueh(TAG, "Snoozing alert due to volume button press");
+                            SnoozeActivity.recheckAlerts();
+                            JoH.static_toast_long(getString(R.string.snoozing_due_mute_button_press));
+                            UserError.Log.ueh(TAG, "Snoozing alert due to MUTE button press");
+                            return true;
                         } else {
                             if (d) UserError.Log.d(TAG, "no active alert to snooze");
                         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -206,6 +206,8 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
     private long volumeDownFirstPressTime = 0;
     private long volumeUpFirstPressTime = 0;
     private long volumeMuteFirstPressTime = 0;
+    private String volumeDownFirstPressUuid = null;
+    private String volumeUpFirstPressUuid = null;
     private static final int MAX_INSULIN_PROFILES = 3;
     public final int maxInsulinProfiles = MultipleInsulins.isEnabled() ? MAX_INSULIN_PROFILES : 0;
     public final static String START_SPEECH_RECOGNITION = "START_APP_SPEECH_RECOGNITION";
@@ -3649,20 +3651,34 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         switch (event.getKeyCode()) {
             case KeyEvent.KEYCODE_VOLUME_DOWN:
                 if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
-                    if (ActiveBgAlert.getOnly() != null) {
+                    final ActiveBgAlert abaDown = ActiveBgAlert.getOnly();
+                    if (abaDown != null && abaDown.is_snoozed && ActiveBgAlert.alertTypegetOnly() == null) {
+                        ActiveBgAlert.ClearData();
+                        SnoozeActivity.recheckAlerts();
+                        if (d) UserError.Log.d(TAG, "Cleared orphaned ActiveBgAlert (no AlertType)");
+                        break;
+                    }
+                    if (abaDown != null) {
                         final long now = System.currentTimeMillis();
-                        if (now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                        if (now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
+                                && abaDown.alert_uuid.equals(volumeDownFirstPressUuid)) {
                             volumeDownFirstPressTime = 0;
+                            volumeDownFirstPressUuid = null;
                             AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), -1);
                             SnoozeActivity.recheckAlerts();
                             JoH.static_toast_long(getString(R.string.snoozing_due_volume_down_button_press));
                             UserError.Log.ueh(TAG, "Snoozing alert due to double volume DOWN button press");
                         } else {
                             volumeDownFirstPressTime = now;
+                            volumeDownFirstPressUuid = abaDown.alert_uuid;
                             JoH.static_toast_long(getString(R.string.volume_down_confirm_snooze));
                         }
                         return true;
                     } else {
+                        volumeDownFirstPressTime = 0;
+                        volumeDownFirstPressUuid = null;
+                        volumeUpFirstPressTime = 0;
+                        volumeUpFirstPressUuid = null;
                         if (d) UserError.Log.d(TAG, "no active alert to snooze");
                     }
                 } else {
@@ -3671,20 +3687,34 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                 break;
             case KeyEvent.KEYCODE_VOLUME_UP:
                 if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
-                    if (ActiveBgAlert.getOnly() != null) {
+                    final ActiveBgAlert abaUp = ActiveBgAlert.getOnly();
+                    if (abaUp != null && abaUp.is_snoozed && ActiveBgAlert.alertTypegetOnly() == null) {
+                        ActiveBgAlert.ClearData();
+                        SnoozeActivity.recheckAlerts();
+                        if (d) UserError.Log.d(TAG, "Cleared orphaned ActiveBgAlert (no AlertType)");
+                        break;
+                    }
+                    if (abaUp != null) {
                         final long now = System.currentTimeMillis();
-                        if (now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                        if (now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
+                                && abaUp.alert_uuid.equals(volumeUpFirstPressUuid)) {
                             volumeUpFirstPressTime = 0;
+                            volumeUpFirstPressUuid = null;
                             AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), -1);
                             SnoozeActivity.recheckAlerts();
                             JoH.static_toast_long(getString(R.string.snoozing_due_volume_up_button_press));
                             UserError.Log.ueh(TAG, "Snoozing alert due to double volume UP button press");
                         } else {
                             volumeUpFirstPressTime = now;
+                            volumeUpFirstPressUuid = abaUp.alert_uuid;
                             JoH.static_toast_long(getString(R.string.volume_up_confirm_snooze));
                         }
                         return true;
                     } else {
+                        volumeDownFirstPressTime = 0;
+                        volumeDownFirstPressUuid = null;
+                        volumeUpFirstPressTime = 0;
+                        volumeUpFirstPressUuid = null;
                         if (d) UserError.Log.d(TAG, "no active alert to snooze");
                     }
                 } else {
@@ -3695,6 +3725,12 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                 if (JoH.quietratelimit("button-press", 5)) {
                     if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
                         final ActiveBgAlert activeBgAlert = ActiveBgAlert.getOnly();
+                        if (activeBgAlert != null && activeBgAlert.is_snoozed && ActiveBgAlert.alertTypegetOnly() == null) {
+                            ActiveBgAlert.ClearData();
+                            SnoozeActivity.recheckAlerts();
+                            if (d) UserError.Log.d(TAG, "Cleared orphaned ActiveBgAlert (no AlertType)");
+                            break;
+                        }
                         if (activeBgAlert != null) {
                             AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), -1);
                             SnoozeActivity.recheckAlerts();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
@@ -6,17 +6,21 @@ import java.util.Date;
 import android.app.Dialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.view.WindowManager;
 
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 
 import android.util.TypedValue;
+import android.view.KeyEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.NumberPicker;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.eveningoutpost.dexdrip.models.ActiveBgAlert;
 import com.eveningoutpost.dexdrip.models.AlertType;
@@ -153,6 +157,12 @@ public class SnoozeActivity extends ActivityWithMenu {
 
 
     private final static String TAG = AlertPlayer.class.getSimpleName();
+    public static final String EXTRA_LAUNCHED_OVER_OTHER_APP = "launched_over_other_app";
+    private static final long VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS = 1500;
+    private long volumeDownFirstPressTime = 0;
+    private long volumeUpFirstPressTime = 0;
+    private long volumeMuteFirstPressTime = 0;
+    private Toast volumeButtonToast = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -160,6 +170,20 @@ public class SnoozeActivity extends ActivityWithMenu {
         if (Home.get_holo()) { setTheme(R.style.OldAppThemeNoTitleBar); }
         JoH.fixActionBar(this);
         setContentView(R.layout.activity_snooze);
+
+        // Show over the lock screen when an alarm is active so volume buttons
+        // can snooze without requiring the user to unlock the device first.
+        if (ActiveBgAlert.getOnly() != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                setShowWhenLocked(true);
+                setTurnScreenOn(true);
+            } else {
+                getWindow().addFlags(
+                        WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                        | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
+            }
+        }
+
         alertStatus = (TextView) findViewById(R.id.alert_status);
         snoozeValue = (NumberPicker) findViewById(R.id.snooze);
 
@@ -351,7 +375,7 @@ public class SnoozeActivity extends ActivityWithMenu {
             return;
         }
         if(aba != null && activeBgAlert== null) {
-            Log.wtf(TAG, "ERRRO displayStatus: aba != null, but activeBgAlert == null exiting...");
+            alertStatus.setText(getString(R.string.test_alert_passed));
             return;
         }
         long now = new Date().getTime();
@@ -374,8 +398,12 @@ public class SnoozeActivity extends ActivityWithMenu {
         } else {
             sendRemoteSnooze.setVisibility(View.GONE);
             if(!aba.ready_to_alarm()) {
-                status = MessageFormat.format("Active alert exists named \"{0}\" {1,choice,0#Alert will rerise at|1#Alert snoozed until} {2,time} ({3} minutes left)",
-                        activeBgAlert.name, aba.is_snoozed ? 1 : 0 , new Date(aba.next_alert_at),(aba.next_alert_at - now) / 60000);
+                final long msLeft = aba.next_alert_at - now;
+                final String timeLeft = msLeft < 120000
+                        ? (msLeft / 1000) + " seconds left"
+                        : (msLeft / 60000) + " minutes left";
+                status = MessageFormat.format("Active alert exists named \"{0}\" {1,choice,0#Alert will rerise at|1#Alert snoozed until} {2,time} ({3})",
+                        activeBgAlert.name, aba.is_snoozed ? 1 : 0, new Date(aba.next_alert_at), timeLeft);
             } else {
                 status = getString(R.string.active_alert_exists_named)+" \"" + activeBgAlert.name + "\" "+getString(R.string.bracket_not_snoozed);
             }
@@ -402,6 +430,105 @@ public class SnoozeActivity extends ActivityWithMenu {
 
         alertStatus.setText(status);
 
+    }
+
+    private void showVolumeButtonToast(final String message) {
+        if (volumeButtonToast != null) {
+            volumeButtonToast.cancel();
+        }
+        volumeButtonToast = Toast.makeText(this, message, Toast.LENGTH_LONG);
+        volumeButtonToast.show();
+    }
+
+    private void doSnoozeFromVolumeButton(final int toastResId, final String logMessage) {
+        int snooze = 30;
+        final AlertType alertType = ActiveBgAlert.alertTypegetOnly();
+        if (alertType != null) {
+            snooze = alertType.default_snooze != 0
+                    ? alertType.default_snooze
+                    : getDefaultSnooze(alertType.above);
+        }
+        AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), snooze);
+        recheckAlerts();
+        JoH.static_toast_long(getString(toastResId));
+        Log.ueh(TAG, logMessage);
+        // Only move xDrip to the background when SnoozeActivity was launched over
+        // another app (screen on). If xDrip was already in the foreground, finish()
+        // alone is correct — moveTaskToBack() would incorrectly hide xDrip.
+        if (getIntent().getBooleanExtra(EXTRA_LAUNCHED_OVER_OTHER_APP, false)) {
+            moveTaskToBack(true);
+        }
+        finish();
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        switch (event.getKeyCode()) {
+            case KeyEvent.KEYCODE_VOLUME_DOWN:
+                if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
+                    if (ActiveBgAlert.getOnly() != null) {
+                        final long now = System.currentTimeMillis();
+                        if (now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                            volumeDownFirstPressTime = 0;
+                            doSnoozeFromVolumeButton(R.string.snoozing_due_volume_down_button_press,
+                                    "Snoozing alert due to double volume DOWN button press");
+                        } else {
+                            final boolean otherActive = now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
+                                    || now - volumeMuteFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS;
+                            volumeDownFirstPressTime = now;
+                            volumeUpFirstPressTime = 0;
+                            volumeMuteFirstPressTime = 0;
+                            showVolumeButtonToast(getString(otherActive
+                                    ? R.string.volume_button_wrong_button
+                                    : R.string.volume_down_confirm_snooze));
+                        }
+                    }
+                }
+                return true;
+            case KeyEvent.KEYCODE_VOLUME_UP:
+                if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
+                    if (ActiveBgAlert.getOnly() != null) {
+                        final long now = System.currentTimeMillis();
+                        if (now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                            volumeUpFirstPressTime = 0;
+                            doSnoozeFromVolumeButton(R.string.snoozing_due_volume_up_button_press,
+                                    "Snoozing alert due to double volume UP button press");
+                        } else {
+                            final boolean otherActive = now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
+                                    || now - volumeMuteFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS;
+                            volumeUpFirstPressTime = now;
+                            volumeDownFirstPressTime = 0;
+                            volumeMuteFirstPressTime = 0;
+                            showVolumeButtonToast(getString(otherActive
+                                    ? R.string.volume_button_wrong_button
+                                    : R.string.volume_up_confirm_snooze));
+                        }
+                    }
+                }
+                return true;
+            case KeyEvent.KEYCODE_VOLUME_MUTE:
+                if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
+                    if (ActiveBgAlert.getOnly() != null) {
+                        final long now = System.currentTimeMillis();
+                        if (now - volumeMuteFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                            volumeMuteFirstPressTime = 0;
+                            doSnoozeFromVolumeButton(R.string.snoozing_due_mute_button_press,
+                                    "Snoozing alert due to double MUTE button press");
+                        } else {
+                            final boolean otherActive = now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
+                                    || now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS;
+                            volumeMuteFirstPressTime = now;
+                            volumeDownFirstPressTime = 0;
+                            volumeUpFirstPressTime = 0;
+                            showVolumeButtonToast(getString(otherActive
+                                    ? R.string.volume_button_wrong_button
+                                    : R.string.volume_button_confirm_snooze));
+                        }
+                    }
+                }
+                return true;
+        }
+        return super.onKeyDown(keyCode, event);
     }
 
     public void setSendRemoteSnoozeOnClick(View v) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
@@ -70,8 +70,8 @@ public class SnoozeActivity extends ActivityWithMenu {
         if (aba != null) {
             AlertType activeBgAlert = ActiveBgAlert.alertTypegetOnly();
             if (disableType == SnoozeType.ALL_ALERTS
-                    || (activeBgAlert.above && disableType == SnoozeType.HIGH_ALERTS)
-                    || (!activeBgAlert.above && disableType == SnoozeType.LOW_ALERTS)
+                    || (activeBgAlert != null && activeBgAlert.above && disableType == SnoozeType.HIGH_ALERTS)
+                    || (activeBgAlert != null && !activeBgAlert.above && disableType == SnoozeType.LOW_ALERTS)
             ) {
                 //active bg alert exists which is a type that is being disabled so let's remove it completely from the database
                 ActiveBgAlert.ClearData();
@@ -162,7 +162,11 @@ public class SnoozeActivity extends ActivityWithMenu {
     private long volumeDownFirstPressTime = 0;
     private long volumeUpFirstPressTime = 0;
     private long volumeMuteFirstPressTime = 0;
+    private String volumeDownFirstPressUuid = null;
+    private String volumeUpFirstPressUuid = null;
+    private String volumeMuteFirstPressUuid = null;
     private Toast volumeButtonToast = null;
+    private boolean lockScreenFlagsSet = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -182,6 +186,7 @@ public class SnoozeActivity extends ActivityWithMenu {
                         WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
                         | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
             }
+            lockScreenFlagsSet = true;
         }
 
         alertStatus = (TextView) findViewById(R.id.alert_status);
@@ -203,6 +208,15 @@ public class SnoozeActivity extends ActivityWithMenu {
         super.onWindowFocusChanged(hasFocus);
         if (hasFocus){
             displayStatus();
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (lockScreenFlagsSet && ActiveBgAlert.getOnly() == null) {
+            finish();
+            return;
         }
     }
 
@@ -331,7 +345,7 @@ public class SnoozeActivity extends ActivityWithMenu {
 
     }
     public static void recheckAlerts() {
-        Notifications.start();
+        Notifications.staticUpdateNotification();
         JoH.startService(MissedReadingService.class); // TODO this should be rate limited or similar as it is polled in various locations leading to excessive cpu
     }
 
@@ -365,6 +379,20 @@ public class SnoozeActivity extends ActivityWithMenu {
     }
 
 
+    private void clearLockScreenFlags() {
+        if (lockScreenFlagsSet) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                setShowWhenLocked(false);
+                setTurnScreenOn(false);
+            } else {
+                getWindow().clearFlags(
+                        WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                                | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
+            }
+            lockScreenFlagsSet = false;
+        }
+    }
+
     void displayStatus() {
         ActiveBgAlert aba = ActiveBgAlert.getOnly();
         AlertType activeBgAlert = ActiveBgAlert.alertTypegetOnly();
@@ -380,6 +408,7 @@ public class SnoozeActivity extends ActivityWithMenu {
         }
         long now = new Date().getTime();
         if(activeBgAlert == null ) {
+            clearLockScreenFlags();
             sendRemoteSnooze.setVisibility(Pref.getBooleanDefaultFalse("send_snooze_to_remote") ? View.VISIBLE : View.GONE);
             if (prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0) > now
                     ||
@@ -450,7 +479,7 @@ public class SnoozeActivity extends ActivityWithMenu {
         }
         AlertPlayer.getPlayer().Snooze(xdrip.getAppContext(), snooze);
         recheckAlerts();
-        JoH.static_toast_long(getString(toastResId));
+        showVolumeButtonToast(getString(toastResId));
         Log.ueh(TAG, logMessage);
         // Only move xDrip to the background when SnoozeActivity was launched over
         // another app (screen on). If xDrip was already in the foreground, finish()
@@ -466,18 +495,24 @@ public class SnoozeActivity extends ActivityWithMenu {
         switch (event.getKeyCode()) {
             case KeyEvent.KEYCODE_VOLUME_DOWN:
                 if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
-                    if (ActiveBgAlert.getOnly() != null) {
+                    final ActiveBgAlert abaDown = ActiveBgAlert.getOnly();
+                    if (abaDown != null) {
                         final long now = System.currentTimeMillis();
-                        if (now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                        if (now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
+                                && abaDown.alert_uuid.equals(volumeDownFirstPressUuid)) {
                             volumeDownFirstPressTime = 0;
+                            volumeDownFirstPressUuid = null;
                             doSnoozeFromVolumeButton(R.string.snoozing_due_volume_down_button_press,
                                     "Snoozing alert due to double volume DOWN button press");
                         } else {
                             final boolean otherActive = now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
                                     || now - volumeMuteFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS;
                             volumeDownFirstPressTime = now;
+                            volumeDownFirstPressUuid = abaDown.alert_uuid;
                             volumeUpFirstPressTime = 0;
+                            volumeUpFirstPressUuid = null;
                             volumeMuteFirstPressTime = 0;
+                            volumeMuteFirstPressUuid = null;
                             showVolumeButtonToast(getString(otherActive
                                     ? R.string.volume_button_wrong_button
                                     : R.string.volume_down_confirm_snooze));
@@ -487,18 +522,24 @@ public class SnoozeActivity extends ActivityWithMenu {
                 return true;
             case KeyEvent.KEYCODE_VOLUME_UP:
                 if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
-                    if (ActiveBgAlert.getOnly() != null) {
+                    final ActiveBgAlert abaUp = ActiveBgAlert.getOnly();
+                    if (abaUp != null) {
                         final long now = System.currentTimeMillis();
-                        if (now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                        if (now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
+                                && abaUp.alert_uuid.equals(volumeUpFirstPressUuid)) {
                             volumeUpFirstPressTime = 0;
+                            volumeUpFirstPressUuid = null;
                             doSnoozeFromVolumeButton(R.string.snoozing_due_volume_up_button_press,
                                     "Snoozing alert due to double volume UP button press");
                         } else {
                             final boolean otherActive = now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
                                     || now - volumeMuteFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS;
                             volumeUpFirstPressTime = now;
+                            volumeUpFirstPressUuid = abaUp.alert_uuid;
                             volumeDownFirstPressTime = 0;
+                            volumeDownFirstPressUuid = null;
                             volumeMuteFirstPressTime = 0;
+                            volumeMuteFirstPressUuid = null;
                             showVolumeButtonToast(getString(otherActive
                                     ? R.string.volume_button_wrong_button
                                     : R.string.volume_up_confirm_snooze));
@@ -508,18 +549,24 @@ public class SnoozeActivity extends ActivityWithMenu {
                 return true;
             case KeyEvent.KEYCODE_VOLUME_MUTE:
                 if (Pref.getBooleanDefaultFalse("buttons_silence_alert")) {
-                    if (ActiveBgAlert.getOnly() != null) {
+                    final ActiveBgAlert abaMute = ActiveBgAlert.getOnly();
+                    if (abaMute != null) {
                         final long now = System.currentTimeMillis();
-                        if (now - volumeMuteFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS) {
+                        if (now - volumeMuteFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
+                                && abaMute.alert_uuid.equals(volumeMuteFirstPressUuid)) {
                             volumeMuteFirstPressTime = 0;
+                            volumeMuteFirstPressUuid = null;
                             doSnoozeFromVolumeButton(R.string.snoozing_due_mute_button_press,
                                     "Snoozing alert due to double MUTE button press");
                         } else {
                             final boolean otherActive = now - volumeDownFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS
                                     || now - volumeUpFirstPressTime <= VOLUME_BUTTON_DOUBLE_PRESS_WINDOW_MS;
                             volumeMuteFirstPressTime = now;
+                            volumeMuteFirstPressUuid = abaMute.alert_uuid;
                             volumeDownFirstPressTime = 0;
+                            volumeDownFirstPressUuid = null;
                             volumeUpFirstPressTime = 0;
+                            volumeUpFirstPressUuid = null;
                             showVolumeButtonToast(getString(otherActive
                                     ? R.string.volume_button_wrong_button
                                     : R.string.volume_button_confirm_snooze));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/ActiveBgAlert.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/ActiveBgAlert.java
@@ -66,6 +66,7 @@ public class ActiveBgAlert extends Model {
     public void snooze(int minutes) {
         next_alert_at = new Date().getTime() + minutes * 60000;
         is_snoozed = true;
+        last_alerted_at = new Date().getTime();
         Log.ueh("Snoozed Alert","Snoozed until: "+JoH.dateTimeText(next_alert_at));
         save();
     }
@@ -124,8 +125,6 @@ public class ActiveBgAlert extends Model {
         AlertType alert = AlertType.get_alert(aba.alert_uuid);
         if(alert == null) {
             Log.d(TAG, "alertTypegetOnly did not find the active alert as part of existing alerts. returning null");
-            // removing the alert to be in a better state.
-            ClearData();
             return null;
         }
         if(!alert.uuid.equals(aba.alert_uuid)) {
@@ -203,4 +202,3 @@ public class ActiveBgAlert extends Model {
         patched = true;
     }
 }
-

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/ActiveBgAlert.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/ActiveBgAlert.java
@@ -53,6 +53,11 @@ public class ActiveBgAlert extends Model {
         return activeBgAlert != null && !activeBgAlert.is_snoozed;
     }
 
+    public static boolean currentlySnoozed() {
+        final ActiveBgAlert aba = getOnly();
+        return aba != null && aba.is_snoozed;
+    }
+
     public static boolean alertSnoozeOver() {
         ActiveBgAlert activeBgAlert = getOnly();
         if (activeBgAlert == null) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
@@ -6,11 +6,14 @@ import static com.eveningoutpost.dexdrip.models.JoH.setMediaDataSource;
 import static com.eveningoutpost.dexdrip.models.JoH.stopAndReleasePlayer;
 import static com.eveningoutpost.dexdrip.receiver.InfoContentProvider.ping;
 
+import android.app.ActivityManager;
 import android.app.Notification;
+import android.app.KeyguardManager;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.provider.Settings;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
@@ -23,6 +26,7 @@ import androidx.core.app.NotificationCompat;
 
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
+import com.eveningoutpost.dexdrip.SnoozeActivity;
 import com.eveningoutpost.dexdrip.models.ActiveBgAlert;
 import com.eveningoutpost.dexdrip.models.AlertType;
 import com.eveningoutpost.dexdrip.models.JoH;
@@ -570,10 +574,78 @@ public class AlertPlayer {
 
             boolean forceSpeaker = alert.force_speaker;
 
-            if (overrideSilent) {
+            if (overrideSilent || Pref.getBooleanDefaultFalse("volume_button_snooze_wake_screen")) {
                 UserError.Log.d(TAG, "Setting full screen intent");
                 builder.setCategory(NotificationCompat.CATEGORY_ALARM);
-                builder.setFullScreenIntent(notificationIntent(context, new Intent(context, Home.class)), true);
+                builder.setFullScreenIntent(notificationIntent(context, new Intent(context, SnoozeActivity.class)), true);
+                // IMPORTANCE_HIGH is required for setFullScreenIntent to activate on Android 8+.
+                // Without it the system silently downgrades the notification and never launches
+                // the full screen activity.
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                    final NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                    final android.app.NotificationChannel ch = nm.getNotificationChannel(NotificationChannels.BG_ALERT_CHANNEL);
+                    if (ch != null && ch.getImportance() < NotificationManager.IMPORTANCE_HIGH) {
+                        ch.setImportance(NotificationManager.IMPORTANCE_HIGH);
+                        nm.createNotificationChannel(ch);
+                    }
+                }
+            }
+
+            // When the screen is on, start SnoozeActivity directly so it comes to the
+            // foreground regardless of what is on screen. This applies whenever xDrip is
+            // already in the foreground (e.g. testing an alert from Settings) or when
+            // override_silent_mode / volume_button_snooze_wake_screen is enabled.
+            final PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+            if (pm != null && pm.isInteractive()) {
+                final KeyguardManager km = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
+                final boolean locked = km != null && km.isKeyguardLocked();
+                if (locked) {
+                    // Screen is on but locked: only launch when override_silent_mode or the
+                    // wake-screen preference is enabled, since setFullScreenIntent handles this
+                    // case and we don't want to unexpectedly interrupt the lock screen otherwise.
+                    if (overrideSilent || Pref.getBooleanDefaultFalse("volume_button_snooze_wake_screen")) {
+                        UserError.Log.d(TAG, "Screen on + locked — starting SnoozeActivity directly");
+                        final Intent launch = new Intent(context, SnoozeActivity.class);
+                        launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                        launch.putExtra(SnoozeActivity.EXTRA_LAUNCHED_OVER_OTHER_APP, true);
+                        context.startActivity(launch);
+                    }
+                } else {
+                    // Screen is on and unlocked. Determine whether xDrip is already the
+                    // foreground app. If so, always show SnoozeActivity — no permission needed
+                    // and no preference check required (covers testing alerts from Settings).
+                    // If another app is in the foreground, SYSTEM_ALERT_WINDOW is required and
+                    // the wake-screen preference must be enabled.
+                    boolean xdripAlreadyForeground = false;
+                    final ActivityManager am = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+                    if (am != null) {
+                        final java.util.List<ActivityManager.RunningAppProcessInfo> procs = am.getRunningAppProcesses();
+                        if (procs != null) {
+                            for (ActivityManager.RunningAppProcessInfo p : procs) {
+                                if (p.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+                                        && p.processName.equals(context.getPackageName())) {
+                                    xdripAlreadyForeground = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (xdripAlreadyForeground) {
+                        UserError.Log.d(TAG, "Screen on + unlocked + xDrip foreground — starting SnoozeActivity directly");
+                        final Intent launch = new Intent(context, SnoozeActivity.class);
+                        launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                        context.startActivity(launch);
+                    } else if ((overrideSilent || Pref.getBooleanDefaultFalse("volume_button_snooze_wake_screen"))
+                            && Settings.canDrawOverlays(context)) {
+                        UserError.Log.d(TAG, "Screen on + unlocked + overlay permission — starting SnoozeActivity over other app");
+                        final Intent launch = new Intent(context, SnoozeActivity.class);
+                        launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                        launch.putExtra(SnoozeActivity.EXTRA_LAUNCHED_OVER_OTHER_APP, true);
+                        context.startActivity(launch);
+                    } else if (overrideSilent || Pref.getBooleanDefaultFalse("volume_button_snooze_wake_screen")) {
+                        UserError.Log.d(TAG, "Screen on + unlocked — no overlay permission, falling back to heads-up notification");
+                    }
+                }
             }
 
             if (notSilencedDueToCall()) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
@@ -580,11 +580,14 @@ public class AlertPlayer {
                 builder.setFullScreenIntent(notificationIntent(context, new Intent(context, SnoozeActivity.class)), true);
                 // IMPORTANCE_HIGH is required for setFullScreenIntent to activate on Android 8+.
                 // Without it the system silently downgrades the notification and never launches
-                // the full screen activity.
+                // the full screen activity. The upgrade runs whenever setFullScreenIntent is set
+                // (override_silent_mode or volume_button_snooze_wake_screen). Both settings
+                // represent an explicit user opt-in to interruptive alert behaviour.
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
                     final NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
                     final android.app.NotificationChannel ch = nm.getNotificationChannel(NotificationChannels.BG_ALERT_CHANNEL);
                     if (ch != null && ch.getImportance() < NotificationManager.IMPORTANCE_HIGH) {
+                        UserError.Log.ueh(TAG, "Upgrading BG alert channel importance to HIGH for full screen intent");
                         ch.setImportance(NotificationManager.IMPORTANCE_HIGH);
                         nm.createNotificationChannel(ch);
                     }
@@ -608,7 +611,11 @@ public class AlertPlayer {
                         final Intent launch = new Intent(context, SnoozeActivity.class);
                         launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                         launch.putExtra(SnoozeActivity.EXTRA_LAUNCHED_OVER_OTHER_APP, true);
-                        context.startActivity(launch);
+                        try {
+                            context.startActivity(launch);
+                        } catch (Exception e) {
+                            UserError.Log.e(TAG, "Failed to start SnoozeActivity (locked): " + e);
+                        }
                     }
                 } else {
                     // Screen is on and unlocked. Determine whether xDrip is already the
@@ -634,14 +641,22 @@ public class AlertPlayer {
                         UserError.Log.d(TAG, "Screen on + unlocked + xDrip foreground — starting SnoozeActivity directly");
                         final Intent launch = new Intent(context, SnoozeActivity.class);
                         launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                        context.startActivity(launch);
+                        try {
+                            context.startActivity(launch);
+                        } catch (Exception e) {
+                            UserError.Log.e(TAG, "Failed to start SnoozeActivity (foreground): " + e);
+                        }
                     } else if ((overrideSilent || Pref.getBooleanDefaultFalse("volume_button_snooze_wake_screen"))
                             && Settings.canDrawOverlays(context)) {
                         UserError.Log.d(TAG, "Screen on + unlocked + overlay permission — starting SnoozeActivity over other app");
                         final Intent launch = new Intent(context, SnoozeActivity.class);
                         launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                         launch.putExtra(SnoozeActivity.EXTRA_LAUNCHED_OVER_OTHER_APP, true);
-                        context.startActivity(launch);
+                        try {
+                            context.startActivity(launch);
+                        } catch (Exception e) {
+                            UserError.Log.e(TAG, "Failed to start SnoozeActivity (overlay): " + e);
+                        }
                     } else if (overrideSilent || Pref.getBooleanDefaultFalse("volume_button_snooze_wake_screen")) {
                         UserError.Log.d(TAG, "Screen on + unlocked — no overlay permission, falling back to heads-up notification");
                     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -664,7 +664,8 @@ public class Notifications extends IntentService {
                 final SpannableString deltaString = new SpannableString("Delta: " + ((dg != null) ? (dg.spannableString(dg.unitized_delta + (dg.from_plugin ? " " + context.getString(R.string.p_in_circle) : "")))
                         : bgGraphBuilder.unitizedDeltaString(true, true)));
 
-                b.setContentText(deltaString);
+                final String summaryString = deltaString + buildSnoozeLine(context);
+                b.setContentText(summaryString);
 
                 notifiationBitmap = new BgSparklineBuilder(mContext)
                         .setBgGraphBuilder(bgGraphBuilder)
@@ -690,12 +691,12 @@ public class Notifications extends IntentService {
                 RemoteViews collapsedViews = new RemoteViews(context.getPackageName(), R.layout.notification_bg_collapsed);
                 collapsedViews.setImageViewBitmap(R.id.notification_image, iconBitmap);
                 collapsedViews.setTextViewText(R.id.notification_title, titleString);
-                collapsedViews.setTextViewText(R.id.notification_summary, deltaString);
+                collapsedViews.setTextViewText(R.id.notification_summary, summaryString);
 
                 RemoteViews expandedViews = new RemoteViews(context.getPackageName(), R.layout.notification_bg_expanded);
                 expandedViews.setImageViewBitmap(R.id.notification_image, notifiationBitmap);
                 expandedViews.setTextViewText(R.id.notification_title, titleString);
-                expandedViews.setTextViewText(R.id.notification_summary, deltaString);
+                expandedViews.setTextViewText(R.id.notification_summary, summaryString);
 
                 b.setStyle(customViewStyle)
                         .setCustomContentView(collapsedViews)
@@ -722,13 +723,24 @@ public class Notifications extends IntentService {
             extras.putString("android.shortCriticalText", critical.replace("\u2192"+"\uFE0E","›"));
             b.addExtras(extras);
             b.setContentTitle(titleString);
-            b.setStyle(new Notification.BigTextStyle().bigText(deltaString));
+            b.setStyle(new Notification.BigTextStyle().bigText(deltaString + buildSnoozeLine(context)));
             b.setCustomContentView(null);
             b.setCustomBigContentView(null);
         }
 
         // strips channel ID if disabled
         return XdripNotification.build(b);
+    }
+
+    private String buildSnoozeLine(final Context context) {
+        final ActiveBgAlert aba = ActiveBgAlert.getOnly();
+        if (aba == null || !aba.is_snoozed) return "";
+        if (aba.last_alerted_at == null || aba.last_alerted_at == 0L) return "";
+        final AlertType alertType = ActiveBgAlert.alertTypegetOnly();
+        if (alertType == null) return "";
+        final String time = android.text.format.DateFormat.getTimeFormat(context)
+                .format(new java.util.Date(aba.next_alert_at));
+        return "\n" + String.format(context.getString(R.string.notification_alert_snoozed_until), alertType.name, time);
     }
 
     private synchronized void bgOngoingNotification(final BgGraphBuilder bgGraphBuilder) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -316,6 +316,7 @@ public class Notifications extends IntentService {
         final long start = end - (60000 * 60 * 3) - (60000 * 10);
         BgGraphBuilder bgGraphBuilder = new BgGraphBuilder(context, start, end);
         //BgGraphBuilder bgGraphBuilder = new BgGraphBuilder(context);
+        final boolean snoozedBefore = bg_ongoing && ActiveBgAlert.currentlySnoozed();
         if (bg_ongoing) {
             bgOngoingNotification(bgGraphBuilder);
         }
@@ -323,7 +324,7 @@ public class Notifications extends IntentService {
             Log.d("NOTIFICATIONS", "Notifications are currently disabled!!");
             return false;
         }
-        
+
         boolean unclearReading = BgReading.getAndRaiseUnclearReading(context);
 
         boolean forced_wear = Home.get_forced_wear();
@@ -343,6 +344,10 @@ public class Notifications extends IntentService {
         evaluateLowPredictionAlarm();
         reportNoiseChanges();
 
+        // Rebuild ongoing notification if snooze status changed during alert evaluation
+        if (bg_ongoing && snoozedBefore != ActiveBgAlert.currentlySnoozed()) {
+            bgOngoingNotification(bgGraphBuilder);
+        }
 
         Sensor sensor = Sensor.currentSensor();
         // TODO need to check performance of rest of this method when in follower mode
@@ -735,10 +740,19 @@ public class Notifications extends IntentService {
     private String buildSnoozeLine(final Context context) {
         final ActiveBgAlert aba = ActiveBgAlert.getOnly();
         if (aba == null || !aba.is_snoozed) return "";
-        if (aba.last_alerted_at == null || aba.last_alerted_at == 0L) return "";
         final AlertType alertType = ActiveBgAlert.alertTypegetOnly();
         if (alertType == null) return "";
-        final String time = android.text.format.DateFormat.getTimeFormat(context)
+        final BgReading bgReading = BgReading.last();
+        if (bgReading != null && JoH.msSince(bgReading.timestamp) < 15 * 60 * 1000) {
+            final double bg = bgReading.calculated_value;
+            if (alertType.above && bg < alertType.threshold) return "";
+            if (!alertType.above) {
+                final double offset = ActivityRecognizedService.raise_limit_due_to_vehicle_mode()
+                        ? ActivityRecognizedService.getVehicle_mode_adjust_mgdl() : 0;
+                if (bg > alertType.threshold + offset) return "";
+            }
+        }
+        final String time = new java.text.SimpleDateFormat("HH:mm", java.util.Locale.getDefault())
                 .format(new java.util.Date(aba.next_alert_at));
         return "\n" + String.format(context.getString(R.string.notification_alert_snoozed_until), alertType.name, time);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -812,6 +812,11 @@
     <string name="minimum_value">The minimum value you consider to be in range.</string>
     <string name="volume_buttons_snooze">Pressing the volume up or down button will snooze an active alarm when in the app</string>
     <string name="buttons_silence_alarms">Buttons silence alarms</string>
+    <string name="volume_button_snooze_wake_screen_title">Volume snooze from lock screen</string>
+    <string name="volume_button_snooze_wake_screen_summary">When an alert fires, wake the screen and show the snooze screen so volume buttons can snooze the alarm from the lock screen</string>
+    <string name="volume_button_confirm_snooze">Press the same volume button again to snooze</string>
+    <string name="volume_down_confirm_snooze">Press the volume DOWN button again to snooze</string>
+    <string name="volume_up_confirm_snooze">Press the volume UP button again to snooze</string>
     <string name="create_shortcut">Create a shortcut from main navigation to BG level screen</string>
     <string name="shortcut_to_bg_alerts">Shortcut to BG Level Alerts</string>
     <string name="suppress_alerts_missed_readings">Suppress snoozed and active alerts after predefined period of missed readings</string>
@@ -1793,6 +1798,12 @@
     <string name="transmitter_maybe_dead">filtered data is exactly double raw sensor data which looks wrong! (Transmitter maybe dead)</string>
     <string name="noise_workings_noise">Noise: %s</string>
     <string name="snoozing_due_button_press">Snoozing alert due to volume button press</string>
+    <string name="snoozing_due_volume_down_button_press">Snoozing alert due to double volume DOWN button press</string>
+    <string name="snoozing_due_volume_up_button_press">Snoozing alert due to double volume UP button press</string>
+    <string name="snoozing_due_mute_button_press">Snoozing alert due to MUTE button press</string>
+    <string name="volume_button_wrong_button">Double press the same volume button to snooze</string>
+    <string name="notification_alert_snoozed_until">Alert %1$s snoozed until %2$s</string>
+    <string name="test_alert_passed">Test scenario passed, no further action</string>
     <string name="share_database">Share database...</string>
     <string name="title_motion_detection_warning">Motion Detection Warning</string>
     <string name="message_motion_detection_warning">Activity Motion Detection is experimental and only some phones are compatible. Its main purpose is to detect vehicle mode.\n\nIn tests it seems higher end phones are the most likely to properly support the sensors needed for it to work.  It may also drain your battery.\n\nFor exercise related movement, Smartwatch step counters work better.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1803,7 +1803,7 @@
     <string name="snoozing_due_mute_button_press">Snoozing alert due to MUTE button press</string>
     <string name="volume_button_wrong_button">Double press the same volume button to snooze</string>
     <string name="notification_alert_snoozed_until">Alert %1$s snoozed until %2$s</string>
-    <string name="test_alert_passed">Test scenario passed, no further action</string>
+    <string name="test_alert_passed">Alert type not found</string>
     <string name="share_database">Share database...</string>
     <string name="title_motion_detection_warning">Motion Detection Warning</string>
     <string name="message_motion_detection_warning">Activity Motion Detection is experimental and only some phones are compatible. Its main purpose is to detect vehicle mode.\n\nIn tests it seems higher end phones are the most likely to properly support the sensors needed for it to work.  It may also drain your battery.\n\nFor exercise related movement, Smartwatch step counters work better.</string>

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -61,6 +61,13 @@
 
                 <CheckBoxPreference
                     android:defaultValue="false"
+                    android:dependency="buttons_silence_alert"
+                    android:key="volume_button_snooze_wake_screen"
+                    android:summary="@string/volume_button_snooze_wake_screen_summary"
+                    android:title="@string/volume_button_snooze_wake_screen_title" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
                     android:key="show_buttons_in_alerts"
                     android:summary="@string/show_action_buttons_within_alerts"
                     android:title="@string/alert_buttons" />
@@ -418,5 +425,3 @@
         </PreferenceCategory>
     </PreferenceScreen>
 </PreferenceScreen>
-
-


### PR DESCRIPTION
At home, we are very happy with this (small) change, especially at night 😄. Both my girlfriend (T1D) and I (as her follower) are already using the `petervanrijt:petervanrijt-alarm-snooze-with-volume-buttons` branch. 

## Table of contents

* What this changes
* Setup after installation
* UI changes
* Security: lock screen behaviour
* Problems solved
* Implementation
* Changed files
* Safety review
* Testing
* Design consideration: separate wake-screen preference

## What this changes
With this change you can snooze a glucose alert by **pressing a volume button on the side of your phone twice**. This works in every situation:

- **Screen off or locked** -- the phone wakes up, shows the snooze screen on top of the lock screen, and waits for your button press. You do not need to unlock the phone.
- **Another app in the foreground** -- the snooze screen appears over the app you were using. After snoozing, the previous app is restored automatically.
- **xDrip already open** -- the snooze screen appears inside the app. The system volume does not change while the alert is active.

A single press is not enough -- you must press the **same** button **twice within 1.5 seconds** to prevent accidental snoozes. The first press shows a brief message asking you to confirm; the second press snoozes the alert.

After snoozing, the ongoing glucose notification (the persistent graph on your phone) shows a line like *"Alert low snoozed until 14:35"* so you can see at a glance when the alert will return.

A new setting (**Settings > Alarms and Alerts > Glucose Alerts Settings > Volume snooze from lock screen**) controls whether the snooze screen is allowed to wake your screen and appear over the lock screen. It is off by default; existing users see no change unless they enable it.

Alert testing via **Settings > Glucose Level Alerts List > Edit alert > Test alert** now also supports volume button snooze, so you can verify the full flow without waiting for a real alert.

## Setup after installation

Volume button snooze works out of the box inside the xDrip Home screen once the setting is enabled. For lock screen and overlay support a few extra steps are needed.

**Step 1 Enable volume button snooze in xDrip**

Open **Settings > Alarms and Alerts > Glucose Alerts Settings** and enable **Buttons silence alarms**. This is the parent setting; without it volume buttons have no snooze function.

**Step 2 Enable lock screen wake**

Under the same screen, enable **Volume snooze from lock screen** (only visible when *Buttons silence alarms* is on). This allows the snooze screen to wake the phone and appear over the lock screen when an alert fires. Leave it off if you only want volume button snooze while xDrip is already open.

When either `override_silent_mode` or `volume_button_snooze_wake_screen` is enabled, the Android notification channel for glucose alerts (`BG_ALERT_CHANNEL`) is upgraded to `IMPORTANCE_HIGH` if it was previously set lower.

**User-visible side effects of IMPORTANCE_HIGH:**

- Android may show **heads-up notifications** (floating banner at the top of the screen) for glucose alerts.
- Android may play the **system notification sound** alongside xDrip's own alert sound.
- The notification may **vibrate** even if the user disabled vibration for this channel.

This upgrade is permanent until the user manually resets the channel in Android Settings > Apps > xDrip > Notifications. A log entry is written when the upgrade occurs.

**Step 3 Grant "Display over other apps" in Android (optional)**

To let the snooze screen appear over other apps (e.g. YouTube, WhatsApp) when the screen is on and unlocked:

1. Go to **Android Settings > Apps > xDrip > Display over other apps** (the exact path varies by device manufacturer).
2. Enable **Allow display over other apps**.

Without this permission the alert still sounds and a heads-up notification is shown; tapping it opens the snooze screen. The volume button snooze itself still works when xDrip is in the foreground.

**Step 4 Verify with a test alert**

Go to **Settings > Alarms and Alerts > Glucose Level Alerts List**, tap an alert and choose **Test alert**. The snooze screen should appear. Double press a volume button to confirm the snooze works. The screen will show *"Alert type not found"* (this is expected for test alerts -- their `AlertType` is not saved to the database).

**Summary of settings**

| Setting | Location | Default | Purpose
| -- | -- | -- | --
| Buttons silence alarms | xDrip > Settings > Alarms and Alerts > Glucose Alerts Settings | Off | Master switch for volume button snooze
| Volume snooze from lock screen | Same screen (child of above) | Off | Snooze screen appears over lock screen
| Display over other apps | Android Settings > Apps > xDrip | Off | Snooze screen appears over other apps


---

## UI changes

This section lists every user-visible change introduced by this PR: new
screens, changed text, new notifications, and altered system behaviour.
No layout XML files were added or modified -- all visual changes use
existing layouts populated with new content.

### 1. New preference: Volume snooze from lock screen

**Location:** Settings > Alarms and Alerts > Glucose Alerts Settings \
**File:** `pref_notifications.xml:62-67`

A new CheckBoxPreference appears below *Buttons silence alert* when that
parent setting is enabled. When the parent is off, the new preference is
greyed out.

| Element | Value |
|---|---|
| Title | *Volume snooze from lock screen* |
| Summary | *When an alert fires, wake the screen and show the snooze screen so volume buttons can snooze the alarm from the lock screen* |
| Key | `volume_button_snooze_wake_screen` |
| Default | Off |

### 2. Toast messages during volume button snooze

**Files:** `SnoozeActivity.java:464-470, 505-572`, `Home.java:3661-3698`

Users see toast messages at three moments during the snooze flow:

**First press -- confirmation (SnoozeActivity and Home):**

| Button pressed | Toast text |
|---|---|
| Volume down | *Press the volume DOWN button again to snooze* |
| Volume up | *Press the volume UP button again to snooze* |
| Mute | *Press the same volume button again to snooze* |

**Wrong button pressed (SnoozeActivity only):**

If the user presses a different volume button within 1.5 s of the first
press, the toast shows: *Double press the same volume button to snooze*

**Second press -- snooze success (SnoozeActivity and Home):**

| Button pressed | Toast text |
|---|---|
| Volume down | *Snoozing alert due to double volume DOWN button press* |
| Volume up | *Snoozing alert due to double volume UP button press* |
| Mute | *Snoozing alert due to MUTE button press* |

All toasts use `TOAST_LENGTH_LONG`. In SnoozeActivity, a pending toast is
cancelled before showing a new one to prevent stacking.

### 3. SnoozeActivity status text changes

**File:** `SnoozeActivity.java:396-462`

The `alertStatus` TextView at the top of the snooze screen shows dynamic
text. This PR changes it in two ways:

**a. Seconds display when close to re-rise**

When the alert will re-rise in less than 120 seconds, the countdown now
shows seconds instead of minutes. Previously this showed *"0 minutes left"*
due to integer truncation.

| Time remaining | Before | After |
|---|---|---|
| 75 seconds | *0 minutes left* | *75 seconds left* |
| 45 seconds | *0 minutes left* | *45 seconds left* |
| 3 minutes | *3 minutes left* | *3 minutes left* (unchanged) |

**b. Alert type not found message**

When an `ActiveBgAlert` exists but its `AlertType` cannot be found (test
alerts, deleted alerts, database issues), the status text now shows:

> *Alert type not found*

Previously this showed *"Test scenario passed, no further action"*, which
was misleading for non-test scenarios.

### 4. SnoozeActivity appears over lock screen

**Files:** `SnoozeActivity.java:178-190`, `AlertPlayer.java:577-663`

When an alert fires and `override_silent_mode` or
`volume_button_snooze_wake_screen` is enabled, the snooze screen appears
as a full-screen activity:

| Scenario | What the user sees |
|---|---|
| Screen off | Screen wakes, SnoozeActivity shown over lock screen |
| Screen on + locked | SnoozeActivity shown over lock screen |
| Screen on + unlocked + xDrip foreground | SnoozeActivity opens inside the app |
| Screen on + unlocked + other app + overlay permission | SnoozeActivity appears over the other app |
| Screen on + unlocked + other app + no permission | Heads-up notification; tapping it opens SnoozeActivity |
| Screen on + notification shade open | SnoozeActivity opens behind the shade (see limitation below) |

The phone is **not** unlocked. The lock screen remains active behind the
snooze activity. After snoozing or pressing Back, the phone returns to
whatever was on screen before.

**Android platform limitation: notification shade open**

When the user has pulled down the notification shade (swipe down from the
top of the screen), SnoozeActivity is started but opens **behind** the
shade. The notification shade is a system-level UI owned by Android itself;
no third-party app can draw over it or dismiss it programmatically. Historically apps could close the shade using
`Intent.ACTION_CLOSE_SYSTEM_DIALOGS`, but Google blocked this for
non-system apps starting with **Android 12 (API 31)** as a security
measure.

**Workaround:** swipe the notification shade back up. SnoozeActivity is
visible behind it and ready for volume button snooze. Alternatively, tap
the xDrip alert notification inside the shade to open SnoozeActivity
directly. The alert sound continues to play regardless.

### 5. SnoozeActivity auto-closes when alert ends

**File:** `SnoozeActivity.java:214-221, 382-394, 411`

Two new behaviours the user can observe:

- **Alert ends while SnoozeActivity is in the background:** when the user
  returns to it, the Activity closes automatically instead of showing stale
  alert information above the lock screen.
- **Alert ends while SnoozeActivity is visible:** the Activity drops back
  behind the lock screen (lock screen flags are cleared). The status text
  updates to *"No active alert exists"*.

### 6. Snooze line in the ongoing BG notification

**File:** `Notifications.java:740-758`

When an alert is snoozed, the persistent BG notification (the one showing
the glucose graph and delta) gains an extra line:

```
Delta: -0.6 mmol/l
Alert low_test snoozed until 14:35
```

The line appears in all four notification styles (standard, collapsed,
expanded, and chip/BigText on Android 16+).

| Condition | Snooze line shown? |
|---|---|
| Alert snoozed, BG still exceeds threshold | Yes |
| Alert snoozed, BG returned within threshold | No (line disappears) |
| Alert snoozed, BG reading older than 15 min | Yes (stale data: always show) |
| Alert snoozed, vehicle mode active (low alert) | Threshold includes +18 mg/dL offset |
| Alert not snoozed | No |
| No active alert | No |

The snooze line appears shortly after snoozing. There may be a brief delay
(typically under 2 seconds) because the entire notification -- including
the glucose graph -- is rebuilt by a background service. This is the
fastest path available within xDrip's architecture. The snooze line
disappears when the snooze expires or the alert is stopped.

### 7. Notification channel importance upgrade

**File:** `AlertPlayer.java:586-594`

When either `override_silent_mode` or `volume_button_snooze_wake_screen` is
enabled, the Android notification channel for glucose alerts
(`BG_ALERT_CHANNEL`) is upgraded to `IMPORTANCE_HIGH` if it was previously
set lower.

**User-visible side effects of IMPORTANCE_HIGH:**

- Android may show **heads-up notifications** (floating banner at the top
  of the screen) for glucose alerts.
- Android may play the **system notification sound** alongside xDrip's own
  alert sound.
- The notification may **vibrate** even if the user disabled vibration for
  this channel.

This upgrade is permanent until the user manually resets the channel in
Android Settings > Apps > xDrip > Notifications. A log entry is written
when the upgrade occurs.

### Summary of all new UI elements

| # | Element | Type | Where visible |
|---|---|---|---|
| 1 | *Volume snooze from lock screen* | Setting (CheckBox) | Settings screen |
| 2 | *Press the volume DOWN/UP button again to snooze* | Toast | SnoozeActivity, Home |
| 3 | *Double press the same volume button to snooze* | Toast | SnoozeActivity |
| 4 | *Snoozing alert due to double volume DOWN/UP/MUTE button press* | Toast | SnoozeActivity, Home |
| 5 | *Alert type not found* | Status text | SnoozeActivity |
| 6 | Seconds countdown (*"75 seconds left"*) | Status text | SnoozeActivity |
| 7 | SnoozeActivity over lock screen | Full-screen activity | Lock screen |
| 8 | SnoozeActivity auto-close on alert end | Activity lifecycle | Lock screen / app |
| 9 | *Alert [name] snoozed until HH:mm* | Notification text | Ongoing BG notification |
| 10 | Channel importance upgrade to HIGH | System notification behaviour | All glucose alert notifications |

---

## Security: lock screen behaviour

The snooze screen uses `FLAG_SHOW_WHEN_LOCKED` to appear above the lock
screen. This does **not** unlock the phone. The lock screen remains active
behind the snooze activity. A finder cannot navigate to other apps,
contacts, messages, or any other data on the device. This is the same
mechanism Android uses for incoming phone calls and alarm clock apps
(e.g. Google Clock).

Additional safeguards:

- A **double press** of the same volume button within 1.5 seconds is
  required to snooze. A single press only shows a confirmation message.
- The snooze screen only appears **during an active glucose alert**. Without
  an active alert, pressing volume buttons has no effect.
- The feature is **opt-in** and off by default. Users must enable *"Volume
  snooze from lock screen"* explicitly.
- The only information visible on the snooze screen is the alert name and
  snooze time. After snoozing or pressing back, the phone returns to the
  lock screen.
- When the alert ends while the snooze screen is still visible, the lock
  screen flags are cleared automatically. When the alert ends while the
  snooze screen is in the background, it auto-closes on return.

---

## Problems solved

**1. Volume buttons did nothing outside Home** -- `SnoozeActivity` had no
key event handler. Added `onKeyDown()` with double press logic, identical
to `Home`.

**2. Snooze screen never appeared over the lock screen** -- Two Android
platform issues blocked `setFullScreenIntent`:

- Android 14+ silently ignores it without `USE_FULL_SCREEN_INTENT`
  (already declared but a duplicate entry was cleaned up).
- Android 8+ requires `IMPORTANCE_HIGH` on the notification channel; xDrip
  used `IMPORTANCE_DEFAULT`. The channel importance is now upgraded at
  runtime when a full screen intent is needed.

**3. Snooze screen never appeared over other apps** -- On Android 10+,
`setFullScreenIntent` is demoted to a heads-up notification when the screen
is already on and unlocked. `AlertPlayer` now starts `SnoozeActivity`
directly, using `SYSTEM_ALERT_WINDOW` when another app is in the
foreground. Falls back to a heads-up notification when the permission is
not granted.

**4. Full screen intent targeted the wrong activity** -- `setFullScreenIntent`
pointed to `Home`; changed to `SnoozeActivity` so the snooze screen appears
directly.

**5. Test alerts could not be snoozed** -- `alertTypegetOnly()` called
`ClearData()` when the `AlertType` was not found, deleting the
`ActiveBgAlert`. Test alerts create a temporary `AlertType` that is not
saved to the database, so the lookup always failed and the alert was
destroyed. Removed the destructive side effect; `SnoozeActivity` now shows
*"Alert type not found"* when `ActiveBgAlert` exists but `AlertType` cannot
be found (test alerts, deleted alerts, database issues). Added a null
guard in `snoozeForType()` to prevent a `NullPointerException` when
`alertTypegetOnly()` returns `null`.

**6. Snooze line for start_snoozed and PreSnooze** -- The snooze line now
appears for all snoozed alerts, including silently started (`start_snoozed`)
and manually pre-snoozed alerts. The line disappears automatically when the
BG reading returns within the alert threshold, even if the snooze time has
not expired.

**7. Snooze line did not update immediately** -- Two separate issues:
(a) After snoozing, `recheckAlerts()` called `Notifications.start()` which
has a 10-second rate limit. If the notification service ran recently the call
was silently dropped, delaying the snooze line by up to 5 minutes.
`recheckAlerts()` now uses `staticUpdateNotification()` which bypasses the
rate limit. (b) When a snooze expired, the ongoing notification was rebuilt
*before* alert evaluation updated the snooze state, so the snooze line
persisted for one extra cycle. `notificationSetter()` now detects snooze
status changes and rebuilds the notification a second time when needed.

**8. Snooze line not cleared on alert removal** -- Removing an alert via
REMOVE ALERT deleted the `AlertType` but left the `ActiveBgAlert` in the
database and did not rebuild the notification. The snooze line persisted
until the next BG reading. The remove handler now stops the alert player,
clears the `ActiveBgAlert` (only when the UUID matches), and rebuilds the
notification immediately.

**9. "0 minutes left" display** -- Integer division truncated sub-minute
values to zero. Now shows seconds when under 120 seconds remain.

**10. Lock screen flags persisted after alert ended** -- `FLAG_SHOW_WHEN_LOCKED`
and `FLAG_TURN_SCREEN_ON` were set in `onCreate()` when an alert was active
but never cleared. If the alert ended while the Activity was still visible,
the Activity stayed above the lock screen until the user pressed Back. Now
cleaned up via two paths: `onResume()` closes the Activity when the alert
ended in the background; `displayStatus()` clears the flags when the alert
ends while the Activity is visible.

**11. First-press toast persisted after second volume press** -- In
`SnoozeActivity`, `doSnoozeFromVolumeButton()` used `JoH.static_toast_long()`
which creates a new toast without cancelling the previous one. After the
second volume press, the confirmation toast from the first press stayed
visible while the success toast queued behind it. Changed to
`showVolumeButtonToast()` which calls `volumeButtonToast.cancel()` before
showing the new toast, so the success message appears immediately.

**12. Orphaned ActiveBgAlert blocked volume buttons after test alert** --
After removing `ClearData()` from `alertTypegetOnly()` (fix #5), snoozed
test alerts leave an orphaned `ActiveBgAlert` in the database (the
temporary `AlertType` is not persisted, so `alertTypegetOnly()` returns
`null`). When the user later presses a volume button in `Home`, the code
enters the snooze flow instead of adjusting system volume, showing
*"Press the volume button again to snooze"* with no active alert sound.
Added orphan detection at the start of each volume button handler:
when `is_snoozed` is `true` and `alertTypegetOnly()` returns `null`, the
record is cleared via `ClearData()`, the notification is rebuilt via
`recheckAlerts()` to remove the stale snooze line, and the key event falls
through to the system for normal volume control.

---

## Implementation

### 1. Double press required for volume button snooze

**Files:** `SnoozeActivity.java`, `Home.java`

To prevent accidental snoozes, a single volume button press no longer
snoozes the alert. The user must press the **same** button **twice within
1.5 seconds**:

- First press: shows a toast -- *"Press the same volume button again to snooze"*
- Second press within 1.5 s: snoozes the alert and closes `SnoozeActivity`

#### Rate limiting: original vs. new

The original code used `JoH.quietratelimit("button-press", 5)` -- a shared
rate limit across all three buttons. A single press was enough to trigger
the snooze immediately; the rate limit only prevented a second snooze within
5 seconds afterwards. Because the key `"button-press"` was shared, pressing
any one button also blocked the other two for those 5 seconds.

The new approach replaces this with a **per-button confirmation mechanism**
using independent timestamps (`volumeDownFirstPressTime`,
`volumeUpFirstPressTime`, `volumeMuteFirstPressTime`) and UUID tracking
(`volumeDownFirstPressUuid`, `volumeUpFirstPressUuid`,
`volumeMuteFirstPressUuid`):

- Protection is applied **before** the action, not after: a single press
  never snoozes.
- Each button has its own timer, so pressing one button does not affect
  the others.
- After a successful double press the timer resets to zero, requiring a
  fresh double press for any subsequent snooze.
- Each first press records the `alert_uuid` of the active alert. The
  second press only triggers a snooze when the UUID matches the currently
  active alert. If the alert changed between presses (alert disappeared
  and a new one appeared), it is treated as a new first press. This
  prevents a stale timestamp from one alert carrying over to a different
  alert.
- When no active alert exists (`getOnly()` returns `null`), all timestamps
  and UUIDs are reset to prevent carry-over from a previous alert.

**Exception: mute in `Home.java`** retains the original single-press
behaviour with `quietratelimit("button-press", 5)` -- see section 2.

| | Original (`quietratelimit`) | New (timestamp per button) |
|---|---|---|
| **Protection** | After: blocks repetition after snooze | Before: requires confirmation before snooze |
| **Single press** | Sufficient to snooze | Only shows toast, no snooze |
| **Scope** | Shared across all buttons | Independent per button |
| **Time window** | 5 s block after action | 1.5 s to place second press |
| **Accidental snooze risk** | Possible with one press | Not possible with one press |

The double press mechanism is used in both `SnoozeActivity` and `Home`.
`SnoozeActivity` adds two extra safeguards that `Home` does not have:
pressing a *different* button clears the first button's timer (preventing
cross-button snoozes), and a "wrong button" toast (`volume_button_wrong_button`)
is shown in that case. `Home` keeps the simpler per-button logic without
cross-button interaction. Mute in `Home` retains the original single-press
behaviour -- see section 2.

### 2. Volume down, volume up and mute all snooze

**Files:** `SnoozeActivity.java`, `Home.java`

**Volume down** and **volume up** require a double press in both
`SnoozeActivity` and `Home`. **Mute** snoozes on a single press in `Home`
(original behaviour restored), and on a double press in `SnoozeActivity`.

Each button produces a distinct confirmation string. These strings are
now used in both `Home` and `SnoozeActivity`:

| Button | Behaviour in `Home` | Toast on success |
|---|---|---|
| Volume down | Double press (1.5 s) | *"Snoozing alert due to double volume DOWN button press"* |
| Volume up | Double press (1.5 s) | *"Snoozing alert due to double volume UP button press"* |
| Mute | Single press + `quietratelimit` (5 s) | *"Snoozing alert due to MUTE button press"* |

The snooze time used is the alert's configured `default_snooze` (or the
standard default if not set), identical to swiping the notification away.

### 3. Volume button handling in SnoozeActivity

**File:** `SnoozeActivity.java`

Added an `onKeyDown()` override and a shared
`doSnoozeFromVolumeButton(int toastResId, String logMessage)` helper to
`SnoozeActivity`. Each caller passes its button-specific toast string
resource and log message. The existing `buttons_silence_alert` preference
gates this behaviour.

#### Snooze time resolution in `doSnoozeFromVolumeButton()`

The snooze time is resolved using the same three-layer logic as swiping
the notification away:

1. **Per-alert setting** -- `alertType.default_snooze` if non-zero
2. **Type-based default** -- `getDefaultSnooze(alertType.above)`: 120 minutes for high alerts, 35 minutes for low alerts
3. **Absolute fallback** -- 30 minutes if the alert type cannot be retrieved at all

The initial value `int snooze = 30` in the method represents layer 3 only.
It is only reached when `alertType == null`; layers 1 and 2 take precedence
whenever the alert type is available.

| Method | Layer 1 (per-alert) | Layer 2 (120/35 min) | Layer 3 (30 min) |
|---|---|---|---|
| `doSnoozeFromVolumeButton()` | yes | yes | yes |
| `GuessDefaultSnoozeTime()` | yes | no | yes |

#### Returning to the previous app after snooze

After snoozing, `doSnoozeFromVolumeButton()` calls `moveTaskToBack(true)`
before `finish()`. This moves the xDrip task to the background first, so
Android restores whatever app the user was using before the alert appeared.
Without this, `finish()` alone would bring the xDrip task to the foreground.
`moveTaskToBack()` is only called when `EXTRA_LAUNCHED_OVER_OTHER_APP` is
set -- if xDrip was already the foreground app, `finish()` alone is correct.

### 4. Show SnoozeActivity over the lock screen

**File:** `SnoozeActivity.java`

When `SnoozeActivity` is launched while an alert is active, the window
flags `FLAG_SHOW_WHEN_LOCKED` and `FLAG_TURN_SCREEN_ON` are set (using
`setShowWhenLocked()` / `setTurnScreenOn()` on Android 8.1+ and window
flags as a fallback). This allows the activity to appear above the lock
screen so that volume button events are delivered without requiring the
user to unlock the device first.

A `lockScreenFlagsSet` boolean tracks whether the flags were set during
`onCreate()`. This enables two cleanup paths:

1. **`onResume()`** -- if the alert ended while the Activity was in the
   background (paused/stopped), `finish()` closes the Activity entirely.
2. **`displayStatus()`** -- if the alert ends while the Activity is visible,
   `clearLockScreenFlags()` removes the flags so the Activity returns
   behind the lock screen.

The `lockScreenFlagsSet` guard ensures that users who open SnoozeActivity
from the menu (without an active alert) are not affected -- the Activity
stays open and is never auto-closed.

### 5. Full screen intent targets SnoozeActivity with correct channel importance

**File:** `AlertPlayer.java`

The `setFullScreenIntent` for `override_silent_mode` alerts previously
targeted `Home.class`. It now targets `SnoozeActivity.class` so that
waking the screen during an alert goes directly to the snooze screen
where volume buttons are handled.

When `setFullScreenIntent` is set (either `override_silent_mode` or
`volume_button_snooze_wake_screen` is enabled), the `BG_ALERT_CHANNEL`
importance is upgraded to `IMPORTANCE_HIGH` at runtime if it is currently
below that level. This ensures Android actually activates the full screen
intent instead of silently downgrading it to a regular notification. The
upgrade is logged with `Log.ueh()` so it appears in xDrip's event log.
Users who have neither setting enabled are not affected.

#### Direct activity start when the screen is already on

`setFullScreenIntent` launches the Activity only in two cases:
- Screen is **off** -- Android wakes the screen
- Screen is **on + locked** -- Android activates the full screen intent over the lock screen

When the screen is **on and unlocked**, Android 10+ deliberately demotes the
full screen intent to a heads-up notification so it does not interrupt the
user's current app. `SnoozeActivity` is never brought to the foreground.

`AlertPlayer` therefore starts `SnoozeActivity` directly when the screen is
on, using `PowerManager.isInteractive()` to detect this. Because the
behaviour differs between the locked and unlocked cases, the handling is
split:

**Screen on + locked:** `startActivity()` is called when `override_silent_mode`
or `volume_button_snooze_wake_screen` is enabled. `SnoozeActivity` has
`FLAG_SHOW_WHEN_LOCKED` set in `onCreate()`, so it appears above the lock
screen without requiring the user to unlock.

**Screen on + unlocked:** `AlertPlayer` checks whether xDrip is already the
foreground app (`ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND`).
Three sub-cases follow:

- **xDrip already in the foreground** (e.g. user is in the app or testing an
  alert from Settings): `startActivity()` is always called, regardless of
  `override_silent_mode` or `volume_button_snooze_wake_screen`. No special
  permission is needed.
- **Another app in the foreground + wake preference enabled + `SYSTEM_ALERT_WINDOW` granted**:
  `startActivity()` is called with `EXTRA_LAUNCHED_OVER_OTHER_APP = true` so
  `SnoozeActivity` returns to the previous app after snoozing.
- **Another app in the foreground, permission not granted or wake preference off**:
  falls back to the heads-up notification; tapping it opens `SnoozeActivity`.

All three `startActivity()` calls are wrapped in try-catch. If the Activity
cannot start (Android 12+ background start restrictions, manufacturer
limitations, disabled component), the error is logged and execution
continues to `playFile()` -- the alert sound still plays. The heads-up
notification from `setFullScreenIntent` serves as fallback for user
interaction.

| | Wake Screen (`wake_phone_during_alerts`) | Volume snooze from lock screen |
|---|---|---|
| **Mechanism** | Wake lock on MediaPlayer | `setFullScreenIntent` on notification |
| **What appears** | Lock screen / current app | `SnoozeActivity` above lock screen |
| **Screen turns on** | Yes | Yes |
| **Volume buttons work** | No -- no xDrip Activity in foreground | Yes -- `SnoozeActivity` receives key events |
| **Unlock required** | Yes, to interact with xDrip | No |

### 6. SYSTEM_ALERT_WINDOW permission added

**File:** `AndroidManifest.xml`

`USE_FULL_SCREEN_INTENT` was already declared in the manifest. A duplicate
entry introduced during development has been removed.

Added the `SYSTEM_ALERT_WINDOW` permission required on Android 10+ to start
an Activity over another app when the screen is on and unlocked. Without
this permission `context.startActivity()` from the background is blocked;
the code falls back to a heads-up notification instead.

### 7. Fix "0 minutes left" display

**File:** `SnoozeActivity.java`

When an alert re-rise time is less than one minute away, `displayStatus()`
previously showed **"0 minutes left"**. The root cause was integer division:
`msLeft / 60000` truncates any value under 60 000 ms to zero.

**Fix:** when fewer than 120 seconds remain, the remaining time is shown in
seconds instead of minutes:

```java
final long msLeft = aba.next_alert_at - now;
final String timeLeft = msLeft < 120000
        ? (msLeft / 1000) + " seconds left"
        : (msLeft / 60000) + " minutes left";
```

### 8. New preference: Volume snooze from lock screen

**Files:** `AlertPlayer.java`, `pref_notifications.xml`, `strings.xml`

Added a new opt-in preference `volume_button_snooze_wake_screen`
(**Settings > Alarms and Alerts > Glucose Alerts Settings > Volume snooze
from lock screen**).

When enabled, all glucose alerts (not only those with `override_silent_mode`)
will use `setFullScreenIntent` to wake the screen and show `SnoozeActivity`
on top of the lock screen when the alert fires.

- Default value: `false` (no change in behaviour for existing users).
- The preference is a child of `buttons_silence_alert` and is disabled
  (greyed out) when that parent preference is off.

### 9. Snooze status in the ongoing BG notification

**Files:** `Notifications.java`, `ActiveBgAlert.java`, `strings.xml`

When an alert is snoozed, the ongoing BG notification (the persistent
notification showing the glucose graph and delta) shows an extra line:

```
Delta: -0.6 mmol/l
Alert laag_test snoozed until 14:35
```

The line is built by `buildSnoozeLine()`, a new helper in `Notifications.java`.
It checks `ActiveBgAlert.is_snoozed` and verifies that the current BG reading
still exceeds the alert's threshold before showing anything.

The threshold check accounts for:
- **Vehicle mode offset:** for low alerts (`!alertType.above`), the threshold
  is raised by `vehicle_mode_adjust_mgdl` (18 mg/dL) when vehicle mode is
  active, matching the logic in `AlertType.get_highest_active_alert_helper()`.
- **Stale data:** when the most recent BG reading is older than 15 minutes,
  the threshold check is skipped entirely. The snooze line is always shown
  in that case -- it is safer to show a possibly unnecessary snooze line
  than to hide it based on outdated data.

The snooze line appears for all snooze scenarios:
- User-initiated snooze via volume buttons, notification swipe, or snooze
  screen.
- `start_snoozed` preference enabled: the alert starts silently but the
  user can see that an alert condition exists.
- `PreSnooze()` from the alert edit screen.

The snooze line disappears automatically when the BG reading returns within
the alert's threshold, even if the snooze time has not yet expired.

The line is added to all four notification styles:
- Standard content text (`setContentText`)
- Collapsed custom view (`notification_bg_collapsed`)
- Expanded custom view (`notification_bg_expanded`)
- Chip-style notification (Android 16+, `BigTextStyle`)

The snooze line appears shortly after snoozing (typically under 2 seconds).
A brief delay is expected because the entire notification -- including the
glucose graph -- is rebuilt by a background IntentService.
`recheckAlerts()` uses `Notifications.staticUpdateNotification()` instead of
`Notifications.start()` to bypass the 10-second rate limit that would
otherwise delay the update by up to 5 minutes. This is the fastest path
available within xDrip's notification architecture.

The snooze line disappears when the snooze expires.
`notificationSetter()` captures the snooze status before building the
ongoing notification, then checks it again after alert evaluation. If the
status changed, the notification is rebuilt a second time.

### 10. Test alert support

**Files:** `ActiveBgAlert.java`, `SnoozeActivity.java`, `strings.xml`

When testing an alert via Settings > Glucose Level Alerts List > Test alert,
`AlertType.testAlert()` creates a temporary `AlertType` object that is **not**
saved to the database. The `ActiveBgAlert` is saved with its UUID.

Previously, `alertTypegetOnly()` called `ClearData()` when the `AlertType`
was not found, deleting the `ActiveBgAlert` and making it impossible to
snooze the test alert via volume buttons.

**Fix:** removed the `ClearData()` side effect from `alertTypegetOnly()`.
Orphaned alerts are still cleaned up by `startAlert()`, which calls
`stopAlert()` before creating any new alert.

`SnoozeActivity.displayStatus()` now shows `"Alert type not found"` when
`ActiveBgAlert` exists but the `AlertType` cannot be found. This message
is accurate for all cases (test alerts, deleted alerts, database issues).
No `ClearData()` is called in the lookup itself -- the orphaned
`ActiveBgAlert` is cleaned up via two paths: (a) automatically when the
next real alert fires (`startAlert()` calls `stopAlert()`), and (b) when
the user presses a volume button in `Home` while the orphaned record exists
(`is_snoozed && alertTypegetOnly() == null` triggers `ClearData()` +
`recheckAlerts()`, restoring normal volume control).

### 11. Clear snooze notification on alert removal

**File:** `EditAlertActivity.java`

When the user removes an alert via the **REMOVE ALERT** button, the ongoing
BG notification snooze line was not cleared immediately. The `AlertType` was
deleted but the `ActiveBgAlert` remained in the database.

**Fix:** the remove handler now checks whether the `ActiveBgAlert` belongs
to the alert being removed (UUID match). If so, `stopAlert()` clears the
`ActiveBgAlert` and stops any active sound. `recheckAlerts()` is called
afterwards to rebuild the notification immediately. Alerts belonging to a
different `AlertType` are left untouched.

---

## Changed files

### `SnoozeActivity.java`

- `onKeyDown()` with double press and UUID tracking for volume down, up, and
  mute. Each button has independent timestamp and UUID variables. Pressing one
  button resets the other two and shows a "wrong button" toast if applicable.
- `doSnoozeFromVolumeButton()` helper: snoozes with `default_snooze`, calls
  `recheckAlerts()` to bypass the 10-second rate limit, shows a button-specific
  toast, logs via `Log.ueh()`, and calls `moveTaskToBack(true)` + `finish()`
  only when launched over another app.
- `showVolumeButtonToast()`: cancels any pending toast before showing a new one.
  Also used in `doSnoozeFromVolumeButton()` so the success toast replaces the
  first-press confirmation toast immediately (M6 fix).
- `FLAG_SHOW_WHEN_LOCKED` and `FLAG_TURN_SCREEN_ON` in `onCreate()` when an
  alert is active. `lockScreenFlagsSet` boolean tracks whether flags were set.
- `onResume()`: calls `finish()` when the alert ended while the Activity was
  in the background (`lockScreenFlagsSet && getOnly() == null`).
- `clearLockScreenFlags()`: removes lock screen flags in `displayStatus()` when
  no active alert exists. Uses API-appropriate method (`setShowWhenLocked(false)`
  on Android 8.1+, `clearFlags()` as fallback).
- `displayStatus()` shows seconds instead of minutes when < 120 s remain.
- `displayStatus()` shows `"Alert type not found"` when `ActiveBgAlert` exists
  but `AlertType` cannot be found.
- `snoozeForType()` null guard: `activeBgAlert.above` check uses inline null
  guards; `ALL_ALERTS` clears `ActiveBgAlert` regardless; `HIGH_ALERTS` and
  `LOW_ALERTS` skip `ClearData()` when the type is unknown.

### `Home.java`

- Volume down and up use double-press logic with independent timestamp and UUID
  tracking. First press stores `alert_uuid`; second press only triggers snooze
  when UUID matches the currently active alert.
- Mute retains original single-press with `quietratelimit("button-press", 5)`.
- When `getOnly()` returns `null`, all timestamps and UUIDs are reset.
- Orphan cleanup: when `is_snoozed` is `true` and `alertTypegetOnly()` returns
  `null`, `ClearData()` removes the orphaned record and `recheckAlerts()` rebuilds
  the notification. The key event falls through to system volume control (M7 fix).
- Key events consumed (`return true`) during active alerts so system volume does
  not change.
- `recheckAlerts()` called after each successful snooze.
- Per-button string resources for toast and log messages.

### `AlertPlayer.java`

- `setFullScreenIntent` target changed from `Home.class` to `SnoozeActivity.class`.
- `BG_ALERT_CHANNEL` importance upgraded to `IMPORTANCE_HIGH` when
  `setFullScreenIntent` is set (`override_silent_mode` or
  `volume_button_snooze_wake_screen`). Logged with `Log.ueh()`.
- Direct `startActivity()` when screen is on: always when xDrip is foreground;
  with `SYSTEM_ALERT_WINDOW` when another app is foreground; fallback to
  heads-up notification otherwise.
- `volume_button_snooze_wake_screen` preference check alongside
  `override_silent_mode` in all relevant code paths.
- All three `startActivity()` calls wrapped in try-catch. Alert sound continues
  via `playFile()` if Activity cannot start.

### `Notifications.java`

- `buildSnoozeLine()`: appends snooze status to the ongoing BG notification.
  Shown when `is_snoozed` and BG still exceeds the threshold (with
  `vehicle_mode_adjust_mgdl` offset for low alerts). Threshold check skipped
  when BG reading is older than 15 minutes (stale data). Added to all four
  notification styles.
- `notificationSetter()` detects snooze status changes during alert evaluation
  and rebuilds the notification when the status flipped.

### `ActiveBgAlert.java`

- `snooze()` sets `last_alerted_at` to the current time.
- `alertTypegetOnly()` no longer calls `ClearData()` on lookup failure.
- Added `currentlySnoozed()` helper for snooze status change detection.

### `EditAlertActivity.java`

- REMOVE ALERT handler: checks `ActiveBgAlert` UUID match, calls `stopAlert()`
  to clear the alert, then `recheckAlerts()` to rebuild the notification.

### `AndroidManifest.xml`

- Added `SYSTEM_ALERT_WINDOW` permission.
- Removed duplicate `USE_FULL_SCREEN_INTENT` entry.

### `pref_notifications.xml`

- New `CheckBoxPreference` for `volume_button_snooze_wake_screen`, default
  `false`, child of `buttons_silence_alert`.

### `strings.xml`

Eleven new strings:
- `volume_button_snooze_wake_screen_title` / `_summary` -- preference labels
- `volume_button_confirm_snooze`, `volume_down_confirm_snooze`,
  `volume_up_confirm_snooze` -- first-press confirmation toasts
- `snoozing_due_volume_down_button_press`,
  `snoozing_due_volume_up_button_press`,
  `snoozing_due_mute_button_press` -- success toasts
- `volume_button_wrong_button` -- wrong-button guidance
- `notification_alert_snoozed_until` -- snooze line in notification
- `test_alert_passed` -- changed from *"Test scenario passed, no further action"*
  to *"Alert type not found"* (H2 fix)

---

## Safety review

Review of all changes for unintended side effects. User safety around
glucose alerts is critical -- an alert that fails to fire, fires incorrectly,
or is accidentally silenced can have direct health consequences.

Each finding is tagged with its origin:
- **Pre-existing** -- the issue existed before this PR
- **This PR** -- introduced by code changes in this PR
- **This session** -- introduced during iterative refinements in the current
  development session

### Critical

**K1. NullPointerException in SnoozeActivity.snoozeForType()** \
Origin: **Pre-existing** (worsened by this PR) \
File: `SnoozeActivity.java:68-79`

`alertTypegetOnly()` can return `null` (test alerts, deleted alerts). The
code dereferences `activeBgAlert.above` without a null check. Before the
PR, `ClearData()` was called as a side effect of `alertTypegetOnly()` when
the lookup failed, so a second call to `snoozeForType()` would skip the
`if (aba != null)` check. After the PR the `ActiveBgAlert` persists, making
the NPE **repeatedly reachable**.

*Fix applied:* Added inline null guards on the `activeBgAlert.above` checks.
`ALL_ALERTS` still clears the `ActiveBgAlert` regardless (its condition does
not depend on `activeBgAlert`). `HIGH_ALERTS` and `LOW_ALERTS` safely skip
`ClearData()` when the `AlertType` is unknown. Steps 3 (high/low prefs
reset) and 4 (`recheckAlerts()`) are always reached.

```java
if (disableType == SnoozeType.ALL_ALERTS
        || (activeBgAlert != null && activeBgAlert.above && disableType == SnoozeType.HIGH_ALERTS)
        || (activeBgAlert != null && !activeBgAlert.above && disableType == SnoozeType.LOW_ALERTS)
) {
    ActiveBgAlert.ClearData();
}
```

**Status: FIXED**

---

**K2. Stale timestamp causes false double press across alert transitions** \
Origin: **This PR** \
File: `Home.java:3654-3700`, `SnoozeActivity.java:496-576`

The timestamp variables are never reset when an alert disappears. Scenario:
user presses volume down during an alert (timestamp set), alert disappears,
new alert appears within 1.5 s, first press on the new alert is treated as
a second press and snoozes immediately. This defeats the double press safety
mechanism.

*Fix applied:* Each button now stores the `alert_uuid` alongside the
timestamp on the first press. The second press only triggers a snooze when
the UUID matches the currently active alert. If the alert changed between
presses, it is treated as a new first press. Additionally, when `getOnly()`
returns `null`, all timestamps and UUIDs are reset. Applied to both
`Home.java` (volume down/up) and `SnoozeActivity.java` (volume down/up/mute).

**Status: FIXED**

---

### High

**H1. buildSnoozeLine() threshold check ignores vehicle_mode offset** \
Origin: **This session** \
File: `Notifications.java:749-753`

`buildSnoozeLine()` compared `bg` directly against `alertType.threshold`.
The actual alert logic in `AlertType.get_highest_active_alert_helper()`
applies a `vehicle_mode_adjust_mgdl` offset (18 mg/dL) for low alerts.
With active vehicle mode, the snooze line could disappear while the alert
was still active, or remain visible after the alert condition had ended.

*Fix applied:* `buildSnoozeLine()` now applies the same offset. For low
alerts (`!alertType.above`), the threshold is raised by the offset when
vehicle mode is active:

```java
if (!alertType.above) {
    final double offset = ActivityRecognizedService.raise_limit_due_to_vehicle_mode()
            ? ActivityRecognizedService.getVehicle_mode_adjust_mgdl() : 0;
    if (bg > alertType.threshold + offset) return "";
}
```

**Status: FIXED**

---

**H2. Misleading "Test scenario passed" message** \
Origin: **This PR** \
File: `SnoozeActivity.java:405-407`, `strings.xml:1806`

The message appeared whenever `ActiveBgAlert` exists but `AlertType` is
`null`. This is not limited to test alerts -- it also occurs when an alert
was deleted from another device, the database is corrupt, or a race
condition removed the `AlertType`.

*Fix applied:* Changed the string resource `test_alert_passed` from
*"Test scenario passed, no further action"* to *"Alert type not found"*.
This is accurate for all cases. No `ClearData()` is called -- the orphaned
`ActiveBgAlert` is automatically cleaned up by `startAlert()` when the next
real alert fires.

**Status: FIXED**

---

**H3. startActivity() without exception handling** \
Origin: **This PR** \
File: `AlertPlayer.java:614-618, 644-648, 655-658`

Three `context.startActivity()` calls were not wrapped in try-catch. If the
Activity could not be started (disabled component, Android 12+ background
start restrictions, manufacturer limitations), the alert handling would
crash. The alert sound might not play.

*Fix applied:* Each `startActivity()` is wrapped in a try-catch for
`Exception`. The catch block logs the error with context (locked/foreground/
overlay) and falls through to `playFile()` and the notification fallback.
The alert sound continues to play even if the Activity cannot start.

**Status: FIXED**

---

**H4. IMPORTANCE_HIGH overrides user notification preference** \
Origin: **This PR** \
File: `AlertPlayer.java:586-594`

The code upgraded the `BG_ALERT_CHANNEL` importance to `IMPORTANCE_HIGH`
on every alert. If a user manually set a lower importance, it was silently
overridden.

*Fix applied:* The upgrade only happens when `setFullScreenIntent` is set,
which requires either `override_silent_mode` or
`volume_button_snooze_wake_screen` to be enabled. Both settings represent
explicit user opt-in to interruptive alert behaviour. A `Log.ueh()` entry
is written when the upgrade occurs.

**Status: FIXED**

---

### Medium

**M1. buildSnoozeLine() does not check for stale BG reading** \
Origin: **This session** \
File: `Notifications.java:746`

`BgReading.last()` can return a reading from minutes or hours ago (sensor
stopped, no recent data). The threshold check compared against this stale
value, potentially hiding the snooze line based on outdated data.

*Fix applied:* The threshold comparison is skipped when the reading is
older than 15 minutes (`JoH.msSince(bgReading.timestamp) >= 15 min`).
With stale data the snooze line is always shown -- the 15-minute threshold
is consistent with stale data logic elsewhere in xDrip.

**Status: FIXED**

---

**M2. recheckAlerts() may run before remove_alert() database commit** \
Origin: **This session** \
File: `EditAlertActivity.java:579-584`

`recheckAlerts()` starts the Notifications IntentService asynchronously.
`remove_alert()` is a synchronous database delete on the UI thread.

*Assessment:* The ordering `stopAlert()` > `remove_alert()` > `recheckAlerts()`
is safe. `remove_alert()` is synchronous on the UI thread. `recheckAlerts()`
dispatches an Intent through the main Looper. The IntentService thread picks
it up only after the current UI method returns, by which time `remove_alert()`
has completed.

**Status: ACCEPTED** (no code change needed)

---

**M3. UserError.Log.ueh() performs database I/O on the UI thread** \
Origin: **This PR** (follows pre-existing pattern) \
File: `Home.java:3659, 3681, 3702`

`UserError.Log.ueh()` calls `new UserError(...).save()` -- a synchronous
database write on the UI thread from `onKeyDown()`. This follows the
established xDrip pattern used throughout the codebase. The write is a
single-row insert that completes in under 1 ms on modern devices.

**Status: SKIPPED** (follows xDrip convention; no user impact)

---

**M4. Lock screen flags persist after alert ends** \
Origin: **This PR** \
File: `SnoozeActivity.java:169, 189, 214-221, 382-394, 411`

`FLAG_SHOW_WHEN_LOCKED` and `FLAG_TURN_SCREEN_ON` were set in `onCreate()`
when an alert was active. If the alert ended while the Activity was still
visible, the flags remained. The Activity stayed above the lock screen until
the user dismissed it.

*Fix applied:* A `lockScreenFlagsSet` boolean tracks whether the flags were
set during `onCreate()`. Two cleanup paths:
1. `onResume()` -- if the alert ended while the Activity was in the
   background, `finish()` closes the Activity.
2. `displayStatus()` -- if the alert ends while the Activity is visible,
   `clearLockScreenFlags()` removes the flags (using `setShowWhenLocked(false)`
   on Android 8.1+ or `clearFlags()` as fallback).

The `lockScreenFlagsSet` guard ensures users who open SnoozeActivity from
the menu (without an active alert) are not affected.

**Status: FIXED**

---

**M5. Bitmap reuse with double bgOngoingNotification() call** \
Origin: **This session** \
File: `Notifications.java:321, 349`

The same `bgGraphBuilder` is passed to two `bgOngoingNotification()` calls.
Both post Runnables to the same Handler. The Handler executes FIFO, so the
first completes (and recycles its bitmaps) before the second starts. Safe
in practice, but the construction is fragile.

**Status: SKIPPED** (correct as-is; any refactoring risks introducing
concurrency issues)

---

**M6. First-press toast persists after second press in SnoozeActivity** \
Origin: **This session** \
File: `SnoozeActivity.java:482`

`doSnoozeFromVolumeButton()` used `JoH.static_toast_long()` which creates
a new toast without cancelling the previous one. After a double press, the
confirmation toast from the first press stayed visible while the success
toast queued behind it. The user saw stale guidance instead of immediate
confirmation.

*Fix applied:* Changed to `showVolumeButtonToast()` which calls
`volumeButtonToast.cancel()` before showing the new toast. The success
message now appears immediately after the second press.

**Status: FIXED**

---

**M7. Orphaned ActiveBgAlert blocks volume buttons after test alert** \
Origin: **This session** \
File: `Home.java:3655-3659, 3691-3695, 3728-3732`

After removing `ClearData()` from `alertTypegetOnly()` (fix #5 / H2), snoozed
test alerts leave an orphaned `ActiveBgAlert` in the database. The temporary
`AlertType` is not persisted, so `alertTypegetOnly()` returns `null`. When the
user later presses a volume button in `Home`, the code enters the snooze flow
instead of adjusting system volume, showing *"Press the volume button again to
snooze"* with no active alert sound.

*Fix applied:* Added orphan detection at the start of each volume button
handler (DOWN, UP, MUTE). When `is_snoozed` is `true` and
`alertTypegetOnly()` returns `null`, `ClearData()` removes the orphaned
record and `recheckAlerts()` rebuilds the notification to remove the stale
snooze line. The key event falls through to `super.onKeyDown()` for normal
volume control.

**Status: FIXED**

---

### Low

**L1. SimpleDateFormat timezone handling** \
Origin: **This session** \
File: `Notifications.java:755-756`

`next_alert_at` stores a UTC timestamp. `SimpleDateFormat("HH:mm")`
formats in the local timezone. Behaviour is correct -- the user sees the
local wake time.

**Status: NO ACTION NEEDED**

---

**L2. Three database queries in buildSnoozeLine()** \
Origin: **This session** \
File: `Notifications.java:741-745`

`getOnly()`, `alertTypegetOnly()`, and `BgReading.last()` are three queries
per notification rebuild. All are lightweight single-row queries. Performance
impact is negligible compared to the graph rendering elsewhere in the method.

**Status: NO ACTION NEEDED**

---

### Findings that are NOT a problem

| Claim | Assessment |
|---|---|
| `currentlySnoozed()` unsafe from IntentService thread | Safe -- ActiveAndroid DB access is thread-safe, `getOnly()` returns a new object per call |
| `is_snoozed` volatile visibility | Correct -- field is `volatile` and read via database, not in-memory cache |
| `staticUpdateNotification()` bypasses rate limit token | By design -- rate limit protects against cascading updates, not one-time user actions |
| `Create()` sets `last_alerted_at = 0L` with guard removed | By design -- BG threshold check replaced the `last_alerted_at > 0` guard |
| Mute rate limit blocks volume down/up | No issue -- volume down/up use independent timestamps, not the shared `"button-press"` key |

---

### Summary of safety review actions

| ID | Severity | Finding | Status |
|---|---|---|---|
| K1 | Critical | NPE in `snoozeForType()` | **Fixed** |
| K2 | Critical | Stale timestamp false double press | **Fixed** |
| H1 | High | Vehicle mode offset missing | **Fixed** |
| H2 | High | Misleading test alert message | **Fixed** |
| H3 | High | `startActivity()` without try-catch | **Fixed** |
| H4 | High | Channel importance override | **Fixed** |
| M1 | Medium | Stale BG reading in snooze line | **Fixed** |
| M2 | Medium | `recheckAlerts()` ordering | **Accepted** |
| M3 | Medium | `Log.ueh()` on UI thread | **Skipped** |
| M4 | Medium | Lock screen flags persist | **Fixed** |
| M5 | Medium | Bitmap reuse fragility | **Skipped** |
| M6 | Medium | First-press toast persists after second press | **Fixed** |
| M7 | Medium | Orphaned ActiveBgAlert blocks volume buttons | **Fixed** |
| L1 | Low | Timezone handling | No action needed |
| L2 | Low | Three DB queries | No action needed |

---

## Testing

### Re-tested from the PR of April 29, 2026

- [x] Double press volume down/up snoozes when alert is active in xDrip
- [x] Single press shows confirmation toast, does not snooze
- [x] Screen off + wake preference on: screen wakes, SnoozeActivity shown over lock screen, double press snoozes without unlock
- [x] Another app in foreground + "Display over other apps" granted: SnoozeActivity appears, previous app restored after snooze
- [x] Another app in foreground, permission not granted: heads-up notification shown as fallback
- [x] Volume buttons do not change system volume while an active alert is being handled
- [x] Volume buttons change system volume normally when no alert is active
- [X] Ongoing BG notification shows snooze line immediately after snoozing
- [x] Snooze line disappears when snooze expires or alert stops
- [x] No snooze line for `start_snoozed` or `PreSnooze()` (alarm never played)
- [x] < 2 minutes until re-rise: shows seconds, not "0 minutes left"
- [x] Test alert: SnoozeActivity shows "Test scenario passed", volume button snooze works
- [x] No behaviour change when `buttons_silence_alert` is disabled

### Volume button snooze -- core functionality

- [ ] Alert fires with screen on in xDrip: double pressing volume down snoozes
- [ ] Alert fires with screen on in xDrip: double pressing volume up snoozes
- [ ] Alert fires with screen on in xDrip: single press of mute snoozes (Home only)
- [ ] Alert fires with screen on in xDrip: single press shows confirmation toast, does not snooze
- [ ] Alert fires with screen on in xDrip: pressing a different button after first press does not snooze, shows "wrong button" toast
- [ ] Snooze time matches the alert's configured `default_snooze`
- [ ] No change in behaviour when `buttons_silence_alert` is disabled
- [ ] Volume buttons in Home change system volume normally when `buttons_silence_alert` is disabled or no alert is active
- [ ] Volume buttons in Home do NOT change system volume when an active alert is being handled

### Lock screen and overlay

- [ ] Alert fires with screen off + `override_silent_mode` on: screen wakes, SnoozeActivity shown over lock screen, double press snoozes without unlock
- [ ] Alert fires with screen off + `volume_button_snooze_wake_screen` on: screen wakes, SnoozeActivity shown over lock screen, double press snoozes without unlock
- [ ] Alert fires with screen on, phone unlocked, another app in foreground + `volume_button_snooze_wake_screen` on + "Display over other apps" granted: SnoozeActivity comes to the foreground directly, double press snoozes, previous app is restored afterwards
- [ ] Alert fires with screen on, phone unlocked + `volume_button_snooze_wake_screen` on, "Display over other apps" NOT granted: heads-up notification shown as fallback
- [ ] Tested on Android 14+: full screen intent fires correctly with `USE_FULL_SCREEN_INTENT` permission present
- [ ] `SnoozeActivity` opened manually from menu (no active alert): no lock screen flags set, Activity is not auto-closed

### Lock screen flag cleanup (M4)

- [ ] Alert ends while SnoozeActivity is in the background: returning to it auto-closes the Activity
- [ ] Alert ends while SnoozeActivity is visible: lock screen flags are cleared (Activity returns behind lock screen)
- [ ] After lock screen flags are cleared, SnoozeActivity shows "no active alert" and remains accessible (no crash)

### Snooze line in ongoing notification

- [ ] Snoozing from Home: ongoing BG notification shows snooze line shortly after snoozing
- [ ] Snoozing from SnoozeActivity: ongoing BG notification shows snooze line shortly after snoozing
- [ ] Snooze expires / alert stopped: snooze line disappears from the notification
- [ ] Alert configured while BG is already beyond threshold: no snooze line appears until the alarm has actually fired and been actively snoozed
- [ ] `start_snoozed` preference enabled: snooze line appears while BG exceeds the alert threshold
- [ ] `start_snoozed` preference enabled: snooze line disappears when BG returns within the threshold, even if snooze time has not expired
- [ ] `PreSnooze()` from alert edit screen: snooze line appears while BG exceeds the alert threshold
- [ ] `PreSnooze()`: snooze line disappears when BG returns within the threshold
- [ ] Vehicle mode active + low alert snoozed: snooze line threshold includes the 18 mg/dL offset
- [ ] Stale BG reading (> 15 min old): snooze line is always shown regardless of threshold

### Safety -- UUID-matched double press (K2)

- [ ] Alert changes between first and second press: treated as new first press, not a snooze
- [ ] Alert disappears between first and second press: no snooze occurs
- [ ] No active alert: volume button presses are ignored (SnoozeActivity) or pass through to system volume (Home)

### Safety -- NPE guard (K1)

- [ ] Disable all alerts while test alert is active: no crash
- [ ] Disable high/low alerts while test alert is active: no crash

### Test alert support

- [ ] Test alert (Settings > Alerts > Test alert): SnoozeActivity shows "Alert type not found", volume button double press stops the alert
- [ ] After snoozed test alert: pressing a volume button in Home clears orphaned ActiveBgAlert and adjusts system volume normally
- [ ] After snoozed test alert: snooze line in ongoing notification disappears on first volume button press in Home

### Toast behaviour

- [ ] Double press in SnoozeActivity: success toast replaces first-press toast immediately (no stacking)
- [ ] Double press in SnoozeActivity: only one toast visible at a time after second press

### Alert removal

- [ ] Snoozed alert removed via REMOVE ALERT: snooze line disappears from the ongoing notification immediately
- [ ] Actively playing alert removed via REMOVE ALERT: alert sound stops, snooze line removed
- [ ] A different alert is snoozed, user removes another alert: snoozed alert is not affected

### Display

- [ ] With < 2 minutes until re-rise: status shows seconds (e.g. "75 seconds left"), not "0 minutes left"

### Logging

- [ ] Snoozing from Home: `UserError` log contains button-specific snooze message
- [ ] Snoozing from SnoozeActivity: `UserError` log contains button-specific snooze message
- [ ] Snoozing from SnoozeActivity: toast shows button-specific message (e.g. "...volume DOWN...")
- [ ] Channel importance upgrade: `UserError` log contains "Upgrading BG alert channel importance to HIGH"

## Design consideration: separate wake-screen preference

The new `volume_button_snooze_wake_screen` preference is a separate opt-in
beneath `buttons_silence_alert`. There is a valid discussion about whether
this should be a separate setting or be implicit when `buttons_silence_alert`
is enabled.

### Arguments for merging (removing the separate setting)

1. **User expectation:** a user who enables "Buttons silence alarms" expects
   volume buttons to silence their alarm in every situation, including when the
   phone is locked. The most common use case -- phone on nightstand, screen off
   -- requires the second setting that many users will not find.
2. **False sense of safety:** a user may think they are covered and go to bed,
   only to discover that volume buttons do nothing when the screen is off.
4. **Cognitive load:** the distinction between "foreground" and "lock screen"
   is an Android implementation detail that users should not need to understand.
5. **Discovery:** the second option is a nested CheckBox. Users who do not
   scroll or read the summary text may never find it.
6. **Precedent:** alarm apps (Google Clock, Samsung Alarm) show over the lock
   screen automatically. No second setting is required.

### Arguments for keeping the separation

1. **Irreversible system side effect:** the setting triggers a permanent
   notification channel importance upgrade to `IMPORTANCE_HIGH`. Once applied,
   only the user can manually reset it in Android Settings.
2. **Lock screen privacy:** the snooze screen shows the alert name. Some users
   may not want diabetes-related information visible on their lock screen.
3. **Existing users:** `buttons_silence_alert` defaults to `true`. Merging
   would give all existing users wake-screen behaviour they never asked for.
4. **Redundancy with `override_silent_mode`:** users with `override_silent_mode`
   already get the wake-screen behaviour. Merging would force it on users who
   do not have that setting enabled.
5. **Permission requirements:** the overlay path requires `SYSTEM_ALERT_WINDOW`,
   a sensitive permission. Silently activating functionality that needs an extra
   permission leads to confusion when it does not work.
7. **Conservative approach for medical software:** explicit opt-in to aggressive
   system behaviour (waking screen, overriding channel importance, showing above
   lock screen) gives the user control and makes the app's actions predictable.

### Current decision

The settings are kept separate. The trade-off is between **safety through
simplicity** (merge: the user cannot misconfigure) and **safety through
control** (separate: the user chooses the level of system intervention
explicitly). Both positions are defensible.

## Full disclosure
This pull request is accelerated using Claude Code (model Opus 4.6 with maximum effort).