### PR TITLE
Companion: add SiSensing Eco

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
@@ -300,6 +300,7 @@ public class UiBasedCollector extends NotificationListenerService {
                 .replace("\u00a0", " ")
                 .replace("\u2060", "")
                 .replace("\\", "/")
+                .replace("当前血糖:", "")
                 .replace("mmol/L", "")
                 .replace("mmol/l", "")
                 .replace("mg/dL", "")

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
@@ -108,6 +108,7 @@ public class UiBasedCollector extends NotificationListenerService {
         coOptedPackages.add("com.microtech.aidexx.smart.mmoll"); //for microtech Brazil version
         coOptedPackages.add("com.ottai.seas");
         coOptedPackages.add("com.microtech.aidexx"); //for microtech china version
+        coOptedPackages.add("com.sisensing.eco"); //for SiSensing Eco China version
         coOptedPackages.add("com.ottai.tag"); // //for ottai china version
         coOptedPackages.add("com.senseonics.eversense365.us");
         coOptedPackages.add("com.kakaohealthcare.pasta"); // A Health app for sensors that we already collect from
@@ -131,6 +132,7 @@ public class UiBasedCollector extends NotificationListenerService {
         coOptedPackagesAll.add("com.microtech.aidexx.smart.mmoll"); //for microtech Brazil version
         coOptedPackagesAll.add("com.ottai.seas");
         coOptedPackagesAll.add("com.microtech.aidexx"); //for microtech china version
+        coOptedPackagesAll.add("com.sisensing.eco"); //for SiSensing Eco China version
         coOptedPackagesAll.add("com.ottai.tag"); // //for ottai china version
         coOptedPackagesAll.add("com.senseonics.eversense365.us");
         coOptedPackagesAll.add("com.kakaohealthcare.pasta"); // Experiment


### PR DESCRIPTION
## Summary

Add support for the SiSensing Eco China companion app package in `UiBasedCollector`.

Package added:
- `com.sisensing.eco`

## Info

`SiSensing Eco`(硅基轻享) is a sub-brand of `SiSensing` in China, primarily supporting the split-type Sibionics `GS1-P2` CGM.

<img width="320" height="320" alt="image" src="https://github.com/user-attachments/assets/8a0b43a6-b888-4c60-af73-fcf161728c05" />

Notification Appearance:

<img width="320" height="83" alt="telegram-cloud-photo-size-5-6143024331596959794-w" src="https://github.com/user-attachments/assets/c0f654de-1a95-4fb7-842e-25e7b31865dd" />
