### PR TITLE
Tidepool: don't force interactive re-login on transient token-refresh network errors

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
@@ -14,9 +14,9 @@ import com.eveningoutpost.dexdrip.utilitymodels.Inevitable;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 
 import net.openid.appauth.AppAuthConfiguration;
+import net.openid.appauth.AuthState;
 import net.openid.appauth.AuthorizationException;
 import net.openid.appauth.AuthorizationResponse;
-import net.openid.appauth.TokenResponse;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -189,61 +189,49 @@ public class AuthFlowIn extends AppCompatActivity {
                 || ex.code == AuthorizationException.GeneralErrors.SERVER_ERROR.code);
     }
 
-    /** The four outcomes of a fresh-token attempt; isolated from side effects to stay unit-testable. */
-    @VisibleForTesting
-    enum TokenOutcome { START_SESSION, RETRY_LOGIN_NO_TOKEN_TYPE, RETRY_LOGIN_TOKEN_REJECTED, RETRY_SILENTLY }
-
-    /**
-     * Decide what to do with a fresh-token result: a usable access token with a stored response starts
-     * a session; a missing token forces interactive re-login unless the failure was transient
-     * ({@link #isTransientTokenError}), in which case the next sync retries silently.
-     */
-    @VisibleForTesting
-    static TokenOutcome classifyFreshTokenResult(final String accessToken,
-                                                 final TokenResponse lastResponse,
-                                                 final AuthorizationException ex) {
-        if (accessToken == null) {
-            return isTransientTokenError(ex) ? TokenOutcome.RETRY_SILENTLY : TokenOutcome.RETRY_LOGIN_TOKEN_REJECTED;
-        }
-        return lastResponse != null ? TokenOutcome.START_SESSION : TokenOutcome.RETRY_LOGIN_NO_TOKEN_TYPE;
-    }
-
     public static void handleTokenLoginAndStartSession() {
         val state = AuthFlowOut.getAuthState();
         if (state != null) {
             val service = AuthFlowOut.getAuthService();
-            state.performActionWithFreshTokens(service, (accessToken, idToken, tokenException) -> {
-                if (tokenException != null) {
-                    Log.e(TAG, "Got exception token: " + tokenException);
-                }
-                val lastResponse = accessToken != null ? state.getLastTokenResponse() : null;
-                switch (classifyFreshTokenResult(accessToken, lastResponse, tokenException)) {
-                    case START_SESSION: {
-                        val session = new Session(lastResponse.tokenType, TidepoolUploader.getSESSION_TOKEN_HEADER());
-                        session.authReply = new MAuthReply(idToken);
-                        session.token = accessToken;
-                        session.authReply.userid = Pref.getStringDefaultBlank(PREF_TIDEPOOL_SUB_NAME);
-                        TidepoolUploader.startSession(session, false);
-                        AuthFlowOut.saveAuthState();
-                        break;
-                    }
-                    case RETRY_LOGIN_NO_TOKEN_TYPE:
-                        Log.e(TAG, "Failing to get response / token type - trying initial login again");
-                        retryInitialLogin();
-                        break;
-                    case RETRY_LOGIN_TOKEN_REJECTED:
-                        Log.e(TAG, "Failing to use access token - trying initial login again");
-                        retryInitialLogin();
-                        break;
-                    case RETRY_SILENTLY:
-                        Log.d(TAG, "Token refresh failed transiently - keeping session, will retry on next sync: " + tokenException);
-                        break;
-                }
-            });
+            state.performActionWithFreshTokens(service,
+                    (accessToken, idToken, tokenException) -> onFreshTokenResult(state, accessToken, idToken, tokenException));
         } else {
             Log.e(TAG, "Failing to get state - trying initial login");
             retryInitialLogin();
         }
+    }
+
+    /**
+     * Act on the result of a fresh-token request. A usable access token with a stored response starts a
+     * session; a missing token forces interactive re-login unless the failure was transient
+     * ({@link #isTransientTokenError}), in which case the next sync retries the silent refresh.
+     */
+    private static void onFreshTokenResult(final AuthState state, final String accessToken,
+                                           final String idToken, final AuthorizationException ex) {
+        if (ex != null) {
+            Log.e(TAG, "Got exception token: " + ex);
+        }
+        if (accessToken == null) {
+            if (isTransientTokenError(ex)) {
+                Log.d(TAG, "Token refresh failed transiently - keeping session, will retry on next sync: " + ex);
+            } else {
+                Log.e(TAG, "Failing to use access token - trying initial login again");
+                retryInitialLogin();
+            }
+            return;
+        }
+        val lastResponse = state.getLastTokenResponse();
+        if (lastResponse == null) {
+            Log.e(TAG, "Failing to get response / token type - trying initial login again");
+            retryInitialLogin();
+            return;
+        }
+        val session = new Session(lastResponse.tokenType, TidepoolUploader.getSESSION_TOKEN_HEADER());
+        session.authReply = new MAuthReply(idToken);
+        session.token = accessToken;
+        session.authReply.userid = Pref.getStringDefaultBlank(PREF_TIDEPOOL_SUB_NAME);
+        TidepoolUploader.startSession(session, false);
+        AuthFlowOut.saveAuthState();
     }
 
     private static void retryInitialLogin() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
