### PR TITLE
nsfollow: fix Juggluco follower breakage (empty {} entries, devicestatus 400, airplane-mode loopback)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollow.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
+import retrofit2.Response;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.Headers;
@@ -129,15 +130,11 @@ public class NightscoutFollow {
                     }
                 }
             }
-            if (JoH.ratelimit("nsfollow-devicestatus", 5 * 60)) {
+            if (NsServerCapabilities.supportsDeviceStatus(urlString)
+                    && JoH.ratelimit("nsfollow-devicestatus", 5 * 60)) {
                 try {
-                    getService().getDeviceStatus(session.url.getHashedSecret()).enqueue(
-                            new NightscoutCallback<>("NS devicestatus download", session,
-                                    statusList -> {
-                                        if (!statusList.isEmpty()) {
-                                            applyDeviceStatus(statusList.get(0));
-                                        }
-                                    }, null));
+                    getService().getDeviceStatus(session.url.getHashedSecret())
+                            .enqueue(new DeviceStatusCallback(session, urlString));
                 } catch (Exception e) {
                     UserError.Log.e(TAG, "Exception in devicestatus work() " + e);
                 }
@@ -187,5 +184,35 @@ public class NightscoutFollow {
         if (ds.uploaderBattery != null) return ds.uploaderBattery;
         if (ds.uploader != null) return ds.uploader.battery;
         return null;
+    }
+
+    /**
+     * Devicestatus callback that disables further devicestatus polling for this server when the
+     * endpoint is rejected with an HTTP 4xx (e.g. Juggluco returns 400 Bad Request).
+     */
+    private static final class DeviceStatusCallback extends NightscoutCallback<List<DeviceStatus>> {
+        private final String url;
+
+        DeviceStatusCallback(final Session session, final String url) {
+            super("NS devicestatus download", session, statusList -> {
+                if (!statusList.isEmpty()) {
+                    applyDeviceStatus(statusList.get(0));
+                }
+            }, null);
+            this.url = url;
+        }
+
+        @Override
+        public void onResponse(final Call<List<DeviceStatus>> call, final Response<List<DeviceStatus>> response) {
+            super.onResponse(call, response);
+            final int code = response.code();
+            if (response.isSuccessful()) {
+                // Self-heal: endpoint works, clear any prior unsupported mark for this server.
+                NsServerCapabilities.markDeviceStatusSupported(url);
+            } else if (code >= 400 && code < 500) {
+                UserError.Log.d(TAG, "devicestatus unsupported (" + code + ") — disabling for this server");
+                NsServerCapabilities.markDeviceStatusUnsupported(url);
+            }
+        }
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowService.java
@@ -28,6 +28,7 @@ import com.eveningoutpost.dexdrip.xdrip;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -70,6 +71,27 @@ public class NightscoutFollowService extends ForegroundService {
         return cm != null && cm.getActiveNetwork() != null;
     }
 
+    @VisibleForTesting
+    static boolean isLoopbackUrl(final String url) {
+        if (url == null || url.isEmpty()) return false;
+        try {
+            String host = URI.create(url).getHost();
+            if (host == null) return false;
+            host = host.toLowerCase();
+            if (host.startsWith("[")) host = host.substring(1, host.length() - 1); // strip IPv6 brackets
+            return host.equals("localhost")
+                    || host.equals("::1")
+                    || host.startsWith("127.");
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    @VisibleForTesting
+    static boolean shouldPoll(final ConnectivityManager cm, final String url) {
+        return isNetworkAvailable(cm) || isLoopbackUrl(url);
+    }
+
     private static long getLag() {
         // Wake delay derived from the nsfollow_lag setting.
         // Values represent seconds of a 5-minute sample period and are scaled
@@ -110,10 +132,12 @@ public class NightscoutFollowService extends ForegroundService {
 
             // Skip network I/O when there is no data connection — saves wake lock extension,
             // DNS resolution, and TCP handshake cost. The alarm above ensures we retry.
+            // Loopback targets (e.g. Juggluco on 127.0.0.1) are always reachable, even in
+            // airplane mode, so never skip them.
             final ConnectivityManager cm =
                     (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-            if (!isNetworkAvailable(cm)) {
-                UserError.Log.d(TAG, "No network — skipping poll");
+            if (!shouldPoll(cm, Pref.getString("nsfollow_url", ""))) {
+                UserError.Log.d(TAG, "No network and non-loopback target — skipping poll");
                 return START_STICKY;
             }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NsServerCapabilities.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NsServerCapabilities.java
@@ -2,7 +2,7 @@ package com.eveningoutpost.dexdrip.cgm.nsfollow;
 
 import androidx.annotation.VisibleForTesting;
 
-import java.util.function.LongSupplier;
+import com.eveningoutpost.dexdrip.models.JoH;
 
 /**
  * In-memory, per-URL record of Nightscout server capabilities that turned out to be unsupported
@@ -19,7 +19,9 @@ import java.util.function.LongSupplier;
  *       the cost of healing is at most one request per recheck window.</li>
  *   <li>The whole state resets immediately when the follow URL changes.</li>
  * </ul>
- * State is process-lifetime only; a cold start re-detects at most once.
+ * State is process-lifetime only; a cold start re-detects at most once. Time comes from
+ * {@link JoH#tsl()} (the project's wall-clock convention; {@code java.time.Clock} is avoided
+ * because minSdk 24 has no core-library desugaring).
  *
  * @author Asbjørn Aarrestad
  */
@@ -28,12 +30,8 @@ public final class NsServerCapabilities {
     /** How long to suppress devicestatus after a rejection before allowing a self-healing re-probe. */
     static final long DEVICESTATUS_RECHECK_MS = 6 * 60 * 60 * 1000L; // 6 hours
 
-    /** Clock indirection so the recheck window is testable without sleeping. */
-    @VisibleForTesting
-    static volatile LongSupplier clock = System::currentTimeMillis;
-
     private static volatile String currentUrl = "";
-    /** 0 = supported/never-marked; otherwise the timestamp of the last rejection. */
+    /** 0 = supported/never-marked; otherwise the {@link JoH#tsl()} timestamp of the last rejection. */
     private static volatile long deviceStatusUnsupportedAt = 0;
 
     private NsServerCapabilities() {
@@ -48,17 +46,29 @@ public final class NsServerCapabilities {
     }
 
     public static synchronized boolean supportsDeviceStatus(final String url) {
+        return supportsDeviceStatusAt(url, JoH.tsl());
+    }
+
+    /** Time-injected variant so the recheck window is deterministically testable. */
+    @VisibleForTesting
+    static synchronized boolean supportsDeviceStatusAt(final String url, final long nowMs) {
         syncUrl(url);
         if (deviceStatusUnsupportedAt == 0) {
             return true;
         }
         // Self-heal: once the recheck window elapses, allow a single re-probe through.
-        return clock.getAsLong() - deviceStatusUnsupportedAt >= DEVICESTATUS_RECHECK_MS;
+        return nowMs - deviceStatusUnsupportedAt >= DEVICESTATUS_RECHECK_MS;
     }
 
     public static synchronized void markDeviceStatusUnsupported(final String url) {
+        markDeviceStatusUnsupportedAt(url, JoH.tsl());
+    }
+
+    /** Time-injected variant so the recheck window is deterministically testable. */
+    @VisibleForTesting
+    static synchronized void markDeviceStatusUnsupportedAt(final String url, final long nowMs) {
         syncUrl(url);
-        deviceStatusUnsupportedAt = clock.getAsLong();
+        deviceStatusUnsupportedAt = nowMs;
     }
 
     /** Clears the unsupported flag — called when the endpoint responds successfully again. */
@@ -71,6 +81,5 @@ public final class NsServerCapabilities {
     public static synchronized void reset() {
         currentUrl = "";
         deviceStatusUnsupportedAt = 0;
-        clock = System::currentTimeMillis;
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NsServerCapabilities.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NsServerCapabilities.java
@@ -1,0 +1,76 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow;
+
+import androidx.annotation.VisibleForTesting;
+
+import java.util.function.LongSupplier;
+
+/**
+ * In-memory, per-URL record of Nightscout server capabilities that turned out to be unsupported
+ * at runtime — specifically the {@code devicestatus} endpoint, which the Juggluco emulator does
+ * not implement (it returns HTTP 400).
+ * <p>
+ * The flag is "semi-sticky" but <b>self-healing</b>:
+ * <ul>
+ *   <li>Once marked unsupported for the current server it stays off, so we take the cheap path
+ *       without re-probing every poll.</li>
+ *   <li>After {@link #DEVICESTATUS_RECHECK_MS} it allows a single re-probe through — if the server
+ *       has started supporting the endpoint (changed under our feet) the next success clears the
+ *       flag via {@link #markDeviceStatusSupported}; if it still fails it is simply re-marked, so
+ *       the cost of healing is at most one request per recheck window.</li>
+ *   <li>The whole state resets immediately when the follow URL changes.</li>
+ * </ul>
+ * State is process-lifetime only; a cold start re-detects at most once.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public final class NsServerCapabilities {
+
+    /** How long to suppress devicestatus after a rejection before allowing a self-healing re-probe. */
+    static final long DEVICESTATUS_RECHECK_MS = 6 * 60 * 60 * 1000L; // 6 hours
+
+    /** Clock indirection so the recheck window is testable without sleeping. */
+    @VisibleForTesting
+    static volatile LongSupplier clock = System::currentTimeMillis;
+
+    private static volatile String currentUrl = "";
+    /** 0 = supported/never-marked; otherwise the timestamp of the last rejection. */
+    private static volatile long deviceStatusUnsupportedAt = 0;
+
+    private NsServerCapabilities() {
+    }
+
+    private static synchronized void syncUrl(final String url) {
+        final String u = (url == null) ? "" : url;
+        if (!u.equals(currentUrl)) {
+            currentUrl = u;
+            deviceStatusUnsupportedAt = 0;
+        }
+    }
+
+    public static synchronized boolean supportsDeviceStatus(final String url) {
+        syncUrl(url);
+        if (deviceStatusUnsupportedAt == 0) {
+            return true;
+        }
+        // Self-heal: once the recheck window elapses, allow a single re-probe through.
+        return clock.getAsLong() - deviceStatusUnsupportedAt >= DEVICESTATUS_RECHECK_MS;
+    }
+
+    public static synchronized void markDeviceStatusUnsupported(final String url) {
+        syncUrl(url);
+        deviceStatusUnsupportedAt = clock.getAsLong();
+    }
+
+    /** Clears the unsupported flag — called when the endpoint responds successfully again. */
+    public static synchronized void markDeviceStatusSupported(final String url) {
+        syncUrl(url);
+        deviceStatusUnsupportedAt = 0;
+    }
+
+    @VisibleForTesting
+    public static synchronized void reset() {
+        currentUrl = "";
+        deviceStatusUnsupportedAt = 0;
+        clock = System::currentTimeMillis;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/RetrofitService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/RetrofitService.java
@@ -14,12 +14,15 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.bind.TypeAdapters;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
@@ -65,6 +68,7 @@ public class RetrofitService {
 
         final Gson gson = new GsonBuilder()
                 .registerTypeAdapterFactory(UNRELIABLE_INTEGER_FACTORY)
+                .registerTypeAdapterFactory(EMPTY_OBJECT_AS_EMPTY_LIST)
                 .create();
         Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl(url)
@@ -186,4 +190,37 @@ public class RetrofitService {
         }
     };
     public static final TypeAdapterFactory UNRELIABLE_INTEGER_FACTORY = TypeAdapters.newFactory(int.class, Integer.class, UNRELIABLE_INTEGER);
+
+    /**
+     * Some Nightscout emulators (Juggluco) return an empty JSON object {@code {}} instead of an
+     * empty array {@code []} for an empty result set. This factory maps that to an empty list for
+     * any {@code List<...>} target, so a no-data poll is a normal empty result rather than a
+     * {@code BEGIN_ARRAY}/{@code BEGIN_OBJECT} parse failure. Real Nightscout returns {@code []},
+     * so it is unaffected.
+     */
+    public static final TypeAdapterFactory EMPTY_OBJECT_AS_EMPTY_LIST = new TypeAdapterFactory() {
+        @Override
+        public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> type) {
+            if (!List.class.isAssignableFrom(type.getRawType())) {
+                return null;
+            }
+            final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+            return new TypeAdapter<T>() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public T read(final JsonReader in) throws IOException {
+                    if (in.peek() == JsonToken.BEGIN_OBJECT) {
+                        in.skipValue(); // consume {} and treat as empty
+                        return (T) new ArrayList<>();
+                    }
+                    return delegate.read(in);
+                }
+
+                @Override
+                public void write(final JsonWriter out, final T value) throws IOException {
+                    delegate.write(out, value);
+                }
+            };
+        }
+    };
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/JugglucoEmulatorContractTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/JugglucoEmulatorContractTest.java
@@ -1,0 +1,124 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.os.Looper;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.models.BgReading;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * Executable documentation of the Juggluco Nightscout-emulator contract, driven end-to-end through
+ * {@link NightscoutFollow#work}. Mirrors watchserver.cpp behaviour (verified 2026-07-02):
+ * <ul>
+ *   <li>entries with find[date][$gt] and no new data → HTTP 200 body {@code {}} (givenothing()).</li>
+ *   <li>entries with data → HTTP 200 JSON array.</li>
+ *   <li>devicestatus.json → HTTP 400 Bad Request text/plain (wrongpath(), route commented out).</li>
+ * </ul>
+ * The follower must import readings when present, treat {@code {}} as an empty poll (no error), and
+ * stop polling devicestatus after the 400.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class JugglucoEmulatorContractTest extends RobolectricTestWithConfig {
+
+    private MockWebServer server;
+    private String url;
+
+    @Before
+    public void setUpServer() throws Exception {
+        super.setUp();
+        server = new MockWebServer();
+        server.start();
+        url = server.url("/").toString();
+        Pref.setString("nsfollow_url", url);
+        JoH.clearRatelimit("nsfollow-devicestatus");
+        JoH.clearRatelimit("nsfollow-treatment-download");
+        NsServerCapabilities.reset();
+        NightscoutFollow.resetInstance();
+        BgReading.deleteALL();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+        NsServerCapabilities.reset();
+        NightscoutFollow.resetInstance();
+        BgReading.deleteALL();
+    }
+
+    private static void awaitCallbacks() throws InterruptedException {
+        Thread.sleep(400);
+        shadowOf(Looper.getMainLooper()).idle();
+    }
+
+    /** A Juggluco-shaped dispatcher: {@code entriesBody} for entries, 400 for devicestatus. */
+    private void useJugglucoDispatcher(final String entriesBody) {
+        server.setDispatcher(new Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest request) {
+                final String path = request.getPath() == null ? "" : request.getPath();
+                if (path.contains("devicestatus")) {
+                    return new MockResponse().setResponseCode(400)
+                            .addHeader("Content-Type", "text/plain")
+                            .setBody("400 Bad Request: " + path);
+                }
+                if (path.contains("entries")) {
+                    return new MockResponse().setResponseCode(200)
+                            .addHeader("Content-Type", "application/json; charset=utf-8")
+                            .setBody(entriesBody);
+                }
+                return new MockResponse().setBody("[]"); // treatments etc.
+            }
+        });
+    }
+
+    // ===== Empty poll: {} tolerated, no data, no crash ===========================================
+
+    @Test
+    public void emptyEntriesObject_isToleratedAndDeviceStatusDisabled() throws Exception {
+        // :: Setup — prior reading forces the find[date][$gt] path; Juggluco answers {} (no new data)
+        final BgReading prior = new BgReading();
+        prior.calculated_value = 120.0;
+        prior.raw_data = 120.0;
+        prior.timestamp = JoH.tsl() - 60_000L;
+        prior.save();
+        useJugglucoDispatcher("{}\n");
+
+        // :: Act
+        NightscoutFollow.work(true);
+        awaitCallbacks();
+
+        // :: Verify — the follower reached the server (no parse crash), and devicestatus is disabled
+        assertThat(server.getRequestCount()).isGreaterThan(0);
+        assertThat(NsServerCapabilities.supportsDeviceStatus(url)).isFalse();
+    }
+
+    // ===== Entries with data are imported ========================================================
+
+    @Test
+    public void entriesArray_isImported() throws Exception {
+        // :: Setup — fresh DB → count-based query; Juggluco returns a real array
+        final long ts = JoH.tsl() - 120_000L;
+        useJugglucoDispatcher("[{\"sgv\":142,\"date\":" + ts + ",\"direction\":\"Flat\",\"type\":\"sgv\"}]");
+
+        // :: Act
+        NightscoutFollow.work(true);
+        awaitCallbacks();
+
+        // :: Verify — the reading landed in the DB
+        assertThat(BgReading.getForPreciseTimestamp(ts, 10_000)).isNotNull();
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusFallbackTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusFallbackTest.java
@@ -1,0 +1,114 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.os.Looper;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * Tests that {@link NightscoutFollow#work} tolerates a server that rejects the {@code devicestatus}
+ * endpoint (Juggluco returns HTTP 400 via wrongpath()): it records the limitation and stops
+ * requesting it.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class NightscoutFollowDeviceStatusFallbackTest extends RobolectricTestWithConfig {
+
+    private MockWebServer server;
+    private String url;
+
+    @Before
+    public void setUpServer() throws Exception {
+        super.setUp();
+        server = new MockWebServer();
+        server.start();
+        url = server.url("/").toString();
+        Pref.setString("nsfollow_url", url);
+        JoH.clearRatelimit("nsfollow-devicestatus");
+        JoH.clearRatelimit("nsfollow-treatment-download");
+        NsServerCapabilities.reset();
+        NightscoutFollow.resetInstance();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+        NsServerCapabilities.reset();
+        NightscoutFollow.resetInstance();
+    }
+
+    private static void awaitCallbacks() throws InterruptedException {
+        Thread.sleep(400);
+        shadowOf(Looper.getMainLooper()).idle();
+    }
+
+    /** entries/treatments respond OK; devicestatus is rejected with 400 like Juggluco's wrongpath(). */
+    private void useDeviceStatus400Dispatcher() {
+        server.setDispatcher(new Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest request) {
+                final String path = request.getPath() == null ? "" : request.getPath();
+                if (path.contains("devicestatus")) {
+                    return new MockResponse().setResponseCode(400)
+                            .addHeader("Content-Type", "text/plain").setBody("Bad Request");
+                }
+                return new MockResponse().setBody("[]");
+            }
+        });
+    }
+
+    // ===== Sticky skip after 400 =================================================================
+
+    @Test
+    public void work_marksDeviceStatusUnsupported_afterHttp400() throws Exception {
+        // :: Setup
+        useDeviceStatus400Dispatcher();
+
+        // :: Act
+        NightscoutFollow.work(false);
+        awaitCallbacks();
+
+        // :: Verify — limitation recorded
+        assertThat(NsServerCapabilities.supportsDeviceStatus(url)).isFalse();
+    }
+
+    @Test
+    public void work_skipsDeviceStatusRequest_whenAlreadyUnsupported() throws Exception {
+        // :: Setup — limitation already known
+        NsServerCapabilities.markDeviceStatusUnsupported(url);
+        server.setDispatcher(new Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest request) {
+                return new MockResponse().setBody("[]");
+            }
+        });
+
+        // :: Act
+        NightscoutFollow.work(false);
+        awaitCallbacks();
+
+        // :: Verify — no devicestatus request was made
+        final int count = server.getRequestCount();
+        for (int i = 0; i < count; i++) {
+            final RecordedRequest r = server.takeRequest(1, TimeUnit.SECONDS);
+            if (r != null && r.getPath() != null) {
+                assertThat(r.getPath()).doesNotContain("devicestatus");
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowEmptyObjectEntriesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowEmptyObjectEntriesTest.java
@@ -1,0 +1,80 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.cgm.nsfollow.messages.Entry;
+import com.eveningoutpost.dexdrip.utils.framework.RetrofitService;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import retrofit2.Response;
+
+/**
+ * Verifies the production Retrofit/Gson stack (built by {@link RetrofitService}) tolerates the
+ * Juggluco emulator returning an empty JSON object {@code {}} for an empty entries result set,
+ * instead of throwing {@code Expected BEGIN_ARRAY but was BEGIN_OBJECT}. Encodes the Juggluco
+ * contract documented in the plan (watchserver.cpp givenothing()).
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class NightscoutFollowEmptyObjectEntriesTest extends RobolectricTestWithConfig {
+
+    private MockWebServer server;
+    private String url;
+    private NightscoutFollow.Nightscout api;
+
+    @Before
+    public void setUpServer() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        url = server.url("/").toString();
+        api = RetrofitService.getRetrofitInstance(url, "TEST", false)
+                .create(NightscoutFollow.Nightscout.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+        RetrofitService.remove(url, "TEST", false);
+    }
+
+    // ===== Juggluco {} empty result ==============================================================
+
+    @Test
+    public void getEntriesSince_emptyObjectBody_parsesAsEmptyList() throws Exception {
+        // :: Setup — Juggluco returns {} (HTTP 200) when find[date][$gt] has no new entries
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("{}\n"));
+
+        // :: Act
+        final Response<List<Entry>> response =
+                api.getEntriesSince("s", 2880, 1773581680000L, "12345").execute();
+
+        // :: Verify — successful, empty list, no exception
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).isEmpty();
+    }
+
+    // ===== Normal array still parses =============================================================
+
+    @Test
+    public void getEntries_arrayBody_stillParses() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(200)
+                .setBody("[{\"sgv\":123,\"date\":1773581680168}]"));
+
+        // :: Act
+        final Response<List<Entry>> response = api.getEntries("s", 10, "12345").execute();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).hasSize(1);
+        assertThat(response.body().get(0).sgv).isEqualTo(123);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowServiceNetworkTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowServiceNetworkTest.java
@@ -47,4 +47,46 @@ public class NightscoutFollowServiceNetworkTest extends RobolectricTestWithConfi
         // :: Verify
         assertThat(NightscoutFollowService.isNetworkAvailable(cm)).isTrue();
     }
+
+    // ===== isLoopbackUrl =========================================================================
+
+    @Test
+    public void isLoopbackUrl_trueForIpv4Loopback() {
+        assertThat(NightscoutFollowService.isLoopbackUrl("http://127.0.0.1:17580/")).isTrue();
+    }
+
+    @Test
+    public void isLoopbackUrl_trueForLocalhostAndIpv6() {
+        assertThat(NightscoutFollowService.isLoopbackUrl("http://localhost:1979/")).isTrue();
+        assertThat(NightscoutFollowService.isLoopbackUrl("http://[::1]:1979/")).isTrue();
+    }
+
+    @Test
+    public void isLoopbackUrl_falseForRemoteHostAndBlank() {
+        assertThat(NightscoutFollowService.isLoopbackUrl("https://my.ns.example.com/")).isFalse();
+        assertThat(NightscoutFollowService.isLoopbackUrl("")).isFalse();
+        assertThat(NightscoutFollowService.isLoopbackUrl(null)).isFalse();
+    }
+
+    // ===== shouldPoll ============================================================================
+
+    @Test
+    public void shouldPoll_trueForLoopback_evenWithNoNetwork() {
+        // :: Setup — airplane mode: CM present, no active network
+        final ConnectivityManager cm = mock(ConnectivityManager.class);
+        when(cm.getActiveNetwork()).thenReturn(null);
+
+        // :: Verify — loopback still polls
+        assertThat(NightscoutFollowService.shouldPoll(cm, "http://127.0.0.1:17580/")).isTrue();
+    }
+
+    @Test
+    public void shouldPoll_falseForRemote_whenNoNetwork() {
+        // :: Setup — no active network
+        final ConnectivityManager cm = mock(ConnectivityManager.class);
+        when(cm.getActiveNetwork()).thenReturn(null);
+
+        // :: Verify — remote host is skipped when offline
+        assertThat(NightscoutFollowService.shouldPoll(cm, "https://my.ns.example.com/")).isFalse();
+    }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NsServerCapabilitiesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NsServerCapabilitiesTest.java
@@ -2,16 +2,21 @@ package com.eveningoutpost.dexdrip.cgm.nsfollow;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
 import org.junit.After;
 import org.junit.Test;
 
 /**
  * Tests for {@link NsServerCapabilities}: default-supported state, sticky marking of an
- * unsupported endpoint, and automatic reset when the server URL changes.
+ * unsupported endpoint, automatic reset when the server URL changes, and self-healing after the
+ * recheck window. The recheck window is exercised through the {@code ...At(url, nowMs)} test
+ * seams so it is deterministic without depending on wall-clock time (the class reads
+ * {@link com.eveningoutpost.dexdrip.models.JoH#tsl()} in production).
  *
  * @author Asbjørn Aarrestad
  */
-public class NsServerCapabilitiesTest {
+public class NsServerCapabilitiesTest extends RobolectricTestWithConfig {
 
     private static final String URL_A = "http://127.0.0.1:17580/";
     private static final String URL_B = "https://my.ns.example.com/";
@@ -47,16 +52,15 @@ public class NsServerCapabilitiesTest {
 
     @Test
     public void allowsReprobe_afterRecheckWindowElapses() {
-        // :: Setup — controllable clock, mark unsupported at t0
-        final long[] nowMs = {1_000_000L};
-        NsServerCapabilities.clock = () -> nowMs[0];
-        NsServerCapabilities.markDeviceStatusUnsupported(URL_A);
+        // :: Setup — mark unsupported at a fixed base time
+        final long base = 1_000_000_000L;
+        NsServerCapabilities.markDeviceStatusUnsupportedAt(URL_A, base);
 
         // :: Verify — suppressed just before the window, re-probed once it elapses
-        nowMs[0] += NsServerCapabilities.DEVICESTATUS_RECHECK_MS - 1;
-        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_A)).isFalse();
-        nowMs[0] += 1;
-        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_A)).isTrue();
+        assertThat(NsServerCapabilities.supportsDeviceStatusAt(
+                URL_A, base + NsServerCapabilities.DEVICESTATUS_RECHECK_MS - 1)).isFalse();
+        assertThat(NsServerCapabilities.supportsDeviceStatusAt(
+                URL_A, base + NsServerCapabilities.DEVICESTATUS_RECHECK_MS)).isTrue();
     }
 
     @Test

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NsServerCapabilitiesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NsServerCapabilitiesTest.java
@@ -1,0 +1,74 @@
+package com.eveningoutpost.dexdrip.cgm.nsfollow;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests for {@link NsServerCapabilities}: default-supported state, sticky marking of an
+ * unsupported endpoint, and automatic reset when the server URL changes.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class NsServerCapabilitiesTest {
+
+    private static final String URL_A = "http://127.0.0.1:17580/";
+    private static final String URL_B = "https://my.ns.example.com/";
+
+    @After
+    public void tearDown() {
+        NsServerCapabilities.reset();
+    }
+
+    @Test
+    public void deviceStatusSupportedByDefault() {
+        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_A)).isTrue();
+    }
+
+    @Test
+    public void markDeviceStatusUnsupported_isStickyForSameUrl() {
+        NsServerCapabilities.markDeviceStatusUnsupported(URL_A);
+        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_A)).isFalse();
+    }
+
+    @Test
+    public void flagResetsWhenUrlChanges() {
+        NsServerCapabilities.markDeviceStatusUnsupported(URL_A);
+
+        // :: Act — switch server: flag clears
+        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_B)).isTrue();
+
+        // :: Verify — switching back re-probes (state is not remembered per-URL)
+        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_A)).isTrue();
+    }
+
+    // ===== Self-healing ==========================================================================
+
+    @Test
+    public void allowsReprobe_afterRecheckWindowElapses() {
+        // :: Setup — controllable clock, mark unsupported at t0
+        final long[] nowMs = {1_000_000L};
+        NsServerCapabilities.clock = () -> nowMs[0];
+        NsServerCapabilities.markDeviceStatusUnsupported(URL_A);
+
+        // :: Verify — suppressed just before the window, re-probed once it elapses
+        nowMs[0] += NsServerCapabilities.DEVICESTATUS_RECHECK_MS - 1;
+        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_A)).isFalse();
+        nowMs[0] += 1;
+        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_A)).isTrue();
+    }
+
+    @Test
+    public void markSupported_clearsFlagImmediately_forSelfHeal() {
+        // :: Setup
+        NsServerCapabilities.markDeviceStatusUnsupported(URL_A);
+        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_A)).isFalse();
+
+        // :: Act — endpoint responded OK again
+        NsServerCapabilities.markDeviceStatusSupported(URL_A);
+
+        // :: Verify — back to normal immediately
+        assertThat(NsServerCapabilities.supportsDeviceStatus(URL_A)).isTrue();
+    }
+}


