### PR TITLE
mg/dL to mmol/L conversion factor

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
@@ -4,7 +4,10 @@ package com.eveningoutpost.dexdrip.utilitymodels;
  * Various constants
  */
 public class Constants {
-    public static final double MMOLL_TO_MGDL = 18.0182;
+    // Molar mass of glucose (C6H12O6) = 180.1559 g/mol
+    // Source: NIST Chemistry WebBook, SRD 69 (https://webbook.nist.gov/cgi/cbook.cgi?ID=C50997)
+    // Conversion factor: 1 mmol/L = 18.01559 mg/dL
+    public static final double MMOLL_TO_MGDL = 18.01559; //
     public static final double MGDL_TO_MMOLL = 1 / MMOLL_TO_MGDL;
 
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/UnitizedTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/UnitizedTest.java
@@ -8,11 +8,11 @@ public class UnitizedTest {
 
     @Test
     public void mmolConvertTest() {
-        assertWithMessage("to mmol").that(Unitized.mmolConvert(99.1)).isWithin(0.001).of(5.5);
+        assertWithMessage("to mmol").that(Unitized.mmolConvert(99.086)).isWithin(0.001).of(5.5);
     }
 
     @Test
     public void mgdlConvertTest() {
-        assertWithMessage("to mgdl").that(Unitized.mgdlConvert(5.5)).isWithin(0.001).of(99.1);
+        assertWithMessage("to mgdl").that(Unitized.mgdlConvert(5.5)).isWithin(0.001).of(99.086);
     }
 }


### PR DESCRIPTION
This PR changes the conversion factor (18.0182) to a more accurate value (18.01559).
The rounding error imposed for showing a value in mmol/L could be significantly greater than the error caused by this minor imperfection.     The absolute error due to this is not the reason for this PR.  The reason is to address a discrepancy between xDrip and Nightscout.

Nightscout (cgm-remote-monitor) was modified in 2021 to use a more accurate conversion factor (18.01559).  xDrip still uses a less accurate value (18.0182).
For two particular values (100 mg/dL and 109 mg/dL), the conversion done by xDrip and Nightscout result in different values.
xDrip shows 5.5 mmol/L while Nightscout shows 5.6 mmol/L for 100 mg/dL.
xDrip shows 6 mmol/L while Nightscout shows 6.1 mmol/L for 109 mg/dL.

Considering the extremely small difference between the two conversion constants, it may seem surprising for this discrepancy.  The discrepancy is caused because the rounded values (after conversion by the two different constants) end up in two different adjacent rounding bins as demonstrated below.

100 / 18.0182 = 5.5499 ~ 5.5
100 / 18.01559 = 5.5507 ~ 5.6

109 / 18.0182 = 6.0494 ~ 6.0
109 / 18.01559 = 6.0503 ~ 6.1  

The following image shows a screenshot of a Nightscout server.
<img width="576" height="385" alt="Screenshot 2026-05-20 000354" src="https://github.com/user-attachments/assets/b2567334-ab22-4248-95a1-126872fac822" />


The following photo shows two xDrip following this same server.  The one on the left is our latest Nightly (2026.05.06).  The one on the right is this PR added to our latest Nightly.
<img width="580" height="573" alt="PXL_20260520_040415438" src="https://github.com/user-attachments/assets/fd6ea0ea-d663-4ec4-8fe2-78b2f62baae9" />

This same difference will appear if a user looks at their Nightscout and xDrip that uploads to it.  The discrepancy only appears if the value in mg/dL is 100 or 109.  
This PR removes the discrepancy.  So, xDrip and Nighscout will show the same values regardless of what the value may be.
