### PR TITLE
Language submenu

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -859,6 +859,7 @@
     <string name="use_flair_colors">Custom Title/Nav Bar</string>
     <string name="upper_title_bar_flair">Upper Title Bar</string>
     <string name="lower_button_bar_falir">Lower Navigation Bar</string>
+    <string name="title_language">Language</string>
     <string name="force_english_text">Force English Text</string>
     <string name="using_local_language">Currently using your device\'s local language</string>
     <string name="forcing_alternate_language">Currently forcing use of alternate language</string>

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -367,21 +367,25 @@
                     android:title="@string/title_enlarge_fonts_on_large_screens" />
             </PreferenceScreen>
 
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="force_english"
-                android:summary="@string/using_local_language"
-                android:summaryOn="@string/forcing_alternate_language"
-                android:switchTextOff="@string/short_off_text_for_switches"
-                android:switchTextOn="@string/short_on_text_for_switches"
-                android:title="@string/force_english_text" />
-            <ListPreference
-                android:defaultValue="en"
-                android:entries="@array/LocaleChoices"
-                android:entryValues="@array/LocaleChoicesValues"
-                android:key="forced_language"
-                android:summary="@string/need_alternate_language"
-                android:title="@string/chosse_language" />
+            <PreferenceScreen
+                android:key="xdrip_language_settings"
+                android:title="@string/title_language">
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:key="force_english"
+                    android:summary="@string/using_local_language"
+                    android:summaryOn="@string/forcing_alternate_language"
+                    android:switchTextOff="@string/short_off_text_for_switches"
+                    android:switchTextOn="@string/short_on_text_for_switches"
+                    android:title="@string/force_english_text" />
+                <ListPreference
+                    android:defaultValue="en"
+                    android:entries="@array/LocaleChoices"
+                    android:entryValues="@array/LocaleChoicesValues"
+                    android:key="forced_language"
+                    android:summary="@string/need_alternate_language"
+                    android:title="@string/chosse_language" />
+            </PreferenceScreen>
 
             <SwitchPreference
                 android:defaultValue="true"


### PR DESCRIPTION
I don't believe language is a display setting.
This PR was rejected: https://github.com/NightscoutFoundation/xDrip/pull/4524 

Considering that, the next best thing is to create a submenu for language settings on the display page.  That's what this PR does.

| Before | After |  
| ------- | ------ |  
| <img width="270" height="600" alt="Screenshot_20260608-105132" src="https://github.com/user-attachments/assets/b5976535-8838-4caf-a876-a846302649cd" /> | <img width="270" height="600" alt="Screenshot_20260608-110825" src="https://github.com/user-attachments/assets/7c92340c-8891-4922-8c06-7d3fd70ccfd4" /> |  
| | <img width="270" height="600" alt="Screenshot_20260608-110844" src="https://github.com/user-attachments/assets/7aae6665-9559-44f6-8717-def9d6e05282" /> |  