### PR DESCRIPTION
## Problem

Reported in discussion #4592: after 2026.07.01, users following **Juggluco** via the Nightscout Follower (URL `http://127.0.0.1:...`) stopped importing data, with repeating errors:

```
NS entries download Failed: java.lang.IllegalStateException:
    Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 1 column 2 path $
NS devicestatus download was not successful: 400 Bad Request
```

Reverting to the previous release fixed it. The regression came from the nsfollow v1 improvements in #4476.

## Root cause (verified against Juggluco source)

Juggluco ships a *partial* Nightscout emulator on `127.0.0.1:17580` (`Common/src/main/cpp/net/watchserver/watchserver.cpp`). Two behaviours break the newer follower code:

1. **Empty entries → `{}`, not `[]`.** `Sgvinterpret::getdata()` calls `givenothing()` (returns HTTP 200 body `{}`) when no entries match. With the new `find[date][$gt]` filter, the steady state between readings has *no new* entries, so almost every poll returns `{}` and Gson deserialization into `List<Entry>` throws `Expected BEGIN_ARRAY but was BEGIN_OBJECT` → nothing imported. The old count-based query always matched historical readings (non-empty array), which is why the previous release worked.
2. **`devicestatus.json` is not implemented** — the route is commented out, so requests fall through to `wrongpath()` → HTTP 400. This is the "master battery" devicestatus fetch added in #4476.

