### PR TITLE
AAPS basal rate fix

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
@@ -139,7 +139,7 @@ public class ExternalStatusService extends IntentService {
 
     public static String getAbsoluteBR(final String statusLine) {
         if (JoH.emptyString(statusLine)) return "";
-        val pattern = Pattern.compile(".*(^|[^0-9.,])([0-9.,]+U/h)", Pattern.DOTALL); // match last of any number followed by units per hour
+        val pattern = Pattern.compile(".*(^|[^0-9.,])([0-9.,]+ ?U/h)", Pattern.DOTALL); // match last of any number followed by units per hour
         val matcher = pattern.matcher(statusLine);
         val matches = matcher.find();       // was at least one found?
 
@@ -190,7 +190,7 @@ public class ExternalStatusService extends IntentService {
 
     public static Double getAbsoluteBRDouble() {
         try {
-            return JoH.tolerantParseDouble(getAbsoluteBR().replace("U/h", ""));
+            return JoH.tolerantParseDouble(getAbsoluteBR().replace(" U/h", "").replace("U/h", ""));
         } catch (NullPointerException | NumberFormatException e) {
             return null;
         }


### PR DESCRIPTION
Trim space before U/h from AAPS external status line to allow correct basal display.
Space seems to always have been there, so I don't know why this happened.
This PR should allow both versions to be parsed: with and without space.