### PR TITLE
chore(deps): remove unused QR-Code-generator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -337,7 +337,6 @@ dependencies {
     implementation 'uk.com.robust-it:cloning:1.9.5'
     implementation 'com.github.amlcurran.showcaseview:library:5.4.3'
     // implementation 'com.itextpdf:itextg:5.5.9'
-    implementation 'com.github.jamorham:QR-Code-generator:d0454644af'
     // Pebble-Trend, needs to be checked if really needed
     //implementation 'com.android.support:multidex:1.0.1'
     implementation 'ar.com.hjg:pngj:2.1.0'


### PR DESCRIPTION
## What

Removes the `com.github.jamorham:QR-Code-generator:d0454644af` dependency, which has **zero source references**.

## Why

QR code generation in xDrip is done via **zxing** (`zxing-android-embedded` / `com.google.zxing:core`) in `QRcodeUtils`. The jamorham nayuki fork exposes the `io.nayuki.qrcodegen.*` package, and a repo-wide search finds no reference to it (`io.nayuki`, `qrcodegen`, `QrSegment` all return nothing). The `QrCode`/`QrCodeFromFile` symbols present in xDrip source are local classes, not this library. Removing it trims the dependency graph and one thing to CVE-scan/maintain.

## Verification

- `grep -rin "io.nayuki\|qrcodegen\|QrSegment" app/src wear/src` → no matches
- `./gradlew :app:assembleFastDebug` ✅ and full `./gradlew test` ✅ (green)
- Resolved-graph diff (`prodReleaseRuntimeClasspath`, before vs after): only the `QR-Code-generator` node leaves the graph. Its single transitive edge (`support-v4:23.4.0` → `androidx.legacy:legacy-support-v4:1.0.0`) was already an overridden duplicate provided by 4 other deps, so no artifact beyond the QR lib itself is removed and no resolved version shifts.

First removal in a small dependency-footprint cleanup series (one dependency per PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)