### PR TITLE
Retiring Android 7

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,10 +89,10 @@ android {
 
     defaultConfig {
         applicationId "com.eveningoutpost.dexdrip"
-        minSdkVersion 24
+        minSdkVersion 26
         // increasing target SDK version can cause compatibility issues with Android 7+
         //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 24
+        targetSdkVersion 26
         // change versionCode only when downgrade should be prevented
         // eg, when data structures are incompatible
         versionCode 1603091400
@@ -225,7 +225,7 @@ android {
             // set minSdkVersion to 21 or higher. When using Android Studio 2.3 or higher,
             // the build automatically avoids legacy multidex when deploying to a device running
             // API level 21 or higher—regardless of what you set as your minSdkVersion.
-            minSdkVersion 24
+            minSdkVersion 26
             versionNameSuffix "-dev"
             buildConfigField "int", "buildVersion", "2021010100"
             buildConfigField "String", "buildUUID", "\"0f79a60a-5616-99be-8eb1-a430edcfd9fd\""

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,7 +110,6 @@
     <application
         android:name=".xdrip"
         android:allowBackup="false"
-        android:appComponentFactory="android.support.v4.app.CoreComponentFactory"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
@@ -118,8 +117,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:requestLegacyExternalStorage="true"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true"
-        tools:replace="android:appComponentFactory">
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".cgm.glupro.GluProActivity"
             android:label="@string/glupro_activity_title"
@@ -332,13 +330,6 @@
             <intent-filter>
                 <action android:name="android.bluetooth.headset.profile.action.CONNECTION_STATE_CHANGED" />
                 <action android:name="android.bluetooth.headset.profile.action.AUDIO_STATE_CHANGED" />
-            </intent-filter>
-        </receiver>
-        <receiver
-            android:name=".wearintegration.ExternalStatusBroadcastReceiver"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.eveningoutpost.dexdrip.ExternalStatusline" />
             </intent-filter>
         </receiver>
         <receiver android:name=".utils.DisconnectReceiver">
@@ -640,14 +631,6 @@
         <receiver android:name=".LibreAlarmReceiver">
             <intent-filter>
                 <action android:name="com.eveningoutpost.dexdrip.FROM_LIBRE_ALARM" />
-            </intent-filter>
-        </receiver>
-        <receiver android:name=".NSEmulatorReceiver">
-            <intent-filter>
-                <action android:name="com.eveningoutpost.dexdrip.NS_EMULATOR" />
-                <action android:name="com.eveningoutpost.dexdrip.OOP2_DECODE_FARM_RESULT" />
-                <action android:name="com.eveningoutpost.dexdrip.OOP2_DECODE_BLE_RESULT" />
-                <action android:name="com.eveningoutpost.dexdrip.OOP2_BLUETOOTH_ENABLE_RESULT" />
             </intent-filter>
         </receiver>
         <receiver android:name=".receivers.aidex.AidexReceiver">

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -3392,11 +3392,10 @@ public class Home extends ActivityWithMenu implements ActivityCompat.OnRequestPe
         new AsyncTask<Void, Void, String>() {
             @Override
             protected String doInBackground(Void... params) {
-                int permissionCheck = ContextCompat.checkSelfPermission(Home.this,
-                        Manifest.permission.READ_EXTERNAL_STORAGE);
-                if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
+                if (ContextCompat.checkSelfPermission(Home.this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED ||
+                        ContextCompat.checkSelfPermission(Home.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
                     ActivityCompat.requestPermissions(Home.this,
-                            new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                            new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE},
                             0);
                     return null;
                 } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiverWrapper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NSEmulatorReceiverWrapper.java
@@ -1,0 +1,32 @@
+package com.eveningoutpost.dexdrip;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Lightweight manifest-registered receiver.
+ *
+ * This keeps the registered receiver tiny until a broadcast is actually received,
+ * then lazily creates and reuses the real receiver.
+ */
+public final class NSEmulatorReceiverWrapper extends BroadcastReceiver {
+
+    private static volatile NSEmulatorReceiver receiverInstance;
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        getReceiverInstance().onReceive(context, intent);
+    }
+
+    private static NSEmulatorReceiver getReceiverInstance() {
+        if (receiverInstance == null) {
+            synchronized (NSEmulatorReceiverWrapper.class) {
+                if (receiverInstance == null) {
+                    receiverInstance = new NSEmulatorReceiver();
+                }
+            }
+        }
+        return receiverInstance;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
@@ -1258,15 +1258,9 @@ public class JoH {
 
     public static boolean setMediaDataSource(final Context context, final MediaPlayer mp, final Uri uri) {
         try {
-            if (uri.toString().startsWith("/")) {
-                UserError.Log.d(TAG, "Setting old style uri: " + uri);
-                mp.setDataSource(context, uri);
-            } else {
-                UserError.Log.d(TAG, "Setting new style uri: " + uri);
-                val pfd = context.getContentResolver().openFileDescriptor(uri, "r");
-                mp.setDataSource(pfd.getFileDescriptor());
-                pfd.close();
-            }
+            if (uri == null || mp == null) return false;
+            // Use the context-aware method for all URIs to satisfy Android 11+ requirements
+            mp.setDataSource(context, uri);
             return true;
         } catch (IOException | NullPointerException | IllegalArgumentException | SecurityException ex) {
             UserError.Log.e(TAG, "setMediaDataSource from uri failed: uri = " + uri.toString(), ex);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ui/NumberGraphic.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ui/NumberGraphic.java
@@ -9,12 +9,12 @@ import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Icon;
-import android.os.Build;
 
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.utilitymodels.ColorCache;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.xdrip;
 
@@ -34,39 +34,25 @@ public class NumberGraphic {
 
     public static void testNotification(String text) {
         {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            final Notification.Builder mBuilder = new Notification.Builder(xdrip.getAppContext(), NotificationChannels.ICON_TEST_CHANNEL);
 
-                final Notification.Builder mBuilder = new Notification.Builder(xdrip.getAppContext());
+            mBuilder.setSmallIcon(Icon.createWithBitmap(getSmallIconBitmap(text)));
 
-                mBuilder.setSmallIcon(Icon.createWithBitmap(getSmallIconBitmap(text)));
+            mBuilder.setContentTitle("Test Number Graphic");
+            mBuilder.setContentText("Check the number is visible");
+            mBuilder.setTimeoutAfter(Constants.SECOND_IN_MS * 30);
+            mBuilder.setOngoing(false);
+            mBuilder.setVibrate(vibratePattern);
 
-                mBuilder.setContentTitle("Test Number Graphic");
-                mBuilder.setContentText("Check the number is visible");
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    mBuilder.setTimeoutAfter(Constants.SECOND_IN_MS * 30);
-                } else {
-                    JoH.runOnUiThreadDelayed(new Runnable() {
-                        @Override
-                        public void run() {
-                            JoH.cancelNotification(Constants.NUMBER_TEXT_TEST_ID);
-                        }
-                    }, Constants.SECOND_IN_MS * 30);
+            int mNotificationId = Constants.NUMBER_TEXT_TEST_ID;
+            final NotificationManager mNotifyMgr = (NotificationManager) xdrip.getAppContext().getSystemService(NOTIFICATION_SERVICE);
+            mNotifyMgr.notify(mNotificationId, mBuilder.build());
+            JoH.runOnUiThreadDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mNotifyMgr.notify(mNotificationId, mBuilder.build());
                 }
-                mBuilder.setOngoing(false);
-                mBuilder.setVibrate(vibratePattern);
-
-                int mNotificationId = Constants.NUMBER_TEXT_TEST_ID;
-                final NotificationManager mNotifyMgr = (NotificationManager) xdrip.getAppContext().getSystemService(NOTIFICATION_SERVICE);
-                mNotifyMgr.notify(mNotificationId, mBuilder.build());
-                JoH.runOnUiThreadDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        mNotifyMgr.notify(mNotificationId, mBuilder.build());
-                    }
-                }, 1000);
-            } else {
-                JoH.static_toast_long("Not supported below Android 6");
-            }
+            }, 1000);
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
@@ -541,7 +541,6 @@ public class AlertPlayer {
                 .setContentIntent(notificationIntent(context, intent))
                 .setLocalOnly(localOnly)
 
-                .setGroup("xDrip level alert")
                 .setPriority(Pref.getBooleanDefaultFalse("high_priority_notifications") ? Notification.PRIORITY_MAX : Notification.PRIORITY_HIGH)
                 .setDeleteIntent(snoozeIntent(context, minsFromStartPlaying));
         if (Pref.getBoolean("show_buttons_in_alerts", true)) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/CollectionServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/CollectionServiceStarter.java
@@ -3,11 +3,9 @@ package com.eveningoutpost.dexdrip.utilitymodels;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.os.PowerManager;
 import android.preference.PreferenceManager;
 
-import com.eveningoutpost.dexdrip.BuildConfig;
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.models.JoH;
@@ -507,16 +505,11 @@ public class CollectionServiceStarter {
 
     @SuppressWarnings("ConstantConditions")
     private void startServiceCompat(final Intent intent) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
-            //    && BuildConfig.targetSDK >= Build.VERSION_CODES.N
-                && ForegroundServiceStarter.shouldRunCollectorInForeground()) {
-            try {
-                Log.d(TAG, String.format("Starting oreo foreground service: %s", intent.getComponent().getClassName()));
-            } catch (NullPointerException e) {
-                Log.d(TAG, "Null pointer exception in startServiceCompat");
-            }
+        try {
+            Log.d(TAG, String.format("Starting foreground service: %s", intent.getComponent().getClassName()));
             mContext.startForegroundService(intent);
-        } else {
+        } catch (Exception e) {
+            // If foreground fails (e.g. app is already in foreground), fall back to standard start
             mContext.startService(intent);
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/ForegroundServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/ForegroundServiceStarter.java
@@ -4,7 +4,6 @@ import android.app.Service;
 import android.content.Context;
 import android.os.Build;
 
-import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
@@ -21,22 +20,14 @@ public class ForegroundServiceStarter {
 
     final private Service mService;
     final private Context mContext;
-    final private boolean run_service_in_foreground;
     //final private Handler mHandler;
 
-
-    public static boolean shouldRunCollectorInForeground() {
-        // Force foreground with Oreo and above
-        return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !Home.get_follower())
-                || Pref.getBoolean("run_service_in_foreground", true);
-    }
 
     public ForegroundServiceStarter(Context context, Service service) {
         mContext = context;
         mService = service;
         //mHandler = new Handler(Looper.getMainLooper());
 
-        run_service_in_foreground = shouldRunCollectorInForeground();
     }
 
 
@@ -45,17 +36,16 @@ public class ForegroundServiceStarter {
             Log.e(TAG, "SERVICE IS NULL - CANNOT START!");
             return;
         }
-        if (run_service_in_foreground) {
-            Log.d(TAG, "should be moving to foreground");
-            // mHandler.post(new Runnable() {
-            //     @Override
-            //     public void run() {
-            // TODO use constants
-            final long end = System.currentTimeMillis() + (60000 * 5);
-            final long start = end - (60000 * 60 * 3) - (60000 * 10);
-            foregroundStatus();
-            Log.d(TAG, "CALLING START FOREGROUND: " + mService.getClass().getSimpleName());
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        Log.d(TAG, "should be moving to foreground");
+        // mHandler.post(new Runnable() {
+        //     @Override
+        //     public void run() {
+        // TODO use constants
+        final long end = System.currentTimeMillis() + (60000 * 5);
+        final long start = end - (60000 * 60 * 3) - (60000 * 10);
+        foregroundStatus();
+        Log.d(TAG, "CALLING START FOREGROUND: " + mService.getClass().getSimpleName());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 /*
                   When is a foreground service not a foreground service?
                   When it's started from the background of course!
@@ -64,26 +54,24 @@ public class ForegroundServiceStarter {
                   service, but only when it isn't re-started with the app open.
                   Even then the restrictions seem to be applied inconsistently!
                  */
-                try {
-                    mService.startForeground(ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext), FOREGROUND_SERVICE_TYPE_MANIFEST);
-                } catch (IllegalArgumentException e) {
-                    UserError.Log.e(TAG, "Got exception trying to use Android 10+ service starting for " + mService.getClass().getSimpleName() + " " + e);
-                    mService.startForeground(ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext));
-                }
-            } else {
+            try {
+                mService.startForeground(ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext), FOREGROUND_SERVICE_TYPE_MANIFEST);
+            } catch (IllegalArgumentException e) {
+                UserError.Log.e(TAG, "Got exception trying to use Android 10+ service starting for " + mService.getClass().getSimpleName() + " " + e);
                 mService.startForeground(ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext));
             }
-
-            //     }
-            // });
+        } else {
+            mService.startForeground(ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext));
         }
+
+        //     }
+        // });
+
     }
 
     public void stop() {
-        if (run_service_in_foreground) {
-            Log.d(TAG, "should be moving out of foreground");
-            mService.stopForeground(true);
-        }
+        Log.d(TAG, "should be moving out of foreground");
+        mService.stopForeground(true);
     }
 
     protected void foregroundStatus() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrations.java
@@ -173,6 +173,11 @@ public class IdempotentMigrations {
         Pref.setBoolean("bluetooth_frequent_reset", false);
         Pref.setBoolean("use_transmiter_pl_bluetooth", false);
         Pref.setBoolean("use_rfduino_bluetooth", false);
+        Pref.setBoolean("use_notification_channels", true);
+        Pref.setBoolean("run_service_in_foreground", true);
+        Pref.setBoolean("notification_channels_grouping", false);
+        Pref.setBoolean("use_number_icon_large", false);
+        Pref.setBoolean("number_icon_large_arrow", false);
 
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
@@ -48,6 +48,7 @@ public class NotificationChannels {
     public static final String BG_PERSISTENT_HIGH_CHANNEL = "bgPersistentHighChannel";
     public static final String CALIBRATION_CHANNEL = "calibrationChannel";
     public static final String ONGOING_CHANNEL = "ongoingChannel";
+    public static final String ICON_TEST_CHANNEL = "numberIconTestChannel";
 
     // get a localized string for each channel / group name
     public static String getString(String id) {
@@ -167,6 +168,7 @@ public class NotificationChannels {
 
         final Notification temp = wip.build();
         if (temp.getChannelId() == null) return null;
+        final int importance = NotificationManager.IMPORTANCE_HIGH;
 
         // create generic audio attributes
         final AudioAttributes generic_audio = new AudioAttributes.Builder()
@@ -182,7 +184,6 @@ public class NotificationChannels {
 
 
         // mirror the notification parameters in the channel
-        template.setGroup(temp.getChannelId());
 
         val mNotification = getNotificationFromInsideBuilder(wip);
         if (mNotification != null) {
@@ -197,20 +198,17 @@ public class NotificationChannels {
 
         // get a nice string to identify the hash
         final String mhash = my_text_hash(template);
+        final String channelId = temp.getChannelId();
+        final String baseName = getBaseDisplayName(channelId);
 
         // create another notification channel using the hash because id is immutable
         final NotificationChannel channel = new NotificationChannel(
                 template.getId() + mhash,
-                getString(temp.getChannelId()) + mhash,
-                NotificationManager.IMPORTANCE_DEFAULT);
+                baseName + mhash,
+                importance); // Change from IMPORTANCE_DEFAULT
 
         // mirror the settings from the previous channel
         channel.setSound(template.getSound(), generic_audio);
-        if (addChannelGroup()) {
-            channel.setGroup(template.getGroup());
-        } else {
-            channel.setGroup(channel.getId());
-        }
         channel.setDescription(template.getDescription());
         channel.setVibrationPattern(template.getVibrationPattern());
 
@@ -222,8 +220,6 @@ public class NotificationChannels {
 
         template.setDescription(temp.getChannelId() + " " + wip.hashCode());
 
-        // create a group to hold this channel if one doesn't exist or update text
-        getNotifManager().createNotificationChannelGroup(new NotificationChannelGroup(channel.getGroup(), getString(channel.getGroup())));
         // create this channel if it doesn't exist or update text
         getNotifManager().createNotificationChannel(channel);
         return mNotification != null ? channel : null; // Note we return null to fallback old behavior if we can't get reflected access
@@ -231,60 +227,34 @@ public class NotificationChannels {
 
     @TargetApi(26)
     public static NotificationChannel getChan(Notification.Builder wip) {
+        /*
+        This method should only be used for the ongoing notification.
+        No alert should use this method.
+         */
+        final String id = ONGOING_CHANNEL;
+        final int importance = Pref.getBooleanDefaultFalse("use_number_icon") ?
+                NotificationManager.IMPORTANCE_DEFAULT : NotificationManager.IMPORTANCE_LOW;
 
-        final Notification temp = wip.build();
-        if (temp.getChannelId() == null) return null;
-
-        // create generic audio attributes
-        final AudioAttributes generic_audio = new AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                .setContentType(AudioAttributes.CONTENT_TYPE_UNKNOWN)
-                .build();
-
-        // create notification channel for hashing purposes from the existing notification builder
-        NotificationChannel template = new NotificationChannel(
-                temp.getChannelId(),
-                getString(temp.getChannelId()),
-                NotificationManager.IMPORTANCE_DEFAULT);
-
-
-        // mirror the notification parameters in the channel
-        template.setGroup(temp.getChannelId());
-        template.setVibrationPattern(temp.vibrate);
-        template.setSound(temp.sound, generic_audio);
-        template.setLightColor(temp.ledARGB);
-        if ((temp.ledOnMS != 0) && (temp.ledOffMS != 0))
-            template.enableLights(true); // weird how this doesn't work like vibration pattern
-        template.setDescription(temp.getChannelId() + " " + wip.hashCode());
-
-        // get a nice string to identify the hash
-        final String mhash = my_text_hash(template);
-
-        // create another notification channel using the hash because id is immutable
+        // Simplify: Create the channel directly using the static ID
         final NotificationChannel channel = new NotificationChannel(
-                template.getId() + mhash,
-                getString(temp.getChannelId()) + mhash,
-                NotificationManager.IMPORTANCE_DEFAULT);
+                id,
+                getBaseDisplayName(id),
+                importance);
 
-        // mirror the settings from the previous channel
-        channel.setSound(template.getSound(), generic_audio);
-        if (addChannelGroup()) {
-            channel.setGroup(template.getGroup());
-        } else {
-            channel.setGroup(channel.getId());
-        }
-        channel.setDescription(template.getDescription());
-        channel.setVibrationPattern(template.getVibrationPattern());
-        template.setLightColor(temp.ledARGB);
-        if ((temp.ledOnMS != 0) && (temp.ledOffMS != 0))
-            template.enableLights(true); // weird how this doesn't work like vibration pattern
-        template.setDescription(temp.getChannelId() + " " + wip.hashCode());
+        // Ongoing service should always be silent and not vibrate
+        channel.setSound(null, null);
+        channel.enableVibration(false);
+        channel.setShowBadge(false);
 
-        // create a group to hold this channel if one doesn't exist or update text
-        getNotifManager().createNotificationChannelGroup(new NotificationChannelGroup(channel.getGroup(), getString(channel.getGroup())));
-        // create this channel if it doesn't exist or update text
         getNotifManager().createNotificationChannel(channel);
-        return  channel;
+        return channel;
+    }
+
+    private static String getBaseDisplayName(String channelId) {
+        if ("bgAlertChannel".equals(channelId)) {
+            return "Glucose Level Alert";
+        }
+        return getString(channelId);
     }
 
     static Notification getNotificationFromInsideBuilder(final NotificationCompat.Builder builder) {
@@ -299,6 +269,16 @@ public class NotificationChannels {
             }
             return null;
         }
+    }
+
+    public static void setupTestChannel() {
+        NotificationChannel channel = new NotificationChannel(
+                ICON_TEST_CHANNEL,
+                "xDrip Icon Test",
+                NotificationManager.IMPORTANCE_DEFAULT);
+        channel.enableVibration(true);
+        channel.setSound(null, null); // Keep it silent
+        getNotifManager().createNotificationChannel(channel);
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
@@ -155,14 +155,6 @@ public class NotificationChannels {
 
     }
 
-    private static boolean addChannelGroup() {
-        // If notifications are grouped, the BG number icon doesn't update
-        if (Pref.getBooleanDefaultFalse("use_number_icon")) {
-            return false;
-        }
-        return Pref.getBooleanDefaultFalse("notification_channels_grouping");
-    }
-
     @TargetApi(26)
     public static NotificationChannel getChan(NotificationCompat.Builder wip) {
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -38,7 +38,6 @@ import com.eveningoutpost.dexdrip.models.Calibration;
 import com.eveningoutpost.dexdrip.models.CalibrationRequest;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.Sensor;
-import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import com.eveningoutpost.dexdrip.models.UserNotification;
 import com.eveningoutpost.dexdrip.R;
@@ -599,23 +598,10 @@ public class Notifications extends IntentService {
         //final NotificationCompat.Builder b = new NotificationCompat.Builder(mContext); // temporary fix until ONGOING CHANNEL is silent by default on android 8+
         //final Notification.Builder b = new Notification.Builder(mContext); // temporary fix until ONGOING CHANNEL is silent by default on android 8+
         final Notification.Builder b;
-        if (useOngoingChannel() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            b = new Notification.Builder(mContext, NotificationChannels.ONGOING_CHANNEL);
-            b.setSound(null);
-        } else {
-            b = new Notification.Builder(mContext);
-        }
+        b = new Notification.Builder(mContext, NotificationChannels.ONGOING_CHANNEL);
         b.setOngoing(Pref.getBoolean("use_proper_ongoing", true));
-        try {
-            b.setGroup("xDrip ongoing");
-        } catch (Exception e) {
-            //
-        }
         b.setVisibility(Pref.getBooleanDefaultFalse("public_notifications") ? Notification.VISIBILITY_PUBLIC : Notification.VISIBILITY_PRIVATE);
-        b.setCategory(NotificationCompat.CATEGORY_STATUS);
-        if (Pref.getBooleanDefaultFalse("high_priority_notifications")) {
-            b.setPriority(Notification.PRIORITY_HIGH);
-        }
+        b.setCategory(Notification.CATEGORY_STATUS);
         final BestGlucose.DisplayGlucose dg = (use_best_glucose) ? BestGlucose.getDisplayGlucose() : null;
         final boolean use_color_in_notification = false; // could be preference option
         final SpannableString titleString = new SpannableString(lastReading == null ? "BG Reading Unavailable" : (dg != null) ? (dg.spannableString(dg.unitized + " " + dg.delta_arrow,use_color_in_notification))

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -568,12 +568,6 @@ public class Notifications extends IntentService {
                 .build();
     }*/
 
-    private boolean useOngoingChannel() {
-        return (Pref.getBooleanDefaultFalse("use_notification_channels") &&
-                Pref.getBooleanDefaultFalse("ongoing_notification_channel") &&
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O);
-    }
-
     //@TargetApi(Build.VERSION_CODES.O)
     public synchronized Notification createOngoingNotification(BgGraphBuilder bgGraphBuilder, Context context) {
         mContext = context;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotification.java
@@ -1,37 +1,42 @@
 package com.eveningoutpost.dexdrip.utilitymodels;
 
-import android.annotation.TargetApi;
 import android.app.Notification;
-import android.os.Build;
+
+import com.eveningoutpost.dexdrip.models.UserError;
 
 /*
  * Created by jwoglom on 5/17/2018
  * <p>
  * Wrapper for android.app.Notification.Builder that adds the necessary notification
  * channel ID if enabled. Identical functionality-wise to XdripNotificationCompat.
+
+ * This is now dedicated to the ongoing notification
+ * No other notification should use this class.
  */
 
 public class XdripNotification {
 
-    @TargetApi(Build.VERSION_CODES.O)
+    private final static String TAG = XdripNotification.class.getSimpleName();
+
     public static Notification build(Notification.Builder builder) {
-        if ((Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O)) {
-            if (Pref.getBooleanDefaultFalse("use_notification_channels")) {
-                // get dynamic channel based on contents of the builder
-                try {
-                    final String id = NotificationChannels.getChan(builder).getId();
-                    builder.setChannelId(id);
-                } catch (NullPointerException e) {
-                    //noinspection ConstantConditions
-                    builder.setChannelId(null);
-                }
-            } else {
-                //noinspection ConstantConditions
-                builder.setChannelId(null);
-            }
-            return builder.build();
-        } else {
-            return builder.build(); // standard pre-oreo behaviour
+        String id;
+        try {
+            // This calls the simplified getChan in NotificationChannels.java
+            id = NotificationChannels.getChan(builder).getId();
+        } catch (Exception e) {
+            id = NotificationChannels.ONGOING_CHANNEL;
         }
+        builder.setChannelId(id);
+
+        builder.setGroup(null);
+        builder.setGroupSummary(false);
+        builder.setCategory(Notification.CATEGORY_STATUS);
+        builder.setWhen(0);
+        builder.setShowWhen(false);
+        builder.setOnlyAlertOnce(true);
+
+        final Notification n = builder.build();
+        UserError.Log.d(TAG, "Notif: chan=" + n.getChannelId() + " group=" + n.getGroup() + " summary=" + ((n.flags & Notification.FLAG_GROUP_SUMMARY) != 0));
+        return n;
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompat.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompat.java
@@ -1,9 +1,9 @@
 package com.eveningoutpost.dexdrip.utilitymodels;
 
-import android.annotation.TargetApi;
 import android.app.Notification;
-import android.os.Build;
 import androidx.core.app.NotificationCompat;
+
+import com.eveningoutpost.dexdrip.models.UserError;
 
 /**
  * Created by jamorham on 18/10/2017.
@@ -11,26 +11,30 @@ import androidx.core.app.NotificationCompat;
 
 public class XdripNotificationCompat extends NotificationCompat {
 
-    @TargetApi(Build.VERSION_CODES.O)
+    private final static String TAG = XdripNotificationCompat.class.getSimpleName();
+
     public static Notification build(NotificationCompat.Builder builder) {
-        if ((Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O)) {
-            if (Pref.getBooleanDefaultFalse("use_notification_channels")) {
-                // get dynamic channel based on contents of the builder
-                try {
-                    final String id = NotificationChannels.getChan(builder).getId();
-                    builder.setChannelId(id);
-                } catch (NullPointerException e) {
-                    //noinspection ConstantConditions
-                    builder.setChannelId(null);
-                }
-            } else {
-                //noinspection ConstantConditions
-                builder.setChannelId(null);
-            }
-            return builder.build();
-        } else {
-            return builder.build(); // standard pre-oreo behaviour
+        String id;
+        try {
+            id = NotificationChannels.getChan(builder).getId();
+        } catch (Exception e) {
+            // Fallback to generic alert channel if the guesser fails
+            id = NotificationChannels.BG_ALERT_CHANNEL;
         }
+        builder.setChannelId(id);
+
+        // Ensure alerts are independent and not summaries
+        builder.setGroup(null);
+        builder.setGroupSummary(false);
+
+        builder.setCategory(NotificationCompat.CATEGORY_ALARM);
+
+        final Notification n = builder.build();
+
+        UserError.Log.d(TAG, "NotifCompat: chan=" + id +
+                " group=" + NotificationCompat.getGroup(n) +
+                " summary=" + ((n.flags & Notification.FLAG_GROUP_SUMMARY) != 0));
+
+        return n;
     }
 }
-

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/WakeLockTrampoline.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/framework/WakeLockTrampoline.java
@@ -5,13 +5,10 @@ import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 import android.util.SparseArray;
 
-import com.eveningoutpost.dexdrip.BuildConfig;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError;
-import com.eveningoutpost.dexdrip.utilitymodels.ForegroundServiceStarter;
 import com.eveningoutpost.dexdrip.xdrip;
 
 import java.util.HashMap;
@@ -63,18 +60,12 @@ public class WakeLockTrampoline extends BroadcastReceiver {
 
         ComponentName startResult;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
-            //    && BuildConfig.targetSDK >= Build.VERSION_CODES.N
-                && ForegroundServiceStarter.shouldRunCollectorInForeground()) {
-            try {
-                UserError.Log.d(TAG, String.format("Starting oreo foreground service: %s", serviceIntent.getComponent().getClassName()));
-            } catch (NullPointerException e) {
-                UserError.Log.d(TAG, "Null pointer exception in startServiceCompat");
-            }
-            startResult = context.startForegroundService(serviceIntent);
-        } else {
-            startResult = context.startService(serviceIntent);
+        try {
+            UserError.Log.d(TAG, String.format("Starting oreo foreground service: %s", serviceIntent.getComponent().getClassName()));
+        } catch (NullPointerException e) {
+            UserError.Log.d(TAG, "Null pointer exception in startServiceCompat");
         }
+        startResult = context.startForegroundService(serviceIntent);
         if (D) UserError.Log.d(TAG, "Start result: " + startResult);
 
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusBroadcastReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusBroadcastReceiver.java
@@ -1,10 +1,8 @@
 package com.eveningoutpost.dexdrip.wearintegration;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-
-
-import androidx.legacy.content.WakefulBroadcastReceiver;
 
 import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
@@ -12,7 +10,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 /**
  * Created by adrian on 14/02/16.
  */
-public class ExternalStatusBroadcastReceiver extends WakefulBroadcastReceiver {
+public class ExternalStatusBroadcastReceiver extends BroadcastReceiver {
 
 
     private static final String TAG = ExternalStatusBroadcastReceiver.class.getSimpleName();
@@ -20,9 +18,10 @@ public class ExternalStatusBroadcastReceiver extends WakefulBroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (Pref.getBoolean("accept_external_status", true)) {
-            startWakefulService(context, new Intent(context, ExternalStatusService.class)
+            Intent serviceIntent = new Intent(context, ExternalStatusService.class)
                     .setAction(ExternalStatusService.ACTION_NEW_EXTERNAL_STATUSLINE)
-                    .putExtras(intent));
+                    .putExtras(intent);
+            context.startForegroundService(serviceIntent);
         } else {
             UserError.Log.d(TAG, "Not accepting external status line due to preference switch");
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusBroadcastReceiverWrapper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusBroadcastReceiverWrapper.java
@@ -1,0 +1,32 @@
+package com.eveningoutpost.dexdrip.wearintegration;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Lightweight manifest-registered receiver.
+ *
+ * This keeps the registered receiver tiny until a broadcast is actually received,
+ * then lazily creates and reuses the real receiver.
+ */
+public class ExternalStatusBroadcastReceiverWrapper extends BroadcastReceiver {
+
+    private static volatile ExternalStatusBroadcastReceiver receiverInstance;
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        getReceiverInstance().onReceive(context, intent);
+    }
+
+    private static ExternalStatusBroadcastReceiver getReceiverInstance() {
+        if (receiverInstance == null) {
+            synchronized (ExternalStatusBroadcastReceiverWrapper.class) {
+                if (receiverInstance == null) {
+                    receiverInstance = new ExternalStatusBroadcastReceiver();
+                }
+            }
+        }
+        return receiverInstance;
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
@@ -1,16 +1,17 @@
 package com.eveningoutpost.dexdrip.wearintegration;
 
-import android.app.IntentService;
+import android.app.Notification;
 import android.content.Intent;
-import androidx.annotation.NonNull;
-import androidx.legacy.content.WakefulBroadcastReceiver;
+import android.os.IBinder;
 
+import androidx.annotation.NonNull;
 
 import com.eveningoutpost.dexdrip.models.APStatus;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.NewDataObserver;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
 
 import java.util.regex.Pattern;
@@ -20,7 +21,7 @@ import lombok.val;
 /**
  * Created by adrian on 14/02/16.
  */
-public class ExternalStatusService extends IntentService {
+public class ExternalStatusService extends android.app.Service {
     //constants
     static final String EXTERNAL_STATUS_STORE = "external-status-store";
     static final String EXTERNAL_STATUS_STORE_TIME = "external-status-store-time";
@@ -30,9 +31,32 @@ public class ExternalStatusService extends IntentService {
     private static final int MAX_LEN = 70;
     private final static String TAG = ExternalStatusService.class.getSimpleName();
 
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Notification.Builder builder = new Notification.Builder(this,
+                NotificationChannels.ONGOING_CHANNEL);
+
+        builder.setContentTitle("xDrip External Status")
+                .setSmallIcon(com.eveningoutpost.dexdrip.R.drawable.ic_launcher);
+
+        startForeground(124, builder.build());
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null) {
+            final String action = intent.getAction();
+            if (ACTION_NEW_EXTERNAL_STATUSLINE.equals(action)) {
+                final String statusLine = intent.getStringExtra(EXTRA_STATUSLINE);
+                update(JoH.tsl(), statusLine, true);
+            }
+        }
+        stopSelf();
+        return START_NOT_STICKY;
+    }
+
     public ExternalStatusService() {
-        super("ExternalStatusService");
-        setIntentRedelivery(true);
     }
 
     private static boolean isCurrent(long timestamp) {
@@ -57,22 +81,8 @@ public class ExternalStatusService extends IntentService {
     }
 
     @Override
-    protected void onHandleIntent(Intent intent) {
-
-        if (intent == null)
-            return;
-
-        try {
-            final String action = intent.getAction();
-            if (action == null) return;
-
-            if (ACTION_NEW_EXTERNAL_STATUSLINE.equals(action)) {
-                final String statusLine = intent.getStringExtra(EXTRA_STATUSLINE);
-                update(JoH.tsl(), statusLine, true);
-            }
-        } finally {
-            WakefulBroadcastReceiver.completeWakefulIntent(intent);
-        }
+    public IBinder onBind(Intent intent) {
+        return null;
     }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.IBinder;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.eveningoutpost.dexdrip.models.APStatus;
 import com.eveningoutpost.dexdrip.models.JoH;
@@ -13,7 +14,9 @@ import com.eveningoutpost.dexdrip.NewDataObserver;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
+import com.eveningoutpost.dexdrip.utils.jobs.BackgroundQueue;
 
+import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
 
 import lombok.val;
@@ -30,6 +33,13 @@ public class ExternalStatusService extends android.app.Service {
     //public static final String RECEIVER_PERMISSION = "com.eveningoutpost.dexdrip.permissions.RECEIVE_EXTERNAL_STATUSLINE";
     private static final int MAX_LEN = 70;
     private final static String TAG = ExternalStatusService.class.getSimpleName();
+
+    // onStartCommand runs on the main thread; update() does synchronous SQLite I/O, so it is
+    // dispatched here. BackgroundQueue is xDrip's sequential background processor, so it preserves
+    // the ordering the old IntentService gave us (avoids overlapping broadcasts racing
+    // createEfficientRecord()'s read-then-write).
+    @VisibleForTesting
+    static Executor dispatchExecutor = BackgroundQueue::post;
 
     @Override
     public void onCreate() {
@@ -49,10 +59,15 @@ public class ExternalStatusService extends android.app.Service {
             final String action = intent.getAction();
             if (ACTION_NEW_EXTERNAL_STATUSLINE.equals(action)) {
                 final String statusLine = intent.getStringExtra(EXTRA_STATUSLINE);
-                update(JoH.tsl(), statusLine, true);
+                final long timestamp = JoH.tsl(); // capture arrival time on the calling thread
+                dispatchExecutor.execute(() -> {
+                    update(timestamp, statusLine, true);
+                    stopSelf(startId);
+                });
+                return START_NOT_STICKY;
             }
         }
-        stopSelf();
+        stopSelf(startId);
         return START_NOT_STICKY;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.preference.PreferenceManager;
@@ -22,6 +23,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.BgGraphBuilder;
 import com.eveningoutpost.dexdrip.utilitymodels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.utilitymodels.ColorCache;
 import com.eveningoutpost.dexdrip.utilitymodels.IdempotentMigrations;
+import com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels;
 import com.eveningoutpost.dexdrip.utilitymodels.PlusAsyncExecutor;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utilitymodels.VersionTracker;
@@ -103,6 +105,14 @@ public class xdrip extends Application {
         JoH.ratelimit("policy-never", 3600); // don't on first load
         new IdempotentMigrations(getApplicationContext()).performAll();
 
+        IntentFilter externalFilter = new IntentFilter("com.eveningoutpost.dexdrip.ExternalStatusline");
+        registerReceiver(new com.eveningoutpost.dexdrip.wearintegration.ExternalStatusBroadcastReceiver(), externalFilter);
+        IntentFilter bgFilter = new IntentFilter();
+        bgFilter.addAction("com.eveningoutpost.dexdrip.NS_EMULATOR");
+        bgFilter.addAction("com.eveningoutpost.dexdrip.OOP2_DECODE_FARM_RESULT");
+        bgFilter.addAction("com.eveningoutpost.dexdrip.OOP2_DECODE_BLE_RESULT");
+        bgFilter.addAction("com.eveningoutpost.dexdrip.OOP2_BLUETOOTH_ENABLE_RESULT");
+        registerReceiver(new NSEmulatorReceiver(), bgFilter);
 
         JobManager.create(this).addJobCreator(new XDripJobCreator());
         DailyJob.schedule();
@@ -133,6 +143,7 @@ public class xdrip extends Application {
         PluggableCalibration.invalidateCache();
         Poller.init();
         BgGraphBuilder.setLogging();
+        NotificationChannels.setupTestChannel();
     }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
@@ -35,6 +35,7 @@ import com.eveningoutpost.dexdrip.watch.lefun.LeFunEntry;
 import com.eveningoutpost.dexdrip.watch.miband.MiBandEntry;
 import com.eveningoutpost.dexdrip.watch.thinjam.BlueJayEntry;
 import com.eveningoutpost.dexdrip.services.broadcastservice.BroadcastEntry;
+import com.eveningoutpost.dexdrip.wearintegration.ExternalStatusBroadcastReceiverWrapper;
 import com.eveningoutpost.dexdrip.webservices.XdripWebService;
 import com.evernote.android.job.JobManager;
 
@@ -106,13 +107,13 @@ public class xdrip extends Application {
         new IdempotentMigrations(getApplicationContext()).performAll();
 
         IntentFilter externalFilter = new IntentFilter("com.eveningoutpost.dexdrip.ExternalStatusline");
-        registerReceiver(new com.eveningoutpost.dexdrip.wearintegration.ExternalStatusBroadcastReceiver(), externalFilter);
+        registerReceiver(new ExternalStatusBroadcastReceiverWrapper(), externalFilter);
         IntentFilter bgFilter = new IntentFilter();
         bgFilter.addAction("com.eveningoutpost.dexdrip.NS_EMULATOR");
         bgFilter.addAction("com.eveningoutpost.dexdrip.OOP2_DECODE_FARM_RESULT");
         bgFilter.addAction("com.eveningoutpost.dexdrip.OOP2_DECODE_BLE_RESULT");
         bgFilter.addAction("com.eveningoutpost.dexdrip.OOP2_BLUETOOTH_ENABLE_RESULT");
-        registerReceiver(new NSEmulatorReceiver(), bgFilter);
+        registerReceiver(new NSEmulatorReceiverWrapper(), bgFilter);
 
         JobManager.create(this).addJobCreator(new XDripJobCreator());
         DailyJob.schedule();

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1538,11 +1538,6 @@
                     android:key="collector_in_foreground"
                     android:title="@string/title_collector_in_foreground">
                     <CheckBoxPreference
-                        android:defaultValue="true"
-                        android:key="run_service_in_foreground"
-                        android:summary="@string/shows_a_persistent_notification"
-                        android:title="@string/run_collector_in_foreground" />
-                    <CheckBoxPreference
                         android:defaultValue="false"
                         android:key="compact_persistent_notification"
                         android:summary="@string/summary_compact_ongoing_notification"

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -115,12 +115,6 @@
                     android:title="@string/title_use_notification_channels">
                     <CheckBoxPreference
                         android:defaultValue="false"
-                        android:key="use_notification_channels"
-                        android:summary="@string/summary_use_notification_channels"
-                        android:title="@string/title_use_notification_channels" />
-                    <CheckBoxPreference
-                        android:defaultValue="false"
-                        android:dependency="use_notification_channels"
                         android:key="ongoing_notification_channel"
                         android:summary="@string/summary_ongoing_notification_channel"
                         android:title="@string/title_ongoing_notification_channel" />
@@ -130,12 +124,6 @@
                         android:key="ongoing_notification_aodchipstyle"
                         android:summary="Display notification chip and lockscreen notification. Android 16+ only"
                         android:title="Use AOD chip style" />
-                    <CheckBoxPreference
-                        android:defaultValue="false"
-                        android:dependency="use_notification_channels"
-                        android:key="notification_channels_grouping"
-                        android:summary="@string/summary_notification_channels_grouping"
-                        android:title="@string/title_notification_channels_grouping" />
                 </PreferenceScreen>
 
                 <PreferenceScreen

--- a/app/src/main/res/xml/xdrip_plus_prefs.xml
+++ b/app/src/main/res/xml/xdrip_plus_prefs.xml
@@ -750,22 +750,6 @@
                     android:switchTextOff="@string/short_off_text_for_switches"
                     android:switchTextOn="@string/short_on_text_for_switches"
                     android:title="@string/title_use_number_icon" />
-                <SwitchPreference
-                    android:defaultValue="false"
-                    android:dependency="number_icon_tested"
-                    android:key="use_number_icon_large"
-                    android:summary="@string/summary_use_number_icon_large"
-                    android:switchTextOff="@string/short_off_text_for_switches"
-                    android:switchTextOn="@string/short_on_text_for_switches"
-                    android:title="@string/title_use_number_icon_large" />
-                <SwitchPreference
-                    android:defaultValue="false"
-                    android:dependency="use_number_icon_large"
-                    android:key="number_icon_large_arrow"
-                    android:summary="@string/summary_number_icon_large_arrow"
-                    android:switchTextOff="@string/short_off_text_for_switches"
-                    android:switchTextOn="@string/short_on_text_for_switches"
-                    android:title="@string/title_number_icon_large_arrow" />
             </PreferenceScreen>
             <SwitchPreference
                 android:defaultValue="false"

--- a/app/src/test/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusServiceTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusServiceTest.java
@@ -9,17 +9,55 @@ import static com.eveningoutpost.dexdrip.wearintegration.ExternalStatusService.g
 import static com.eveningoutpost.dexdrip.wearintegration.ExternalStatusService.getTBRInt;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import android.app.Service;
+import android.content.Intent;
+
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
 
+import org.junit.After;
 import org.junit.Test;
+import org.robolectric.Robolectric;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
 
 import lombok.val;
 
 // jamorham
 
 public class ExternalStatusServiceTest extends RobolectricTestWithConfig {
+
+    private final Executor originalDispatchExecutor = ExternalStatusService.dispatchExecutor;
+
+    @After
+    public void restoreDispatchExecutor() {
+        ExternalStatusService.dispatchExecutor = originalDispatchExecutor;
+    }
+
+    /**
+     * Off {@code IntentService}, {@code onStartCommand} runs on the main thread. The status update
+     * does synchronous SQLite I/O, so it must be handed to the background executor rather than run
+     * inline on the calling thread. This captures the scheduled work without running it to prove it
+     * is deferred.
+     */
+    @Test
+    public void onStartCommandDefersStatusUpdateToExecutor() {
+        val scheduled = new ArrayList<Runnable>();
+        ExternalStatusService.dispatchExecutor = scheduled::add;
+
+        val intent = new Intent(ExternalStatusService.ACTION_NEW_EXTERNAL_STATUSLINE);
+        val service = Robolectric.buildService(ExternalStatusService.class, intent).create().get();
+
+        val result = service.onStartCommand(intent, 0, 42);
+
+        assertWithMessage("status update must be handed to the executor, not executed inline on the calling thread")
+                .that(scheduled).hasSize(1);
+        assertWithMessage("service should not be sticky")
+                .that(result).isEqualTo(Service.START_NOT_STICKY);
+    }
 
     final String tbr1 =  "Loop Disabled\n10% 0.55U 0g"; // typical
     final String tbr2 =  "Loop Disabled\n999% 15% 0.55U 0g"; // weird

--- a/libglupro/build.gradle
+++ b/libglupro/build.gradle
@@ -11,8 +11,8 @@ android {
     compileSdkVersion 34
 
     defaultConfig {
-        minSdkVersion 24
-        targetSdkVersion 24
+        minSdkVersion 26
+        targetSdkVersion 26
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/libkeks/build.gradle
+++ b/libkeks/build.gradle
@@ -11,8 +11,8 @@ android {
     compileSdkVersion 34
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 24
+        minSdkVersion 26
+        targetSdkVersion 26
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/localeapi/build.gradle
+++ b/localeapi/build.gradle
@@ -3,8 +3,8 @@ android {
     compileSdkVersion 34
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 23
+        minSdkVersion 26
+        targetSdkVersion 26
         multiDexEnabled false
     }
 


### PR DESCRIPTION
This is a cleaned up version of a previous PR that I have now closed: https://github.com/NightscoutFoundation/xDrip/pull/4525  
<br/>  
  
---  
  
**Why we need this**  
We need to use newer packages and tools.  So much changes with Android 8 and a lot of very important functions will be affected in xDrip.  That's why we have delayed this for so long.   But, I feel the time has come that we should go ahead and retire Android 7.  I am not very happy forcing users to go our and buy phones.  But, I feel we have delayed this long enough.  
<br/>  
  
---  
  
**Changes to the UI and functionality**  

| Before | After |  
| ------- | ------ |  
| <img width="269" height="310" alt="Screenshot_20260703-092820" src="https://github.com/user-attachments/assets/a390a61c-4d74-4287-810f-643e91f899c1" /> | <img width="269" height="307" alt="Screenshot_20260703-105809" src="https://github.com/user-attachments/assets/50ff17b9-73be-4b8b-85ec-b7c97e0d8e0e" /> |  
| <img width="269" height="228" alt="Screenshot_20260703-120032" src="https://github.com/user-attachments/assets/8ac5a1a9-0fa8-43d3-ac17-10d4d80e5044" /> | <img width="269" height="228" alt="Screenshot_20260703-112654" src="https://github.com/user-attachments/assets/e59f1df9-878a-4ab1-a612-67bb626b2fe9" /> |  
| <img width="269" height="419" alt="Screenshot_20260703-093022" src="https://github.com/user-attachments/assets/bc2453ae-4c2d-4918-b479-658cf1761bb8" /> | <img width="269" height="420" alt="Screenshot_20260703-113650" src="https://github.com/user-attachments/assets/66025744-4ad3-4426-a7b0-41bd5c7de881" /> |  

  
<br/>  

**Why is the notification grouping option removed?**  
Verifications take a very long time.  Every additional option means we have to run the entire verification tests one more time.  
Your alert notification will not be grouped with the ongoing notification.  There may be an exception that I will cover in detail below.  
If your persistent high alert and high alert trigger together, they will be grouped together.  Forcing these two not to be grouped would make this PR considerably more complicated than it already is.  
  
**Why is the option to run the collector in the foreground removed?**  
I don't know why there may be a need to disable this.  Please tell me if you believe there is a legitimate case when you need to disable it.  
  
**Why is the large number icon and arrow in the ongoing notification option removed?**  
These options have not been operational for 6 years: https://github.com/NightscoutFoundation/xDrip/discussions/4590  
If we want to fix this feature and bring it back, we can.  It has to be done in a separate PR.  
  
<br/>  
  
---  
  
**Android 11 issue**  
https://github.com/NightscoutFoundation/xDrip/issues/1503  
This PR happens to fix the problem on my Android 11 phone.  
I will suggest updating to the corresponding release after merge in that issue as a possible solution.   
  
<br/>  
  
---  
  
**Tests**  
  
This has an impact on too many parameters.  It is possible that I have not seen all the impacts.  Therefore, I wish for this to be tested by others as well before we merge it.  
  
We cannot have a release that causes an alert to become silent or use a different custom sound file.  
  
To test the alerts, I have used the fake data source set to run fast.  This would have it go through a full cycle in about 1 hour and 15 minutes.  
A user could have notification channels enabled or disabled right now.  For that reason, I had to test both conditions.  

If a user decides to go back to an older release, their alerts should not go silent or use a different custom sound file.   That has been tested as well.  

I have used Pixel 6a for all of the tests.
I have also run tests with a Motorola Android 11.
I have also run some tests with a Motorola Android 8.

I am using this as my active xDrip on Pixel 10a running Android 17.  It is collecting directly from G7.  It is uploading to Nightscout and Tidepool and broadcasting to AAPS.  
<br/>  
  
---  
  
**Number icon in notification area and grouping**  
Android 16 groups notifications from an app if it decides that the app generates too many notifications.  

This PR avoids that grouping as long as you do not enable "Number icon in notification area".
But, if you enable that feature, Android 16 may still group the xDrip notifications if the frequency is higher than a certain value.  
I can cause this in my tests when I set the fake data source to fast and enable enough notifications to cause about one notification every 10 minutes.
But, the grouping ends if the frequency drops below one alert per 30 minutes.  
<br/>  
  
---  
  
**Preparing the users**  
I will make an announcement on facebook as well as in our discussions.
Users should be aware that after this update, notification channels will be enabled for them and they will have no option to disable them thanks (NOT) to Google.    
This may require some understanding.  I don't want anyone to get the impression that xDrip is an unstable app shifting left and right for no reason.  
So, the announcement will explain to the users what to expect from Notification channels.  
<br/>  
  
---  
  
**Existing problems**  
Google's Notification channels have major issues.  
We may be able to possibly make changes to xDrip to make the experience better.  But, this is something that exists already in xDrip if you enable notification channels.  This PR enables notification channels whether you want it or not.  The resulting problems have been addressed if they had been caused by this PR.  But, if the problems existed already, we can plan and address them in future PRs.  

For example if you change the sound file in any of your other alerts, a new notification channel will be created for you.  But, the previous notification channel will still remain (zombie) and you will have no way of deleting it other than reinstalling xDrip.  This is not something that this PR is causing.  