### PR TITLE
Language submenu

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -1138,6 +1138,8 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             units_pref = findPreference("units");
             bindPreferenceSummaryToValue(units_pref);
 
+            addPreferencesFromResource(R.xml.pref_language);
+
             addPreferencesFromResource(R.xml.pref_notifications);
             bindPreferenceSummaryToValue(findPreference("bg_alert_profile"));
             bindPreferenceSummaryToValue(findPreference("calibration_notification_sound"));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -863,6 +863,7 @@
     <string name="using_local_language">Currently using your device\'s local language</string>
     <string name="forcing_alternate_language">Currently forcing use of alternate language</string>
     <string name="need_alternate_language">If you need an alternate language translation within xDrip+</string>
+    <string name="language">Language</string>
     <string name="chosse_language">Choose a specific language</string>
     <string name="widget_range_lines">Widget Range Lines</string>
     <string name="show_range_on_widget">Show a high and low line on the widget.</string>

--- a/app/src/main/res/xml/pref_language.xml
+++ b/app/src/main/res/xml/pref_language.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceScreen
+        android:key="language_settings_screen"
+        android:title="@string/language">
+        <PreferenceCategory
+            android:title="@string/language"
+            android:key="language_category">
+            <SwitchPreference
+                android:defaultValue="false"
+                android:key="force_english"
+                android:summary="@string/using_local_language"
+                android:summaryOn="@string/forcing_alternate_language"
+                android:switchTextOff="@string/short_off_text_for_switches"
+                android:switchTextOn="@string/short_on_text_for_switches"
+                android:title="@string/force_english_text" />
+            <ListPreference
+                android:defaultValue="en"
+                android:entries="@array/LocaleChoices"
+                android:entryValues="@array/LocaleChoicesValues"
+                android:key="forced_language"
+                android:summary="@string/need_alternate_language"
+                android:title="@string/chosse_language" />
+        </PreferenceCategory>
+    </PreferenceScreen>
+</PreferenceScreen>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -368,22 +368,6 @@
             </PreferenceScreen>
 
             <SwitchPreference
-                android:defaultValue="false"
-                android:key="force_english"
-                android:summary="@string/using_local_language"
-                android:summaryOn="@string/forcing_alternate_language"
-                android:switchTextOff="@string/short_off_text_for_switches"
-                android:switchTextOn="@string/short_on_text_for_switches"
-                android:title="@string/force_english_text" />
-            <ListPreference
-                android:defaultValue="en"
-                android:entries="@array/LocaleChoices"
-                android:entryValues="@array/LocaleChoicesValues"
-                android:key="forced_language"
-                android:summary="@string/need_alternate_language"
-                android:title="@string/chosse_language" />
-
-            <SwitchPreference
                 android:defaultValue="true"
                 android:key="bg_compensate_noise"
                 android:summary="@string/try_to_work_around_noisy_readings"


### PR DESCRIPTION
This PR adds a new item "Language" to the main settings page between "Glucose units" and "Alarms and alerts".

Currently, language settings are located under the "Display" menu.
But, language is a more general factor with respect to display.
I have found myself looking through the menus looking for language at times.
I believe the top level of the settings is more suited for the setting.

Since there are currently two different settings related to language, this PR moves them both under the new "Language" setting.  It removes those two settings from the display menu.  

I am currently running this and see no issues.  

| Before | After |  
| ------- | ------ |  
| <img width="269" height="314" alt="Screenshot_20260510-112653" src="https://github.com/user-attachments/assets/4ab598b5-4a8a-4405-b1c0-fd51e152f8d5" /> | <img width="269" height="336" alt="Screenshot_20260510-112037" src="https://github.com/user-attachments/assets/25f2710b-4629-4e78-80d4-4b5258994433" /> |  
| | <img width="269" height="289" alt="Screenshot_20260510-112120" src="https://github.com/user-attachments/assets/cf213487-2bc7-4841-9560-bd34a21aa016" /> |  
| <img width="269" height="309" alt="Screenshot_20260510-112925" src="https://github.com/user-attachments/assets/80fcce07-8e12-4753-abbe-43f9f30760b6" />  | <img width="269" height="333" alt="Screenshot_20260510-112100" src="https://github.com/user-attachments/assets/ef6c9e94-7e27-4a2a-add7-6419a895094f" /> |  
