### PR TITLE
Daily job even on mobile

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/jobs/DailyJob.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/jobs/DailyJob.java
@@ -27,7 +27,9 @@ public class DailyJob extends Job {
     protected Result onRunJob(@NonNull Job.Params params) {
         final long startTime = JoH.tsl();
         DailyIntentService.work();
-        UserError.Log.uel(TAG, JoH.dateTimeText(JoH.tsl()) + " Job Ran - finished, duration: " + JoH.niceTimeScalar(JoH.msSince(startTime)));
+        final String cellService = !JoH.isLANConnected()? " (mobile)" : "";
+        UserError.Log.uel(TAG, JoH.dateTimeText(JoH.tsl()) + " Job Ran" + cellService + ", duration: " + JoH.niceTimeScalar(JoH.msSince(startTime)));
+
         return Result.SUCCESS;
     }
 
@@ -39,7 +41,7 @@ public class DailyJob extends Job {
                     .setRequiresDeviceIdle(true)
 //                    .setRequiresCharging(true) // If the battery level is not low, we should run even if it is not being charged.
                     .setRequiresBatteryNotLow(true)
-                    .setRequiredNetworkType(JobRequest.NetworkType.UNMETERED)
+                    .setRequiredNetworkType(JobRequest.NetworkType.CONNECTED)
                     .setUpdateCurrent(true)
                     .build()
                     .schedule();


### PR DESCRIPTION
xDrip will never run the daily job for someone who never uses WiFi.  
This results in the Google Drive automated daily backup never running.  
This was reported on facebook.  I asked them to post in our discussions for reference:
https://github.com/NightscoutFoundation/xDrip/discussions/4502 

I don't think this is right.  If someone does not want to upload using mobile, they can control that on the Nightscout settings page or on the Google Drive backup settings page.
I don't think daily job should impose such a limitation.  

This PR changes xDrip's behavior such that the daily job is run as long as there is connectivity to the internet even if it is through cell service and not WiFi.

I am currently using this.  I disabled WiFi on my phone last night after having installed this PR.  The following shows the logs and the log associated with the daily job that highlights that it ran while using mobile data.

<img width="324" height="720" alt="Screenshot_20260430-093121" src="https://github.com/user-attachments/assets/e7254834-a6e1-4257-be2d-6e74241a7909" />  
  
Please ignore the previous logs showing mobile that are related to a previous design I decided to change.  
I wanted to give priority to WiFi.  But, that became too complicated.  I don't see a reason to give priority to WiFi.  The user has full control over limiting uploads to WiFi already.  
Only the log dated April 30 is related to this PR.  

What do you think?