Additionally, Juggluco binds loopback only, which is reachable in airplane mode even though `ConnectivityManager` reports no active network — so the new network guard skipped polling entirely.

## Changes

- **Tolerate `{}` empty-object entries as an empty list** (`RetrofitService.EMPTY_OBJECT_AS_EMPTY_LIST`, gated to `List` targets; `RetrofitService.getRetrofitInstance`'s only caller is `NightscoutFollow`). No exception on the common empty-poll path; the efficient `find[date][$gt]` query is retained. Real Nightscout returns `[]`, so it is unaffected.
- **Self-healing, per-URL skip of `devicestatus` after HTTP 4xx** (`NsServerCapabilities`): record the rejection and stop polling, but allow one re-probe after a 6h recheck window, clear immediately on a later 200, and reset when the follow URL changes. Never triggers on transient network errors. Uses `JoH.tsl()` for time (project convention; `java.time.Clock` needs API 26+ and minSdk is 24 with no desugaring), with `@VisibleForTesting` `...At(url, nowMs)` seams for deterministic window tests.
- **Loopback-aware network guard** (`NightscoutFollowService.shouldPoll` / `isLoopbackUrl`): loopback targets (`127.0.0.0/8`, `::1`, `localhost`) always poll, even with no active network.

## Testing

TDD throughout. New/updated tests:

- `NightscoutFollowEmptyObjectEntriesTest` — reproduces the exact `Expected BEGIN_ARRAY but was BEGIN_OBJECT` failure, now tolerated.
- `NsServerCapabilitiesTest` — default/sticky/URL-reset + self-heal (re-probe after window, immediate clear on success).
- `NightscoutFollowDeviceStatusFallbackTest` — 400 → sticky skip.
- `JugglucoEmulatorContractTest` — executable documentation of the Juggluco contract (`{}` / array / 400), driven end-to-end through `NightscoutFollow.work()`.
- `NightscoutFollowServiceNetworkTest` — extended with loopback / `shouldPoll`.

Full `./gradlew test` passes.

Fixes #4592

🤖 Generated with [Claude Code](https://claude.com/claude-code)