@@ -174,12 +174,9 @@ public class AuthFlowIn extends AppCompatActivity {
     }
 
     /**
-     * True when a fresh-token action failed for a transient reason — no connectivity or a
-     * server-side error — rather than a rejected credential. In these cases the stored refresh
-     * token is still presumably valid, so the next sync should retry the silent refresh instead
-     * of dropping the user into an interactive browser re-login. A genuinely expired/revoked
-     * refresh token surfaces as an OAuth token error (e.g. {@code invalid_grant}), not as one of
-     * these general errors, so it still correctly triggers re-login.
+     * True for a transient token-refresh failure (no connectivity or a server-side error), where the
+     * stored refresh token is still valid and the next sync should retry silently. A rejected
+     * credential instead surfaces as an OAuth token error ({@code invalid_grant}) and still forces re-login.
      */
     @VisibleForTesting
     static boolean isTransientTokenError(final AuthorizationException ex) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
@@ -16,6 +16,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import net.openid.appauth.AppAuthConfiguration;
 import net.openid.appauth.AuthorizationException;
 import net.openid.appauth.AuthorizationResponse;
+import net.openid.appauth.TokenResponse;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -188,6 +189,25 @@ public class AuthFlowIn extends AppCompatActivity {
                 || ex.code == AuthorizationException.GeneralErrors.SERVER_ERROR.code);
     }
 
