### PR TITLE
Nightscout follower backfill for a 1-minute sample period

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
@@ -10,6 +10,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.messages.Entry;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.utils.NightscoutUrl;
 import com.eveningoutpost.dexdrip.evaluators.MissedReadingsEstimator;
+import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.utils.framework.RetrofitService;
 
 import java.util.List;
@@ -22,7 +23,6 @@ import retrofit2.http.Headers;
 import retrofit2.http.Query;
 
 import static com.eveningoutpost.dexdrip.models.JoH.emptyString;
-import static com.eveningoutpost.dexdrip.utilitymodels.BgGraphBuilder.DEXCOM_PERIOD;
 import static com.eveningoutpost.dexdrip.cgm.nsfollow.NightscoutFollowService.msg;
 
 /**
@@ -95,7 +95,7 @@ public class NightscoutFollow {
 
         if (!emptyString(urlString)) {
             try {
-                int count = Math.min(MissedReadingsEstimator.estimate() + 1, (int) (Constants.DAY_IN_MS / DEXCOM_PERIOD));
+                int count = Math.min(MissedReadingsEstimator.estimate() + 1, (int) (Constants.DAY_IN_MS / DexCollectionType.getCurrentSamplePeriod()));
                 UserError.Log.d(TAG, "Estimating missed readings as: " + count);
                 count = Math.max(10, count); // pep up with a view to potential period mismatches - might be excessive
                 getService().getEntries(session.url.getHashedSecret(), count, JoH.tsl() + "").enqueue(session.entriesCallback);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/evaluators/MissedReadingsEstimator.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/evaluators/MissedReadingsEstimator.java
@@ -5,8 +5,7 @@ package com.eveningoutpost.dexdrip.evaluators;
 import com.eveningoutpost.dexdrip.models.BgReading;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
-
-import static com.eveningoutpost.dexdrip.utilitymodels.BgGraphBuilder.DEXCOM_PERIOD;
+import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 
 public class MissedReadingsEstimator {
 
@@ -14,7 +13,7 @@ public class MissedReadingsEstimator {
 
         final BgReading bgReading = BgReading.last();
         final long since = bgReading != null ? JoH.msSince(bgReading.timestamp) : Constants.DAY_IN_MS;
-        return (int) (since / DEXCOM_PERIOD);
+        return (int) (since / DexCollectionType.getCurrentSamplePeriod());
     }
 
 }


### PR DESCRIPTION
This PR affects the backfill request behavior of the Nightscout follower.
If the sample period is set to 1 minute, the backfill request requests for more samples respectively.
The problem this PR addresses is explained here: https://github.com/NightscoutFoundation/xDrip/discussions/4515