### PR TITLE
[cleanup] Replace android.preference.PreferenceManager with androidx (Batch 1: 5 files)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,7 +134,7 @@ android {
 
         }
         unitTests.all {
-            jvmArgs '-noverify'
+            jvmArgs '-noverify', '--add-opens=java.base/java.util=ALL-UNNAMED'
 
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BGHistory.java
@@ -4,7 +4,7 @@ import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BestGlucose.java
@@ -1,7 +1,7 @@
 package com.eveningoutpost.dexdrip;
 
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StrikethroughSpan;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/AlertType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/AlertType.java
@@ -2,7 +2,7 @@ package com.eveningoutpost.dexdrip.models;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.provider.BaseColumns;
 
 import com.activeandroid.util.SQLiteUtils;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Calibration.java
@@ -2,7 +2,7 @@ package com.eveningoutpost.dexdrip.models;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.provider.BaseColumns;
 import androidx.annotation.NonNull;
 import android.widget.Toast;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Profile.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Profile.java
@@ -1,7 +1,7 @@
 package com.eveningoutpost.dexdrip.models;
 
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 
 import com.eveningoutpost.dexdrip.Home;

--- a/app/src/test/java/com/eveningoutpost/dexdrip/BGHistoryTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/BGHistoryTest.java
@@ -33,8 +33,10 @@ public class BGHistoryTest extends RobolectricTestWithConfig {
     /** Characterization: the activity builds, populating the statistics text view via prefs. */
     @Test
     public void onCreate_buildsAndPopulatesStatistics() {
+        // :: Act
         BGHistory activity = Robolectric.buildActivity(BGHistory.class).create().get();
 
+        // :: Verify
         assertThat(activity).isNotNull();
         TextView stats = activity.findViewById(R.id.historystats);
         assertThat(stats).isNotNull();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/BGHistoryTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/BGHistoryTest.java
@@ -1,0 +1,42 @@
+package com.eveningoutpost.dexdrip;
+
+import android.widget.TextView;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Characterization test for {@link BGHistory}. Building the activity runs onCreate →
+ * setupCharts → setupStatistics, which is where PreferenceManager.getDefaultSharedPreferences()
+ * is called (feeding StatsResult). This locks in that the screen still builds before/after the
+ * android.preference → androidx.preference import swap.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class BGHistoryTest extends RobolectricTestWithConfig {
+
+    // --- Setup ---
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+    }
+
+    // --- onCreate ---
+
+    /** Characterization: the activity builds, populating the statistics text view via prefs. */
+    @Test
+    public void onCreate_buildsAndPopulatesStatistics() {
+        BGHistory activity = Robolectric.buildActivity(BGHistory.class).create().get();
+
+        assertThat(activity).isNotNull();
+        TextView stats = activity.findViewById(R.id.historystats);
+        assertThat(stats).isNotNull();
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/BestGlucoseTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/BestGlucoseTest.java
@@ -29,6 +29,10 @@ public class BestGlucoseTest extends RobolectricTestWithConfig {
     /** Characterization: with no readings in the database, getDisplayGlucose returns null. */
     @Test
     public void getDisplayGlucose_returnsNullWhenNoReadings() {
-        assertThat(BestGlucose.getDisplayGlucose()).isNull();
+        // :: Act
+        final BestGlucose.DisplayGlucose displayGlucose = BestGlucose.getDisplayGlucose();
+
+        // :: Verify
+        assertThat(displayGlucose).isNull();
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/BestGlucoseTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/BestGlucoseTest.java
@@ -1,0 +1,34 @@
+package com.eveningoutpost.dexdrip;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Characterization tests for {@link BestGlucose}, locking in the behaviour that flows through
+ * its {@code PreferenceManager.getDefaultSharedPreferences()} usage before/after the
+ * android.preference → androidx.preference import swap.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class BestGlucoseTest extends RobolectricTestWithConfig {
+
+    // --- Setup ---
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+    }
+
+    // --- getDisplayGlucose ---
+
+    /** Characterization: with no readings in the database, getDisplayGlucose returns null. */
+    @Test
+    public void getDisplayGlucose_returnsNullWhenNoReadings() {
+        assertThat(BestGlucose.getDisplayGlucose()).isNull();
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/AlertTypeTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/AlertTypeTest.java
@@ -1,0 +1,69 @@
+package com.eveningoutpost.dexdrip.models;
+
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import java.util.Date;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Characterization tests for {@link AlertType}, covering each method that reads from
+ * {@code PreferenceManager.getDefaultSharedPreferences()}, so the android.preference →
+ * androidx.preference import swap is proven behaviour-preserving.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class AlertTypeTest extends RobolectricTestWithConfig {
+
+    // --- Setup ---
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+    }
+
+    // --- get_highest_active_alert ---
+
+    /** Characterization: returns null while alerts are snoozed via alerts_disabled_until. */
+    @Test
+    public void get_highest_active_alert_returnsNullWhenAlertsDisabled() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+        prefs.edit().putLong("alerts_disabled_until", new Date().getTime() + 60_000).commit();
+
+        assertThat(AlertType.get_highest_active_alert(xdrip.getAppContext(), 100)).isNull();
+    }
+
+    // --- toSettings ---
+
+    /** Characterization: toSettings serialises the alert table into the saved_alerts preference. */
+    @Test
+    public void toSettings_writesSavedAlertsPreference() {
+        boolean result = AlertType.toSettings(xdrip.getAppContext());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+        assertThat(result).isTrue();
+        assertThat(prefs.contains("saved_alerts")).isTrue();
+    }
+
+    // --- fromSettings ---
+
+    /** Characterization: fromSettings returns true (no-op) when no saved_alerts string is present. */
+    @Test
+    public void fromSettings_returnsTrueWhenNothingSaved() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+        prefs.edit().putString("saved_alerts", "").commit();
+
+        assertThat(AlertType.fromSettings(xdrip.getAppContext())).isTrue();
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/AlertTypeTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/AlertTypeTest.java
@@ -38,10 +38,15 @@ public class AlertTypeTest extends RobolectricTestWithConfig {
     /** Characterization: returns null while alerts are snoozed via alerts_disabled_until. */
     @Test
     public void get_highest_active_alert_returnsNullWhenAlertsDisabled() {
+        // :: Setup
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
         prefs.edit().putLong("alerts_disabled_until", new Date().getTime() + 60_000).commit();
 
-        assertThat(AlertType.get_highest_active_alert(xdrip.getAppContext(), 100)).isNull();
+        // :: Act
+        AlertType highestActiveAlert = AlertType.get_highest_active_alert(xdrip.getAppContext(), 100);
+
+        // :: Verify
+        assertThat(highestActiveAlert).isNull();
     }
 
     // --- toSettings ---
@@ -49,8 +54,10 @@ public class AlertTypeTest extends RobolectricTestWithConfig {
     /** Characterization: toSettings serialises the alert table into the saved_alerts preference. */
     @Test
     public void toSettings_writesSavedAlertsPreference() {
+        // :: Act
         boolean result = AlertType.toSettings(xdrip.getAppContext());
 
+        // :: Verify
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
         assertThat(result).isTrue();
         assertThat(prefs.contains("saved_alerts")).isTrue();
@@ -61,9 +68,14 @@ public class AlertTypeTest extends RobolectricTestWithConfig {
     /** Characterization: fromSettings returns true (no-op) when no saved_alerts string is present. */
     @Test
     public void fromSettings_returnsTrueWhenNothingSaved() {
+        // :: Setup
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
         prefs.edit().putString("saved_alerts", "").commit();
 
-        assertThat(AlertType.fromSettings(xdrip.getAppContext())).isTrue();
+        // :: Act
+        boolean result = AlertType.fromSettings(xdrip.getAppContext());
+
+        // :: Verify
+        assertThat(result).isTrue();
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/CalibrationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/CalibrationTest.java
@@ -83,6 +83,19 @@ public class CalibrationTest extends RobolectricTestWithConfig {
         assertThat(calibration2.intercept).isWithin(0.001).of(15);
     }
 
+    /**
+     * Characterization: create() reads units/history prefs via
+     * PreferenceManager.getDefaultSharedPreferences() and returns null for out-of-range glucose.
+     * Exercises the second PreferenceManager call site (distinct from initialCalibration above),
+     * locking behaviour across the android.preference → androidx.preference import swap.
+     */
+    @Test
+    public void create_returnsNullWhenGlucoseOutOfRange() {
+        Calibration calibration = Calibration.create(10000, 0, RuntimeEnvironment.application);
+
+        assertThat(calibration).isNull();
+    }
+
     // ===== Internal Helpers ======================================================================
 
     private void addMockBgReading(int raw_data, int minutes, Sensor sensor) {

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/CalibrationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/CalibrationTest.java
@@ -91,8 +91,10 @@ public class CalibrationTest extends RobolectricTestWithConfig {
      */
     @Test
     public void create_returnsNullWhenGlucoseOutOfRange() {
+        // :: Act
         Calibration calibration = Calibration.create(10000, 0, RuntimeEnvironment.application);
 
+        // :: Verify
         assertThat(calibration).isNull();
     }
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/ProfileTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/ProfileTest.java
@@ -56,11 +56,14 @@ public class ProfileTest extends RobolectricTestWithConfig {
      */
     @Test
     public void reloadPreferences_appliesInsulinActionTimeFromDefaultPrefs() {
+        // :: Setup
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
         prefs.edit().putString("xplus_insulin_dia", "5.5").commit();
 
+        // :: Act
         Profile.reloadPreferences();
 
+        // :: Verify
         assertThat(Profile.insulinActionTime(1651949922000L)).isEqualTo(5.5d);
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/ProfileTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/ProfileTest.java
@@ -1,14 +1,28 @@
 package com.eveningoutpost.dexdrip.models;
 
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.profileeditor.BasalRepository;
+import com.eveningoutpost.dexdrip.xdrip;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 public class ProfileTest extends RobolectricTestWithConfig {
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+    }
 
     @Before
     public void before() {
@@ -33,5 +47,20 @@ public class ProfileTest extends RobolectricTestWithConfig {
     @Test
     public void getBasalRatePercentFromAbsoluteTest() {
        assertWithMessage("50% == 1.0U").that(Profile.getBasalRateAbsoluteFromPercent(1651949922000L, 50)).isEqualTo(1.0d);
+    }
+
+    /**
+     * Characterization: the no-arg reloadPreferences() reads defaults through
+     * PreferenceManager.getDefaultSharedPreferences() and applies them (here the insulin action
+     * time). Locks in behaviour across the android.preference → androidx.preference import swap.
+     */
+    @Test
+    public void reloadPreferences_appliesInsulinActionTimeFromDefaultPrefs() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+        prefs.edit().putString("xplus_insulin_dia", "5.5").commit();
+
+        Profile.reloadPreferences();
+
+        assertThat(Profile.insulinActionTime(1651949922000L)).isEqualTo(5.5d);
     }
 }


### PR DESCRIPTION
## What

Category 2 cleanup (Batch 1) of the deprecated-API effort started in #4479: replace
`android.preference.PreferenceManager` with `androidx.preference.PreferenceManager` in 5 files:

- `BestGlucose`
- `BGHistory`
- `models/AlertType`
- `models/Calibration`
- `models/Profile`

Each is a **one-line import swap** — no logic changes. Both `PreferenceManager`s return the
*same* default `SharedPreferences` file (`getDefaultSharedPreferences()`), so the change is
behaviour-preserving. This follows the pattern established and reviewed in #4479 (the
`Agreement` pattern PR).

## Why

`android.preference.*` is deprecated. `Preferences.java` (which is coupled to the
`android.preference.*` *UI* classes) is intentionally **excluded** here — it belongs to the
separate `PreferenceFragmentCompat` migration (Category 3), not this mechanical swap.

## Tests

New / extended characterization tests lock in the behaviour flowing through each file's
`getDefaultSharedPreferences()` usage, so the swap is proven safe:

- `BestGlucoseTest`, `BGHistoryTest` (new)
- `AlertTypeTest` (new — 3 cases)
- `CalibrationTest`, `ProfileTest` (extended)

Full `./gradlew test` suite is green.

### Manual emulator preference-search test (per #4479 review condition)

Verified on `API34_Phone` (Android 14) with a FastDebug build of this branch:

- Settings → search opens; typing `glucose` / `insulin` returns live results with correct
  single- and multi-level breadcrumbs.
- Tapping a nested result navigates into the correct sub-screen (deep hierarchy traversal).
- A no-match term shows a graceful "No results" empty state.
- `adb logcat -b crash` empty — no xDrip crashes; the search indexer walks the full
  preference tree without error.

## Note on `app/build.gradle`

Adds a **test-only** JVM arg `--add-opens=java.base/java.util=ALL-UNNAMED` to the unit-test
task, so Robolectric can build chart-containing Activities (needed for `BGHistoryTest`) under
JDK 17+. This affects the test JVM only — no app/APK behaviour change.

## Screenshots (preference-search test)

| Settings + search icon | Search opened | Search `glucose` |
|---|---|---|
| ![Settings](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch1-search-test/04_prefs.png) | ![Search opened](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch1-search-test/05_search_open.png) | ![glucose results](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch1-search-test/06_search_glucose.png) |

| Nested result navigated | Search `insulin` (deep breadcrumbs) | No-match empty state |
|---|---|---|
| ![nav result](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch1-search-test/07_nav_result.png) | ![insulin results](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch1-search-test/08_search_insulin.png) | ![no results](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch1-search-test/09_search_nomatch.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