+    /** The four outcomes of a fresh-token attempt; isolated from side effects to stay unit-testable. */
+    @VisibleForTesting
+    enum TokenOutcome { START_SESSION, RETRY_LOGIN_NO_TOKEN_TYPE, RETRY_LOGIN_TOKEN_REJECTED, RETRY_SILENTLY }
+
+    /**
+     * Decide what to do with a fresh-token result: a usable access token with a stored response starts
+     * a session; a missing token forces interactive re-login unless the failure was transient
+     * ({@link #isTransientTokenError}), in which case the next sync retries silently.
+     */
+    @VisibleForTesting
+    static TokenOutcome classifyFreshTokenResult(final String accessToken,
+                                                 final TokenResponse lastResponse,
+                                                 final AuthorizationException ex) {
+        if (accessToken == null) {
+            return isTransientTokenError(ex) ? TokenOutcome.RETRY_SILENTLY : TokenOutcome.RETRY_LOGIN_TOKEN_REJECTED;
+        }
+        return lastResponse != null ? TokenOutcome.START_SESSION : TokenOutcome.RETRY_LOGIN_NO_TOKEN_TYPE;
+    }
+
     public static void handleTokenLoginAndStartSession() {
         val state = AuthFlowOut.getAuthState();
         if (state != null) {
@@ -196,26 +216,28 @@ public class AuthFlowIn extends AppCompatActivity {
                 if (tokenException != null) {
                     Log.e(TAG, "Got exception token: " + tokenException);
                 }
-                if (accessToken != null) {
-                    val lastReponse = state.getLastTokenResponse();
-                    if (lastReponse != null) {
-                        val session = new Session(lastReponse.tokenType, TidepoolUploader.getSESSION_TOKEN_HEADER());
+                val lastResponse = accessToken != null ? state.getLastTokenResponse() : null;
+                switch (classifyFreshTokenResult(accessToken, lastResponse, tokenException)) {
+                    case START_SESSION: {
+                        val session = new Session(lastResponse.tokenType, TidepoolUploader.getSESSION_TOKEN_HEADER());
                         session.authReply = new MAuthReply(idToken);
                         session.token = accessToken;
                         session.authReply.userid = Pref.getStringDefaultBlank(PREF_TIDEPOOL_SUB_NAME);
                         TidepoolUploader.startSession(session, false);
                         AuthFlowOut.saveAuthState();
-                    } else {
+                        break;
+                    }
+                    case RETRY_LOGIN_NO_TOKEN_TYPE:
                         Log.e(TAG, "Failing to get response / token type - trying initial login again");
                         retryInitialLogin();
-                    }
-                } else {
-                    if (isTransientTokenError(tokenException)) {
-                        Log.d(TAG, "Token refresh failed transiently - keeping session, will retry on next sync: " + tokenException);
-                    } else {
+                        break;
+                    case RETRY_LOGIN_TOKEN_REJECTED:
                         Log.e(TAG, "Failing to use access token - trying initial login again");
                         retryInitialLogin();
-                    }
+                        break;
+                    case RETRY_SILENTLY:
+                        Log.d(TAG, "Token refresh failed transiently - keeping session, will retry on next sync: " + tokenException);
+                        break;
                 }
             });
         } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
@@ -6,6 +6,7 @@ import static com.eveningoutpost.dexdrip.tidepool.AuthFlowOut.eraseAuthState;
 
 import android.content.Intent;
 import android.os.Bundle;
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.eveningoutpost.dexdrip.models.UserError.Log;
@@ -172,6 +173,24 @@ public class AuthFlowIn extends AppCompatActivity {
         }
     }
 
+    /**
+     * True when a fresh-token action failed for a transient reason — no connectivity or a
+     * server-side error — rather than a rejected credential. In these cases the stored refresh
+     * token is still presumably valid, so the next sync should retry the silent refresh instead
+     * of dropping the user into an interactive browser re-login. A genuinely expired/revoked
+     * refresh token surfaces as an OAuth token error (e.g. {@code invalid_grant}), not as one of
+     * these general errors, so it still correctly triggers re-login.
+     */
+    @VisibleForTesting
+    static boolean isTransientTokenError(final AuthorizationException ex) {
+        if (ex == null) {
+            return false;
+        }
+        return ex.type == AuthorizationException.TYPE_GENERAL_ERROR
+                && (ex.code == AuthorizationException.GeneralErrors.NETWORK_ERROR.code
+                || ex.code == AuthorizationException.GeneralErrors.SERVER_ERROR.code);
+    }
+
     public static void handleTokenLoginAndStartSession() {
         val state = AuthFlowOut.getAuthState();
         if (state != null) {
@@ -194,8 +213,12 @@ public class AuthFlowIn extends AppCompatActivity {
                         retryInitialLogin();
                     }
                 } else {
-                    Log.e(TAG, "Failing to use access token - trying initial login again");
-                    retryInitialLogin();
+                    if (isTransientTokenError(tokenException)) {
+                        Log.d(TAG, "Token refresh failed transiently - keeping session, will retry on next sync: " + tokenException);
+                    } else {
+                        Log.e(TAG, "Failing to use access token - trying initial login again");
+                        retryInitialLogin();
+                    }
                 }
             });
         } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowIn.java
