### PR TITLE
Fix/preserve sensor row on stale stop ack

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -1988,6 +1988,15 @@ public class Ob1G5CollectionService extends G5BaseService {
 
 
         if (!is_started && was_started) {
+            // A SessionStartTxMessage queued at the moment a stopped-state calibration
+            // is processed means xDrip has already moved on to a new sensor session
+            // locally - whether the Start was queued behind a still-pending Stop, or in
+            // the gap between the connection that delivered the Stop and the one now
+            // reading the transmitter's resulting Stopped state. Either way, the stop
+            // ack we are now processing applies to the prior session, so do not clear
+            // the newly-created Sensor row or emit duplicate stop notifications or
+            // treatments.
+            final boolean staleStopAck = pendingStart();
             if (Sensor.isActive()) {
                 if (Pref.getBooleanDefaultFalse("ob1_g5_restart_sensor")) {
                     if (state.ended()) {
@@ -2000,15 +2009,21 @@ public class Ob1G5CollectionService extends G5BaseService {
                     final PendingIntent pi = PendingIntent.getActivity(xdrip.getAppContext(), G5_SENSOR_RESTARTED, JoH.getStartActivityIntent(Home.class), PendingIntent.FLAG_UPDATE_CURRENT);
                     JoH.showNotification("Auto Start", "Sensor Requesting Restart", pi, G5_SENSOR_RESTARTED, true, true, false);
                     UserError.Log.uel(TAG, "Sensor Requesting Restart");
+                } else if (staleStopAck) {
+                    UserError.Log.uel(TAG, "Ignoring stale stop ack: a Start is already queued for the next sensor session");
                 } else {
                     UserError.Log.uel(TAG, "Marking sensor session as stopped");
                     Sensor.stopSensor();
                 }
             }
-            final PendingIntent pi = PendingIntent.getActivity(xdrip.getAppContext(), G5_SENSOR_STARTED, JoH.getStartActivityIntent(Home.class), PendingIntent.FLAG_UPDATE_CURRENT);
-            JoH.showNotification(state.getText(), "Sensor Stopped", pi, G5_SENSOR_STARTED, true, true, false);
-            UserError.Log.ueh(TAG, "Native Sensor is now Stopped: " + state.getExtendedText());
-            Treatments.sensorStop(null, "Stopped by transmitter: " + state.getExtendedText());
+            if (!staleStopAck) {
+                final PendingIntent pi = PendingIntent.getActivity(xdrip.getAppContext(), G5_SENSOR_STARTED, JoH.getStartActivityIntent(Home.class), PendingIntent.FLAG_UPDATE_CURRENT);
+                JoH.showNotification(state.getText(), "Sensor Stopped", pi, G5_SENSOR_STARTED, true, true, false);
+                UserError.Log.ueh(TAG, "Native Sensor is now Stopped: " + state.getExtendedText());
+                Treatments.sensorStop(null, "Stopped by transmitter: " + state.getExtendedText());
+            } else {
+                UserError.Log.ueh(TAG, "Suppressing duplicate stop notification: transmitter stop ack belongs to a session already replaced in xDrip");
+            }
         } else if (is_started && !was_started) {
             JoH.cancelNotification(G5_SENSOR_STARTED);
             UserError.Log.ueh(TAG, "Native Sensor is now Started: " + state.getExtendedText());


### PR DESCRIPTION
This patch fixes the following issue (discussed in https://github.com/NightscoutFoundation/xDrip/discussions/4542):

1. User stops the current sensor session in xDrip. xDrip queues a SessionStopTxMessage. No BLE traffic has happened yet; the command sits in the queue waiting for the  next connection.
2. User starts a new sensor session in xDrip. Sensor.create() closes the previous local Sensors row and inserts a brand-new active row pointing at the new session. xDrip queues a SessionStartTxMessage. At this moment xDrip's local state already considers the new session active.
3. The transmitter eventually receives the queued Stop and ACKs it. Its on-board calibration state moves to Stopped.
4. On a subsequent BLE connection, xDrip reads glucose and gets a calibration state of Stopped. processCalibrationState(Stopped) enters the !is_started && was_started branch.
5. That branch calls Sensor.stopSensor() against Sensor.currentSensor() - which is the row the user just created in step 2. The new local row gets stopped_at set. The transmitter session is unaffected and continues to warm up.

Result: xDrip's local database no longer has an active Sensors row. The main screen reverts to "Please start sensor," nothing is broadcast, no BG values are processed -- even though the transmitter is healthy. The detailed G6 view stays correct because Ob1G5StateMachine tracks the physical session separately from the local table.

The patch fixes step 5: when pendingStart() is true at the moment of step 4, we know the row about to be killed is the new session, not the prior one the transmitter is confirming stopped. So we skip the Sensor.stopSensor() call (and the duplicate notification/treatment) and let the new row stand.

This issue was also described in https://github.com/NightscoutFoundation/xDrip/issues/1632 previously.