### PR TITLE
add glucose offset calibration

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
@@ -258,6 +258,9 @@ public class BestGlucose {
             warning_level = 2;
         }
 
+        // offset calibration: shift the displayed value here (after delta/slope are computed). No-op when unset.
+        estimate = BgReading.applyGlucoseOffset(estimate);
+
         dg.unitized_value = BgGraphBuilder.unitized(estimate, doMgdl);
         final String stringEstimate = BgGraphBuilder.unitized_string(estimate, doMgdl);
         if ((lastBgReading.hide_slope) || (bg_from_filtered)) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -3131,6 +3131,8 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
                 String stringEstimate = bgGraphBuilder.unitized_string(estimate);
                 currentBgValueText.setText(stringEstimate + (itr == null ? " " + BgReading.activeSlopeArrow() : ""));
             }
+            // offset calibration active: warn that the shown value is shifted
+            if (extrastring.isEmpty() && BgReading.getGlucoseOffsetMgdl() != 0) extrastring = "⚠";
             if (extrastring.length() > 0)
                 currentBgValueText.setText(extrastring + currentBgValueText.getText());
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
@@ -659,6 +659,22 @@ public class BgReading extends Model implements ShareUploadableBg {
         Log.i(TAG, "NEW VALUE CALCULATED AT: " + bgReading.calculated_value);
     }
 
+    // user configurable glucose offset ("offset calibration"), entered in display units, returned as mg/dl
+    public static final String GLUCOSE_OFFSET_PREF = "bg_glucose_offset";
+
+    public static double getGlucoseOffsetMgdl() {
+        final double offset = Pref.getStringToDouble(GLUCOSE_OFFSET_PREF, 0d);
+        if (offset == 0) return 0d;
+        return Pref.getString("units", "mgdl").equals("mgdl") ? offset : offset * Constants.MMOLL_TO_MGDL;
+    }
+
+    public static double applyGlucoseOffset(final double mgdl) {
+        final double offset = getGlucoseOffsetMgdl();
+        if (offset == 0) return mgdl;
+        if (mgdl <= BG_READING_ERROR_VALUE) return mgdl; // leave error / placeholder markers unchanged
+        return mgdl + offset;
+    }
+
     public static void pushBgReadingSyncToWatch(BgReading bgReading, boolean is_new) {
         Log.d(TAG, "pushTreatmentSyncToWatch Add treatment to UploaderQueue.");
         if (Pref.getBooleanDefaultFalse("wear_sync")) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -316,7 +316,7 @@ public class BgGraphBuilder {
             String collector = getDexCollectionType().toString(); // Identify which collector is being used
 
             for (BgReading r : recent) { // Process each reading in the Look-back period
-                double valueY = unitized(r.calculated_value); // Reading value
+                double valueY = unitized(BgReading.applyGlucoseOffset(r.calculated_value)); // Reading value (incl. offset calibration)
                 if (Double.isNaN(valueY)) { // Skip invalid readings
                     UserError.Log.e(TAG, "NaN detected. Collector = " + collector + ",  Raw = " + r.raw_data);
                     continue;
@@ -1334,6 +1334,7 @@ public class BgGraphBuilder {
                 plugin_adjusted = true; // plugin will be adjusting data
             }
 
+            final double offsetMgdl = BgReading.getGlucoseOffsetMgdl(); // offset calibration, applied to visible plot below
             for (final BgReading bgReading : bgReadings) {
                 // jamorham special
 
@@ -1368,11 +1369,17 @@ public class BgGraphBuilder {
                     bgReading.filtered_calculated_value = plugin.getGlucoseFromFilteredBgReading(bgReading, cd);
                 }
 
+                // shifted values for the visible plot; the noise estimate below stays raw (it is re-offset in getDisplayGlucose)
+                final double dv = (offsetMgdl != 0 && bgReading.calculated_value > BgReading.BG_READING_ERROR_VALUE)
+                        ? bgReading.calculated_value + offsetMgdl : bgReading.calculated_value;
+                final double dfv = (offsetMgdl != 0 && bgReading.filtered_calculated_value > BgReading.BG_READING_ERROR_VALUE)
+                        ? bgReading.filtered_calculated_value + offsetMgdl : bgReading.filtered_calculated_value;
+
                 if ((show_filtered) && (bgReading.filtered_calculated_value > 0) && (bgReading.filtered_calculated_value != bgReading.calculated_value)) {
-                    filteredValues.add(new HPointValue((double) ((bgReading.timestamp - timeshift) / FUZZER), (float) unitized(Math.min(bgReading.filtered_calculated_value, BgReading.BG_READING_MAXIMUM_VALUE))));
+                    filteredValues.add(new HPointValue((double) ((bgReading.timestamp - timeshift) / FUZZER), (float) unitized(Math.min(dfv, BgReading.BG_READING_MAXIMUM_VALUE))));
                 } else if (show_pseudo_filtered) {
                     // TODO differentiate between filtered and pseudo-filtered when both may be in play at different times
-                    final double rollingValue = rollingAverage.put(bgReading.calculated_value);
+                    final double rollingValue = rollingAverage.put(dv);
                     if (rollingAverage.reachedPeak()) {
                         filteredValues.add(new HPointValue((double) ((bgReading.timestamp + rollingOffset) / FUZZER), (float) unitized(Math.min(rollingValue, BgReading.BG_READING_MAXIMUM_VALUE))));
                     }
@@ -1384,18 +1391,18 @@ public class BgGraphBuilder {
                     pluginValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(Math.min(plugin.getGlucoseFromBgReading(bgReading, cd), BgReading.BG_READING_MAXIMUM_VALUE))));
                 }
                 if (bgReading.ignoreForStats) {
-                    if (unitized(bgReading.calculated_value) <= defaultMaxY) { // Don't display value marked as bad if greater than the default Max (defaultMaxY)
-                        badValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
+                    if (unitized(dv) <= defaultMaxY) { // Don't display value marked as bad if greater than the default Max (defaultMaxY)
+                        badValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(dv)));
                     }
-                } else if (bgReading.calculated_value >= BgReading.BG_READING_MAXIMUM_VALUE) {
+                } else if (dv >= BgReading.BG_READING_MAXIMUM_VALUE) {
                     highValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(BgReading.BG_READING_MAXIMUM_VALUE)));
-                } else if (unitized(bgReading.calculated_value) >= highMark) {
-                    highValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
-                } else if (unitized(bgReading.calculated_value) >= lowMark) {
-                    val ppx = new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value));
+                } else if (unitized(dv) >= highMark) {
+                    highValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(dv)));
+                } else if (unitized(dv) >= lowMark) {
+                    val ppx = new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(dv));
                     inRangeValues.add(ppx);
