### PR TITLE
chore(deps): standardize Truth to 1.4.5 across app, wear, libkeks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -366,7 +366,7 @@ dependencies {
     testImplementation 'org.objenesis:objenesis:2.5.1'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation "org.robolectric:robolectric:4.16"
-    testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "com.google.truth:truth:1.4.5"
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.13'
 
     testImplementation 'org.mockito:mockito-inline:2.13.0'

--- a/libkeks/build.gradle
+++ b/libkeks/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     // use lombok in unit tests
     testCompileOnly 'org.projectlombok:lombok:1.18.24'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
-    testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "com.google.truth:truth:1.4.5"
 
 }
 java {

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     implementation 'org.apache.commons:commons-math3:3.6'
     testImplementation "org.robolectric:robolectric:4.16"
     testImplementation 'junit:junit:4.13.2'
-    testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "com.google.truth:truth:1.4.5"
 
     // add missing JAXB dependencies for JDK 9+
     if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {


### PR DESCRIPTION
## What

Bump the [Truth](https://github.com/google/truth) assertion library from **1.1.3** (2021) to **1.4.5** (latest) in `:app`, `:wear` and `:libkeks`, matching the version already used by `:libglupro` and `:ipluginda`. This removes the version drift so all modules share a single Truth version.

## Why

Housekeeping / consistency. Two modules were already on 1.4.5 while the other three lagged five minor releases behind. A single version avoids surprises in shared test utilities and keeps the dependency footprint tidy.

## Scope & risk

- **Test-only.** Truth is a `testImplementation` dependency — it never ships in any APK, so there is zero runtime/behavioural impact.
- **No source changes needed.** All 112 Truth-using test files use the stable `Truth.assertThat` / `Truth.assertWithMessage` entry points. None use `Truth8` (the entry point removed in 1.4.0), so the 1.1.3 → 1.4.5 jump compiles cleanly.

## Verification

- `./gradlew test` — full suite across all `:app` + `:wear` flavours plus `:libkeks`: **BUILD SUCCESSFUL**, no compile breaks, no test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)