### PR TITLE
okhttp 4 migration — Phase A: characterization-test baseline

### DIFF
--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/GzipRequestInterceptorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/GzipRequestInterceptorTest.java
@@ -1,0 +1,117 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.zip.GZIPInputStream;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * Characterization tests for {@link GzipRequestInterceptor} on okhttp 3.12.13.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class GzipRequestInterceptorTest extends RobolectricTestWithConfig {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private MockWebServer server;
+    private OkHttpClient client;
+
+    @Before
+    public void setUpServer() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        client = new OkHttpClient.Builder()
+                .addInterceptor(new GzipRequestInterceptor())
+                .build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) server.shutdown();
+    }
+
+    private static String gunzip(byte[] gzipped) throws Exception {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GZIPInputStream in = new GZIPInputStream(new ByteArrayInputStream(gzipped))) {
+            final byte[] buf = new byte[1024];
+            int n;
+            while ((n = in.read(buf)) != -1) out.write(buf, 0, n);
+        }
+        return out.toString("UTF-8");
+    }
+
+    @Test
+    public void postWithBody_isGzippedAndTagged() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final Request request = new Request.Builder()
+                .url(server.url("/upload"))
+                .post(RequestBody.create(JSON, "{\"a\":1}"))
+                .build();
+
+        // :: Act
+        try (Response response = client.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        // :: Verify
+        final RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getHeader("Content-Encoding")).isEqualTo("gzip");
+        assertThat(gunzip(recorded.getBody().readByteArray())).isEqualTo("{\"a\":1}");
+    }
+
+    @Test
+    public void getWithoutBody_passesThroughUntouched() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final Request request = new Request.Builder().url(server.url("/ping")).get().build();
+
+        // :: Act
+        try (Response response = client.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        // :: Verify
+        final RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getHeader("Content-Encoding")).isNull();
+        assertThat(recorded.getBodySize()).isEqualTo(0);
+    }
+
+    @Test
+    public void requestAlreadyEncoded_passesThroughUntouched() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final Request request = new Request.Builder()
+                .url(server.url("/upload"))
+                .header("Content-Encoding", "identity")
+                .post(RequestBody.create(JSON, "already"))
+                .build();
+
+        // :: Act
+        try (Response response = client.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        // :: Verify
+        final RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getHeader("Content-Encoding")).isEqualTo("identity");
+        assertThat(recorded.getBody().readUtf8()).isEqualTo("already");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/BaseMessageTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/BaseMessageTest.java
@@ -1,0 +1,50 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow.messages;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.google.gson.annotations.Expose;
+
+import org.junit.Test;
+
+import okhttp3.RequestBody;
+import okio.Buffer;
+
+/**
+ * Characterization tests for {@link BaseMessage#getBody()}.
+ *
+ * Pins the request body serialization and content-type produced on okhttp 3.12.13.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class BaseMessageTest extends RobolectricTestWithConfig {
+
+    /**
+     * Minimal concrete message so the abstract base can be exercised. Fields use {@code @Expose}
+     * because {@code JoH.defaultGsonInstance()} is configured with
+     * {@code excludeFieldsWithoutExposeAnnotation()} — without it, Gson emits {@code {}}.
+     */
+    private static class SampleMessage extends BaseMessage {
+        @Expose
+        final String name = "abc";
+        @Expose
+        final int value = 7;
+    }
+
+    @Test
+    public void getBody_serializesJsonWithCharsetContentType() throws Exception {
+        // :: Setup
+        final SampleMessage message = new SampleMessage();
+
+        // :: Act
+        final RequestBody body = message.getBody();
+        final Buffer buffer = new Buffer();
+        body.writeTo(buffer);
+        final String content = buffer.readUtf8();
+
+        // :: Verify
+        assertThat(content).isEqualTo("{\"name\":\"abc\",\"value\":7}");
+        assertThat(body.contentType()).isNotNull();
+        assertThat(body.contentType().toString()).isEqualTo("application/json; charset=utf-8");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/webfollow/CmdMediaTypeTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/webfollow/CmdMediaTypeTest.java
@@ -1,0 +1,37 @@
+package com.eveningoutpost.dexdrip.cgm.webfollow;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import okhttp3.MediaType;
+
+/**
+ * Characterization test pinning the private {@code Cmd.JSON} media type constant.
+ *
+ * The full body-building path runs inside {@link Cmd#process(String)} with heavy
+ * context, so this reflects on the constant directly. It pins exactly the surface the
+ * Phase C5 {@code MediaType.parse -> MediaType.get} change could alter.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class CmdMediaTypeTest extends RobolectricTestWithConfig {
+
+    @Test
+    public void jsonConstant_isApplicationJson() throws Exception {
+        // :: Setup
+        final Field jsonField = Cmd.class.getDeclaredField("JSON");
+        jsonField.setAccessible(true);
+
+        // :: Act
+        final MediaType json = (MediaType) jsonField.get(null);
+
+        // :: Verify
+        assertThat(json).isNotNull();
+        assertThat(json.toString()).isEqualTo("application/json");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/BaseMessageTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/BaseMessageTest.java
@@ -1,0 +1,51 @@
+package com.eveningoutpost.dexdrip.tidepool;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.google.gson.annotations.Expose;
+
+import org.junit.Test;
+
+import okhttp3.RequestBody;
+import okio.Buffer;
+
+/**
+ * Characterization tests for {@link BaseMessage#getBody()}.
+ *
+ * Pins the request body serialization and content-type produced on okhttp 3.12.13,
+ * so the okhttp4 migration can be proven behavior-preserving.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class BaseMessageTest extends RobolectricTestWithConfig {
+
+    /**
+     * Minimal concrete message so the abstract base can be exercised. Fields use {@code @Expose}
+     * because {@code JoH.defaultGsonInstance()} is configured with
+     * {@code excludeFieldsWithoutExposeAnnotation()} — without it, Gson emits {@code {}}.
+     */
+    private static class SampleMessage extends BaseMessage {
+        @Expose
+        final String name = "abc";
+        @Expose
+        final int value = 7;
+    }
+
+    @Test
+    public void getBody_serializesJsonWithCharsetContentType() throws Exception {
+        // :: Setup
+        final SampleMessage message = new SampleMessage();
+
+        // :: Act
+        final RequestBody body = message.getBody();
+        final Buffer buffer = new Buffer();
+        body.writeTo(buffer);
+        final String content = buffer.readUtf8();
+
+        // :: Verify
+        assertThat(content).isEqualTo("{\"name\":\"abc\",\"value\":7}");
+        assertThat(body.contentType()).isNotNull();
+        assertThat(body.contentType().toString()).isEqualTo("application/json; charset=utf-8");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/GzipRequestInterceptorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/GzipRequestInterceptorTest.java
@@ -1,0 +1,117 @@
+package com.eveningoutpost.dexdrip.tidepool;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.zip.GZIPInputStream;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * Characterization tests for the package-private {@link GzipRequestInterceptor} on okhttp 3.12.13.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class GzipRequestInterceptorTest extends RobolectricTestWithConfig {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private MockWebServer server;
+    private OkHttpClient client;
+
+    @Before
+    public void setUpServer() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        client = new OkHttpClient.Builder()
+                .addInterceptor(new GzipRequestInterceptor())
+                .build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) server.shutdown();
+    }
+
+    private static String gunzip(byte[] gzipped) throws Exception {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GZIPInputStream in = new GZIPInputStream(new ByteArrayInputStream(gzipped))) {
+            final byte[] buf = new byte[1024];
+            int n;
+            while ((n = in.read(buf)) != -1) out.write(buf, 0, n);
+        }
+        return out.toString("UTF-8");
+    }
+
+    @Test
+    public void postWithBody_isGzippedAndTagged() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final Request request = new Request.Builder()
+                .url(server.url("/upload"))
+                .post(RequestBody.create(JSON, "{\"a\":1}"))
+                .build();
+
+        // :: Act
+        try (Response response = client.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        // :: Verify
+        final RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getHeader("Content-Encoding")).isEqualTo("gzip");
+        assertThat(gunzip(recorded.getBody().readByteArray())).isEqualTo("{\"a\":1}");
+    }
+
+    @Test
+    public void getWithoutBody_passesThroughUntouched() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final Request request = new Request.Builder().url(server.url("/ping")).get().build();
+
+        // :: Act
+        try (Response response = client.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        // :: Verify
+        final RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getHeader("Content-Encoding")).isNull();
+        assertThat(recorded.getBodySize()).isEqualTo(0);
+    }
+
+    @Test
+    public void requestAlreadyEncoded_passesThroughUntouched() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200));
+        final Request request = new Request.Builder()
+                .url(server.url("/upload"))
+                .header("Content-Encoding", "identity")
+                .post(RequestBody.create(JSON, "already"))
+                .build();
+
+        // :: Act
+        try (Response response = client.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        // :: Verify
+        final RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getHeader("Content-Encoding")).isEqualTo("identity");
+        assertThat(recorded.getBody().readUtf8()).isEqualTo("already");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/InfoInterceptorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/InfoInterceptorTest.java
@@ -59,6 +59,7 @@ public class InfoInterceptorTest extends RobolectricTestWithConfig {
         final int code;
         try (Response response = client.newCall(request).execute()) {
             code = response.code();
+            assertThat(response.body()).isNotNull();
             responseBody = response.body().string();
         }
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/InfoInterceptorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/InfoInterceptorTest.java
@@ -1,0 +1,75 @@
+package com.eveningoutpost.dexdrip.tidepool;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * Characterization tests for {@link InfoInterceptor} on okhttp 3.12.13.
+ *
+ * It logs body size only; the request and response must pass through unchanged.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class InfoInterceptorTest extends RobolectricTestWithConfig {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private MockWebServer server;
+    private OkHttpClient client;
+
+    @Before
+    public void setUpServer() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        client = new OkHttpClient.Builder()
+                .addInterceptor(new InfoInterceptor("test-tag"))
+                .build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) server.shutdown();
+    }
+
+    @Test
+    public void postWithBody_passesRequestAndResponseThroughUnchanged() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(201).setBody("ok"));
+        final Request request = new Request.Builder()
+                .url(server.url("/v1/data"))
+                .post(RequestBody.create(JSON, "{\"a\":1}"))
+                .build();
+
+        // :: Act
+        final String responseBody;
+        final int code;
+        try (Response response = client.newCall(request).execute()) {
+            code = response.code();
+            responseBody = response.body().string();
+        }
+
+        // :: Verify
+        assertThat(code).isEqualTo(201);
+        assertThat(responseBody).isEqualTo("ok");
+
+        final RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getMethod()).isEqualTo("POST");
+        assertThat(recorded.getPath()).isEqualTo("/v1/data");
+        assertThat(recorded.getHeader("Content-Encoding")).isNull();
+        assertThat(recorded.getBody().readUtf8()).isEqualTo("{\"a\":1}");
+    }
+}