-                } else if (bgReading.calculated_value >= 40) {
-                    lowValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
+                } else if (dv >= 40) {
+                    lowValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(dv)));
                 } else if (bgReading.calculated_value > 13) {
                     lowValues.add(new HPointValue((double) (bgReading.timestamp / FUZZER), (float) unitized(40)));
                 }
@@ -1408,10 +1415,10 @@ public class BgGraphBuilder {
                 }
 
                 avg2counter++;
-                avg2value += bgReading.calculated_value;
+                avg2value += dv;
                 if (bgReading.timestamp > avg1start) {
                     avg1counter++;
-                    avg1value += bgReading.calculated_value;
+                    avg1value += dv;
                 }
 
                 // noise calculator
@@ -1447,11 +1454,11 @@ public class BgGraphBuilder {
                 if (!simple && (bgReading.timestamp > trendstart) && (bgReading.timestamp > last_calibration)) {
                     if (has_filtered && (bgReading.filtered_calculated_value > 0) && (bgReading.filtered_calculated_value != bgReading.calculated_value)) {
                         polyxList.add((double) bgReading.timestamp - timeshift);
-                        polyyList.add(unitized(bgReading.filtered_calculated_value));
+                        polyyList.add(unitized(dfv));
                     }
                     if (bgReading.calculated_value > 0) {
                         polyxList.add((double) bgReading.timestamp);
-                        polyyList.add(unitized(bgReading.calculated_value));
+                        polyyList.add(unitized(dv));
                     }
                     if (d)
                         Log.d(TAG, "poly Added: " + JoH.qs(polyxList.get(polyxList.size() - 1)) + " / " + JoH.qs(polyyList.get(polyyList.size() - 1), 2));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1775,6 +1775,8 @@
     <string name="title_accept_broadcast_snooze">Accept Local Broadcast</string>
     <string name="title_bg_compensate_noise">\u26A0 Smooth sensor noise</string>
     <string name="title_bg_compensate_noise_ultrasensitive">\u26A0 Smooth sensor noise ultrasensitive</string>
+    <string name="title_bg_glucose_offset">Glucose offset calibration</string>
+    <string name="summary_bg_glucose_offset">Shift every incoming glucose reading by a fixed amount, in your selected units. For example +1 raises all readings by 1; use a negative value to lower them. Leave at 0 to disable.</string>
     <string name="no_battery_optimization_whitelisting">Device does not appear to support battery optimization whitelisting!</string>
     <string name="no_i_really_know">No, I really know what I\'m doing</string>
     <string name="use_for_calibration">Use %s for Calibration?</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1102,6 +1102,13 @@
             android:summary="@string/debug_and_other_misc_options"
             android:title="@string/less_common_settings">
 
+            <EditTextPreference
+                android:defaultValue="0"
+                android:inputType="numberDecimal|numberSigned"
+                android:key="bg_glucose_offset"
+                android:summary="@string/summary_bg_glucose_offset"
+                android:title="@string/title_bg_glucose_offset" />
+
             <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
                 android:key="xdrip_extra_status_line"
                 android:summary="@string/options_for_extra_line"


### PR DESCRIPTION
Add a user-configurable glucose offset that shifts the displayed glucose by a fixed amount. The value is entered in the user's units; a positive value raises every shown reading, negative lowers it. Default 0 (disabled).

Some CGMs (Syai, Instara, ...) have no built-in calibration, and from time to time we need to adjust their accuracy.

A ⚠ warning icon is shown before the main-screen value while the offset is non-zero, as a reminder that the value is shifted.

<img width="1080" height="2269" alt="edited_9b55f9a5-f352-4f23-b503-82a5be1ce34a13849555906928206087" src="https://github.com/user-attachments/assets/db5fc78c-4007-47f4-9cc8-3b0b995de5f2" />
