### PR TITLE
Dynamic api version check

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,7 @@ android {
         minSdkVersion 24
         // increasing target SDK version can cause compatibility issues with Android 7+
         //noinspection ExpiredTargetSdkVersion
+        buildConfigField "int", "minSDK", minSdkVersion.mApiLevel.toString()
         targetSdkVersion 24
         // change versionCode only when downgrade should be prevented
         // eg, when data structures are incompatible

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -364,9 +364,22 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
             }
         }
 
-        if (Build.VERSION.SDK_INT < 17) {
-            JoH.static_toast_long(gs(R.string.xdrip_will_not_work_below_android_version_42));
-            finish();
+        if (Build.VERSION.SDK_INT < BuildConfig.minSDK) {
+            final String message = gs(R.string.xdrip_requires_newer_android);
+            try {
+                new AlertDialog.Builder(this)
+                        .setTitle(R.string.app_name)
+                        .setMessage(message)
+                        .setCancelable(false) // Prevents clicking outside the dialog to dismiss
+                        .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                            finish(); // Closes the activity after OK
+                        })
+                        .show();
+            } catch (Exception e) {
+                JoH.static_toast_long(message);
+                finish(); // Closes the activity if the dialog can't show
+            }
+            return; // CRITICAL: Stops the rest of onCreate() from running
         }
 
         xdrip.checkForcedEnglish(Home.this);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1677,6 +1677,7 @@
     <string name="unusual_internal_context_problem__please_report">Unusual internal context problem - please report</string>
     <string name="cannot_start__please_report_context_problem">Cannot start - please report context problem</string>
     <string name="xdrip_will_not_work_below_android_version_42">xDrip+ will not work below Android version 4.2</string>
+    <string name="xdrip_requires_newer_android">xDrip requires a newer version of Android to run.</string>
     <string name="xdrip_oop2_not_installed">xDrip+ needs OOP2 to handle Libre2/LibreUS sensors.</string>
     <string name="this_app_needs_battery_optimization_whitelisting_or_it_will_not_work_well_please_reset_app_preferences">This app needs battery optimization whitelisting or it will not work well. Please reset app preferences</string>
     <string name="setting_disabled_">Setting disabled :)</string>


### PR DESCRIPTION
This is what we currently have in Home.java:

        if (Build.VERSION.SDK_INT < 17) {
            JoH.static_toast_long(gs(R.string.xdrip_will_not_work_below_android_version_42));
            finish();
        }
        
And the corresponding string is this:
xDrip+ will not work below Android version 4.2

We have not updated either the comparator in Home or the corresponding string since we have raised minSDK.

This PR makes several changes:
1-The comparison is now dynamic.  As we raise minSDK, It will automatically point to the updated minSDK.  Therefore, there will be nothing to forget in that respect.
2- The corresponding string is more general not identifying any particular Android version.  Again, there will be no need to update it when/if we raise minSDK.
3- Instead of a toast message, we will show a dialog, which will stay on the screen until the user acknowledges it.
4- If the dialog fails to show, we will only then show a toast message.
5- After showing the dialog or the toast, the code will terminate instead of continuing to run.  There is no reason to continue to run considering we cannot test xDrip on older versions of Android.