### PR DESCRIPTION
> **Phase A of the okhttp 4 migration — ready for review.** This PR adds tests only: no production code and no dependency versions change. It establishes the behavior baseline and the approach to review before the dependency bumps (Phase B) begin.

## Why we are doing this

xDrip's HTTP stack is pinned to **okhttp 3.12.13**. The 3.12.x line is okhttp's old *legacy LTS* branch (kept alive for Android < 5.0 / Java 7) and it is **end-of-life** — it has received no fixes since 2021. We want to move onto a maintained line.

The end goal is okhttp 5.x (the actively maintained line), but we get there in two careful steps. This effort takes us to **okhttp 4.12.0** first, as a safe halfway point across okhttp's big internal change (the 4.x Kotlin rewrite). A later, separate effort will take 4.12.0 → 5.x.

The hard rule for the whole migration is: **no change in observable behavior.** To guarantee that — rather than hope for it — we first write **characterization tests**: tests that pin the *current* behavior on okhttp 3.12.13. Once they are green, every later dependency bump must keep them green, which proves the bump preserved behavior.

## What is in this PR (Phase A)

Six new characterization tests covering the HTTP code paths that previously had **no test coverage**. Each pins the exact current behavior:

| Test | Pins |
|------|------|
| `tidepool/BaseMessageTest` | JSON request body bytes + `content-type` (incl. okhttp's auto `; charset=utf-8`) |
| `cgm/nsfollow/messages/BaseMessageTest` | same, for the Nightscout-follow message base |
| `cgm/webfollow/CmdMediaTypeTest` | the `Cmd.JSON` media-type constant (`application/json`) |
| `cgm/nsfollow/GzipRequestInterceptorTest` | gzip compression, `Content-Encoding: gzip` tagging, and pass-through cases |
| `tidepool/GzipRequestInterceptorTest` | same, for the tidepool copy (package-private class) |
| `tidepool/InfoInterceptorTest` | request and response pass through unchanged |

- **No production code changed** (`app/src/main` diff is empty).
- **No dependency versions changed** — still okhttp 3.12.13 / Retrofit 2.4.0.
- Full `./gradlew test` suite is green.

## What comes after this PR (not included here)

- **B1** — bump okhttp 3.12.13 → 3.14.9 **and** Retrofit 2.4.0 → 2.9.0 together (this is the exact pair upstream tests against).
- **B2** — bump okhttp 3.14.9 → 4.12.0 (the Kotlin-rewrite step), isolated so any regression is easy to bisect/revert.
- **C** — replace deprecated okhttp API calls, one area at a time.
- **D** — remove dead pre-Lollipop TLS-1.2 code (separate, independent).

## Note for reviewers

Incidentally found: `GzipRequestInterceptor` exists as **three identical copies** (nsfollow `public`, tidepool package-private, and an inner class in `NightscoutUploader`). Consolidating them is **out of scope** here, but is a good follow-up cleanup PR — and the tests in this PR would de-risk it.

## Test plan

- [x] `./gradlew test` green (full suite, all flavored variants)
- [x] No changes under `app/src/main`
- [ ] Reviewer: confirm the characterization-test approach is acceptable before Phase B begins