@@ -206,8 +206,9 @@ public class AuthFlowIn extends AppCompatActivity {
      * session; a missing token forces interactive re-login unless the failure was transient
      * ({@link #isTransientTokenError}), in which case the next sync retries the silent refresh.
      */
-    private static void onFreshTokenResult(final AuthState state, final String accessToken,
-                                           final String idToken, final AuthorizationException ex) {
+    @VisibleForTesting
+    static void onFreshTokenResult(final AuthState state, final String accessToken,
+                                   final String idToken, final AuthorizationException ex) {
         if (ex != null) {
             Log.e(TAG, "Got exception token: " + ex);
         }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
@@ -1,0 +1,55 @@
+package com.eveningoutpost.dexdrip.tidepool;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import net.openid.appauth.AuthorizationException;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Tests for {@link AuthFlowIn#isTransientTokenError} — the classifier that decides whether a
+ * failed Tidepool token refresh should be retried silently (transient network/server error) or
+ * fall back to an interactive browser re-login (rejected credential).
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class AuthFlowInTest extends RobolectricTestWithConfig {
+
+    @Test
+    public void networkError_isTransient() {
+        // :: Setup — mirror what AppAuth produces on a failed refresh over a bad network:
+        // a fresh instance built from the NETWORK_ERROR template ({"type":0,"code":3}).
+        final AuthorizationException networkError = AuthorizationException.fromTemplate(
+                AuthorizationException.GeneralErrors.NETWORK_ERROR, new IOException("timeout"));
+
+        // :: Act & Verify
+        assertThat(AuthFlowIn.isTransientTokenError(networkError)).isTrue();
+    }
+
+    @Test
+    public void serverError_isTransient() {
+        // :: Setup
+        final AuthorizationException serverError = AuthorizationException.fromTemplate(
+                AuthorizationException.GeneralErrors.SERVER_ERROR, new IOException("503"));
+
+        // :: Act & Verify
+        assertThat(AuthFlowIn.isTransientTokenError(serverError)).isTrue();
+    }
+
+    @Test
+    public void invalidGrant_isNotTransient_soReloginStillHappens() {
+        // :: Verify — a revoked/expired refresh token must still force interactive re-login.
+        assertThat(AuthFlowIn.isTransientTokenError(
+                AuthorizationException.TokenRequestErrors.INVALID_GRANT)).isFalse();
+    }
+
+    @Test
+    public void nullException_isNotTransient() {
+        // :: Verify
+        assertThat(AuthFlowIn.isTransientTokenError(null)).isFalse();
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
@@ -11,9 +11,9 @@ import org.junit.Test;
 import java.io.IOException;
 
 /**
- * Tests for {@link AuthFlowIn#isTransientTokenError} — the classifier that decides whether a
- * failed Tidepool token refresh should be retried silently (transient network/server error) or
- * fall back to an interactive browser re-login (rejected credential).
+ * Tests for {@link AuthFlowIn#isTransientTokenError} — the predicate that classifies a failed
+ * Tidepool token refresh as transient (network/server error → retry silently on next sync) vs. a
+ * rejected credential (→ interactive browser re-login).
  *
  * @author Asbjørn Aarrestad
  */

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
@@ -2,14 +2,9 @@ package com.eveningoutpost.dexdrip.tidepool;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import android.net.Uri;
-
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 
 import net.openid.appauth.AuthorizationException;
-import net.openid.appauth.AuthorizationServiceConfiguration;
-import net.openid.appauth.TokenRequest;
-import net.openid.appauth.TokenResponse;
 
 import org.junit.Test;
 
@@ -65,49 +60,5 @@ public class AuthFlowInTest extends RobolectricTestWithConfig {
     public void nullException_isNotTransient() {
         // :: Verify
         assertThat(AuthFlowIn.isTransientTokenError(null)).isFalse();
-    }
-
-    // classifyFreshTokenResult — the full outcome decision the fresh-token callback acts on.
-
-    @Test
-    public void noAccessTokenWithTransientError_retriesSilently() {
-        // :: Setup
-        final AuthorizationException networkError = AuthorizationException.fromTemplate(
-                AuthorizationException.GeneralErrors.NETWORK_ERROR, new IOException("timeout"));
-
-        // :: Act & Verify — the fix: a transient failure keeps the session, no re-login.
-        assertThat(AuthFlowIn.classifyFreshTokenResult(null, null, networkError))
-                .isEqualTo(AuthFlowIn.TokenOutcome.RETRY_SILENTLY);
-    }
-
-    @Test
-    public void noAccessTokenWithRejectedCredential_retriesLogin() {
-        // :: Act & Verify — a genuine credential failure still forces interactive re-login.
-        assertThat(AuthFlowIn.classifyFreshTokenResult(
-                null, null, AuthorizationException.TokenRequestErrors.INVALID_GRANT))
-                .isEqualTo(AuthFlowIn.TokenOutcome.RETRY_LOGIN_TOKEN_REJECTED);
-    }
-
-    @Test
-    public void accessTokenButNoLastResponse_retriesLogin() {
-        // :: Act & Verify — have a token but no stored response/token type: re-login as before.
-        assertThat(AuthFlowIn.classifyFreshTokenResult("access-token", null, null))
-                .isEqualTo(AuthFlowIn.TokenOutcome.RETRY_LOGIN_NO_TOKEN_TYPE);
-    }
-
-    @Test
-    public void accessTokenWithLastResponse_startsSession() {
-        // :: Setup — a minimal real TokenResponse (refresh-token grant needs only a refresh token).
-        final AuthorizationServiceConfiguration config = new AuthorizationServiceConfiguration(
-                Uri.parse("https://auth.example/authorize"), Uri.parse("https://auth.example/token"));
-        final TokenRequest request = new TokenRequest.Builder(config, "xdrip")
-                .setGrantType("refresh_token")
-                .setRefreshToken("refresh-token")
-                .build();
-        final TokenResponse lastResponse = new TokenResponse.Builder(request).build();
-
-        // :: Act & Verify — happy path: valid token and a stored response starts the session.
-        assertThat(AuthFlowIn.classifyFreshTokenResult("access-token", lastResponse, null))
-                .isEqualTo(AuthFlowIn.TokenOutcome.START_SESSION);
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
@@ -48,6 +48,15 @@ public class AuthFlowInTest extends RobolectricTestWithConfig {
     }
 
     @Test
+    public void otherGeneralError_isNotTransient() {
+        // :: Verify — a general error that is not a connectivity/server failure (here: JSON
+        // deserialization, type 0 code 5) must NOT be transient. Without this the code-level
+        // discrimination would be dead and every general error would suppress re-login.
+        assertThat(AuthFlowIn.isTransientTokenError(
+                AuthorizationException.GeneralErrors.JSON_DESERIALIZATION_ERROR)).isFalse();
+    }
+
+    @Test
     public void nullException_isNotTransient() {
         // :: Verify
         assertThat(AuthFlowIn.isTransientTokenError(null)).isFalse();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
@@ -2,9 +2,14 @@ package com.eveningoutpost.dexdrip.tidepool;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import android.net.Uri;
+
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 
 import net.openid.appauth.AuthorizationException;
+import net.openid.appauth.AuthorizationServiceConfiguration;
+import net.openid.appauth.TokenRequest;
+import net.openid.appauth.TokenResponse;
 
 import org.junit.Test;
 
@@ -60,5 +65,49 @@ public class AuthFlowInTest extends RobolectricTestWithConfig {
     public void nullException_isNotTransient() {
         // :: Verify
         assertThat(AuthFlowIn.isTransientTokenError(null)).isFalse();
+    }
+
+    // classifyFreshTokenResult — the full outcome decision the fresh-token callback acts on.
+
+    @Test
+    public void noAccessTokenWithTransientError_retriesSilently() {
+        // :: Setup
+        final AuthorizationException networkError = AuthorizationException.fromTemplate(
+                AuthorizationException.GeneralErrors.NETWORK_ERROR, new IOException("timeout"));
+
+        // :: Act & Verify — the fix: a transient failure keeps the session, no re-login.
+        assertThat(AuthFlowIn.classifyFreshTokenResult(null, null, networkError))
+                .isEqualTo(AuthFlowIn.TokenOutcome.RETRY_SILENTLY);
+    }
+
+    @Test
+    public void noAccessTokenWithRejectedCredential_retriesLogin() {
+        // :: Act & Verify — a genuine credential failure still forces interactive re-login.
+        assertThat(AuthFlowIn.classifyFreshTokenResult(
+                null, null, AuthorizationException.TokenRequestErrors.INVALID_GRANT))
+                .isEqualTo(AuthFlowIn.TokenOutcome.RETRY_LOGIN_TOKEN_REJECTED);
+    }
+
+    @Test
+    public void accessTokenButNoLastResponse_retriesLogin() {
+        // :: Act & Verify — have a token but no stored response/token type: re-login as before.
+        assertThat(AuthFlowIn.classifyFreshTokenResult("access-token", null, null))
+                .isEqualTo(AuthFlowIn.TokenOutcome.RETRY_LOGIN_NO_TOKEN_TYPE);
+    }
+
+    @Test
+    public void accessTokenWithLastResponse_startsSession() {
+        // :: Setup — a minimal real TokenResponse (refresh-token grant needs only a refresh token).
+        final AuthorizationServiceConfiguration config = new AuthorizationServiceConfiguration(
+                Uri.parse("https://auth.example/authorize"), Uri.parse("https://auth.example/token"));
+        final TokenRequest request = new TokenRequest.Builder(config, "xdrip")
+                .setGrantType("refresh_token")
+                .setRefreshToken("refresh-token")
+                .build();
+        final TokenResponse lastResponse = new TokenResponse.Builder(request).build();
+
+        // :: Act & Verify — happy path: valid token and a stored response starts the session.
+        assertThat(AuthFlowIn.classifyFreshTokenResult("access-token", lastResponse, null))
+                .isEqualTo(AuthFlowIn.TokenOutcome.START_SESSION);
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
@@ -41,8 +41,8 @@ public class AuthFlowInTest extends RobolectricTestWithConfig {
     }
 
     @Test
-    public void invalidGrant_isNotTransient_soReloginStillHappens() {
-        // :: Verify — a revoked/expired refresh token must still force interactive re-login.
+    public void invalidGrant_isNotTransient() {
+        // :: Verify — a rejected credential (invalid_grant) is an OAuth token error, not transient.
         assertThat(AuthFlowIn.isTransientTokenError(
                 AuthorizationException.TokenRequestErrors.INVALID_GRANT)).isFalse();
     }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/AuthFlowInTest.java
@@ -1,12 +1,17 @@
 package com.eveningoutpost.dexdrip.tidepool;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.os.Looper;
 
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 
+import net.openid.appauth.AuthState;
 import net.openid.appauth.AuthorizationException;
 
 import org.junit.Test;
+import org.robolectric.shadows.ShadowToast;
 
 import java.io.IOException;
 
@@ -60,5 +65,41 @@ public class AuthFlowInTest extends RobolectricTestWithConfig {
     public void nullException_isNotTransient() {
         // :: Verify
         assertThat(AuthFlowIn.isTransientTokenError(null)).isFalse();
+    }
+
+    /**
+     * The predicate tests above pin the classification. These two pin what the classification is
+     * actually used for — whether a failed refresh escalates to the interactive browser login.
+     * Entering that flow announces itself with a "Connecting to Tidepool" toast
+     * ({@link AuthFlowOut#doTidePoolInitialLogin}), which is the observable difference the reporter
+     * in #4605 sees as a login page appearing on a flaky network.
+     */
+    @Test
+    public void transientNetworkError_keepsSessionInsteadOfLaunchingLogin() {
+        // :: Setup — AppAuth hands back no access token plus {"type":0,"code":3} when the silent
+        // refresh cannot reach the server. This is the exact failure captured in #4608's log.
+        final AuthorizationException networkError = AuthorizationException.fromTemplate(
+                AuthorizationException.GeneralErrors.NETWORK_ERROR, new IOException("no route to host"));
+
+        // :: Act
+        AuthFlowIn.onFreshTokenResult(new AuthState(), null, null, networkError);
+        shadowOf(Looper.getMainLooper()).idle();
+
+        // :: Verify — no interactive login was started, so no login page is pushed at the user.
+        assertThat(ShadowToast.getTextOfLatestToast()).isNull();
+    }
+
+    @Test
+    public void rejectedCredential_stillLaunchesInteractiveLogin() {
+        // :: Setup — a refresh token the server refuses is not transient; the user genuinely has to
+        // log in again. This guards against the fix suppressing re-login across the board.
+        final AuthorizationException invalidGrant = AuthorizationException.TokenRequestErrors.INVALID_GRANT;
+
+        // :: Act
+        AuthFlowIn.onFreshTokenResult(new AuthState(), null, null, invalidGrant);
+        shadowOf(Looper.getMainLooper()).idle();
+
+        // :: Verify
+        assertThat(ShadowToast.getTextOfLatestToast()).isEqualTo("Connecting to Tidepool");
     }
 }


### PR DESCRIPTION
### Problem

On unreliable networks, xDrip repeatedly pops the Tidepool browser/login page
(reported in #4605). The reporter's log shows:

    TidePoolAuth: failed to fetch configuration
    TidePoolAuth: Failing to use access token - trying initial login again
    TidePoolAuth: Got exception token: AuthorizationException:
        {"type":0,"code":3,"errorDescription":"Network error"}

### Root cause

`AuthFlowIn.handleTokenLoginAndStartSession()` refreshes the Tidepool token via
AppAuth's `performActionWithFreshTokens`. When the access token needs refreshing
while the network is down, AppAuth's refresh call fails and hands the callback
`accessToken == null` with `GeneralErrors.NETWORK_ERROR` (`type:0, code:3`). The
callback only checked whether an access token came back, so on `null` it always
called `retryInitialLogin()` → `doTidePoolInitialLogin()` →
`performAuthorizationRequest()`, which launches the interactive login page.

So a transient connectivity failure was treated identically to a rejected
credential. The stored refresh token is still valid — the device just couldn't
reach the server that moment. A genuinely expired/revoked refresh token surfaces
differently (`TokenRequestErrors.INVALID_GRANT`, type 2), so it is unaffected by
this change and still triggers a real re-login.

This path has existed since 2023 (`e33663e55`); it is not a recent regression —
it surfaces only on genuinely flaky networks.

### Fix

Add `isTransientTokenError(AuthorizationException)`: a `TYPE_GENERAL_ERROR` with
code `NETWORK_ERROR` or `SERVER_ERROR` is transient. On a transient failure the
fresh-token callback now keeps the session and lets the next sync retry the
silent refresh; every other failure preserves the existing fall-back to
interactive login. The callback body was also lifted out of the lambda into a
small `onFreshTokenResult(...)` method so the flow reads top-to-bottom —
behavior and all existing log messages are unchanged.

### Testing

New `AuthFlowInTest` pins the classifier boundary: `NETWORK_ERROR` / `SERVER_ERROR`
→ transient; `INVALID_GRANT`, a non-network general error
(`JSON_DESERIALIZATION_ERROR`), and `null` → not transient (so re-login still
fires for genuine credential problems). Full `./gradlew test` green.

### Verifying this build

This is grounded in code analysis — the AppAuth token-refresh path plus the
reporter's own `{"type":0,"code":3}` log — rather than a staged reproduction
(the failure needs the access token to expire *during* a network outage). The
recovery path is verified in code: a network error never discards the stored
refresh token, and `TidepoolEntry.newData()` re-drives the silent refresh
(≤20 min), so Tidepool resyncs on reconnect with no login prompt. Field
confirmation from anyone hitting this on flaky networks is welcome.

Refs #4605
