### PR TITLE
feat(webservices): Add Nightscout-compatible profile.json endpoint exposing xDrip's carb ratio, insulin sensitivity, basal rate, and carb absorption rate.

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,10 +1,10 @@
-name: Unit Test & Build APK (ICR_ISF_profile)
+name: Unit Test
 
 on:
   push:
-    branches: [ ICR_ISF_profile ]
+    branches: [ master ]
   pull_request:
-    branches: [ ICR_ISF_profile ]
+    branches: [ master ]
 
 jobs:
   build:
@@ -27,8 +27,3 @@ jobs:
         arguments: assembleProdRelease testProdReleaseUnitTest
     - name: Check Output
       run: bash ./etc/CheckBuild/check-release.sh test
-    - name: Upload APK
-      uses: actions/upload-artifact@v4
-      with:
-        name: xdrip-prod-release
-        path: app/build/outputs/apk/prod/release/*.apk

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,10 +1,10 @@
-name: Unit Test
+name: Unit Test & Build APK (ICR_ISF_profile)
 
 on:
   push:
-    branches: [ master ]
+    branches: [ ICR_ISF_profile ]
   pull_request:
-    branches: [ master ]
+    branches: [ ICR_ISF_profile ]
 
 jobs:
   build:
@@ -27,3 +27,8 @@ jobs:
         arguments: assembleProdRelease testProdReleaseUnitTest
     - name: Check Output
       run: bash ./etc/CheckBuild/check-release.sh test
+    - name: Upload APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: xdrip-prod-release
+        path: app/build/outputs/apk/prod/release/*.apk

--- a/app/src/main/java/com/eveningoutpost/dexdrip/dagger/Singleton.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/dagger/Singleton.java
@@ -55,6 +55,10 @@ public class Singleton extends SingletonHotel {
     Lazy<BaseWebService> webServiceStatus;
 
     @Inject
+    @Named("WebServiceProfile")
+    Lazy<BaseWebService> webServiceProfile;
+
+    @Inject
     @Named("WebServiceSteps")
     Lazy<BaseWebService> webServiceSteps;
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/webservices/RouteFinder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/webservices/RouteFinder.java
@@ -42,6 +42,10 @@ public class RouteFinder {
         // support for nightscout style barebones status.json endpoint
         routes.add(new RouteInfo("status.json", "WebServiceStatus"));
 
+        // support for nightscout style profile.json endpoint
+        routes.add(new RouteInfo("profile.json", "WebServiceProfile"));
+        routes.add(new RouteInfo("api/v1/profile.json", "WebServiceProfile"));
+
         // support for working with step counter
         routes.add(new RouteInfo("steps/", "WebServiceSteps"));
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebServiceModule.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebServiceModule.java
@@ -63,6 +63,14 @@ public class WebServiceModule {
 
     @Provides
     @Singleton
+    @Named("WebServiceProfile")
+    BaseWebService providesWebServiceProfile() {
+        UserError.Log.d(TAG, "creating WebServiceProfile");
+        return new WebServiceProfile();
+    }
+
+    @Provides
+    @Singleton
     @Named("WebServiceTasker")
     BaseWebService providesWebServiceTasker() {
         UserError.Log.d(TAG, "creating WebServiceTasker");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebServiceProfile.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebServiceProfile.java
@@ -1,0 +1,111 @@
+package com.eveningoutpost.dexdrip.webservices;
+
+import com.eveningoutpost.dexdrip.models.DateUtil;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.models.UserError;
+import com.eveningoutpost.dexdrip.profileeditor.BasalProfile;
+import com.eveningoutpost.dexdrip.profileeditor.ProfileEditor;
+import com.eveningoutpost.dexdrip.profileeditor.ProfileItem;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static com.eveningoutpost.dexdrip.models.JoH.tolerantParseDouble;
+
+/**
+ * emulates the Nightscout /api/v1/profile.json endpoint at profile.json
+ * <p>
+ * returns the active carb ratio, insulin sensitivity and basal rate per time block
+ * from ProfileEditor / BasalProfile, plus the global carb absorption rate
+ */
+
+public class WebServiceProfile extends BaseWebService {
+
+    private static final String TAG = "WebServiceProfile";
+    private static final String DEFAULT_PROFILE_NAME = "Default";
+    private static final int MINS_PER_DAY = 24 * 60;
+
+    public WebResponse request(String query) {
+        final JSONArray reply = new JSONArray();
+
+        try {
+            final List<ProfileItem> profileItemList = ProfileEditor.loadData(false);
+            Collections.sort(profileItemList, Comparator.comparingInt(item -> item.start_min));
+
+            final boolean using_mgdl = Pref.getString("units", "mgdl").equals("mgdl");
+            final String units = using_mgdl ? "mg/dl" : "mmol";
+            final String timezone = TimeZone.getDefault().getID();
+
+            final JSONObject defaultProfile = new JSONObject();
+            defaultProfile.put("carbratio", buildBlockArray(profileItemList, BlockField.CARB_RATIO));
+            defaultProfile.put("sens", buildBlockArray(profileItemList, BlockField.SENSITIVITY));
+            defaultProfile.put("basal", buildBasalArray(BasalProfile.load(BasalProfile.getActiveRateName())));
+            // xDrip stores carb absorption rate as a single global value, not per time block
+            defaultProfile.put("carbs_hr", tolerantParseDouble(Pref.getString("profile_carb_absorption_default", "35")));
+            defaultProfile.put("units", units);
+            defaultProfile.put("timezone", timezone);
+
+            final JSONObject store = new JSONObject();
+            store.put(DEFAULT_PROFILE_NAME, defaultProfile);
+
+            final long now = JoH.tsl();
+            final JSONObject profile = new JSONObject();
+            profile.put("defaultProfile", DEFAULT_PROFILE_NAME);
+            profile.put("store", store);
+            profile.put("startDate", DateUtil.toISOString(now));
+            profile.put("mills", now);
+            profile.put("units", units);
+
+            reply.put(profile);
+        } catch (JSONException e) {
+            UserError.Log.wtf(TAG, "Got json exception: " + e);
+        }
+
+        return new WebResponse(reply.toString());
+    }
+
+    private enum BlockField {CARB_RATIO, SENSITIVITY}
+
+    private static double fieldValue(final ProfileItem item, final BlockField field) {
+        return field == BlockField.CARB_RATIO ? item.carb_ratio : item.sensitivity;
+    }
+
+    private static JSONArray buildBlockArray(final List<ProfileItem> profileItemList, final BlockField field) throws JSONException {
+        final JSONArray blocks = new JSONArray();
+        for (final ProfileItem item : profileItemList) {
+            final JSONObject block = new JSONObject();
+            block.put("time", String.format(Locale.ENGLISH, "%02d:%02d", item.start_min / 60, item.start_min % 60));
+            block.put("timeAsSeconds", item.start_min * 60);
+            block.put("value", fieldValue(item, field));
+            blocks.put(block);
+        }
+        return blocks;
+    }
+
+    // basal segments are stored as an evenly spaced List<Float> covering the whole day
+    private static JSONArray buildBasalArray(final List<Float> segments) throws JSONException {
+        final JSONArray blocks = new JSONArray();
+        if (segments == null || segments.isEmpty()) {
+            return blocks;
+        }
+        final int minutesPerSegment = MINS_PER_DAY / segments.size();
+        for (int i = 0; i < segments.size(); i++) {
+            final int start_min = i * minutesPerSegment;
+            final JSONObject block = new JSONObject();
+            block.put("time", String.format(Locale.ENGLISH, "%02d:%02d", start_min / 60, start_min % 60));
+            block.put("timeAsSeconds", start_min * 60);
+            block.put("value", JoH.roundDouble(segments.get(i), 2));
+            blocks.put(block);
+        }
+        return blocks;
+    }
+
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/webservices/RouteFinderTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/webservices/RouteFinderTest.java
@@ -5,6 +5,7 @@ import com.eveningoutpost.dexdrip.models.BgReading;
 import com.eveningoutpost.dexdrip.models.DateUtil;
 import com.eveningoutpost.dexdrip.models.Sensor;
 import com.eveningoutpost.dexdrip.models.Treatments;
+import com.eveningoutpost.dexdrip.profileeditor.BasalProfile;
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.utilitymodels.NanoStatus;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
@@ -19,6 +20,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.Arrays;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -221,6 +223,74 @@ public class RouteFinderTest extends RobolectricTestWithConfig {
         } catch (JSONException e) {
             return null;
         }
+    }
+
+    @Test
+    public void test_WebServiceProfile() {
+        final RouteFinder routeFinder = new RouteFinder();
+
+        // no saved profile blocks: falls back to a single default block from prefs
+        Pref.setString("profile_carb_ratio_default", "12");
+        Pref.setString("profile_insulin_sensitivity_default", "45");
+        Pref.setString("profile_carb_absorption_default", "30");
+        Pref.setString("units", "mgdl");
+
+        // two basal segments covering 12 hours each
+        BasalProfile.save(BasalProfile.getActiveRateName(), Arrays.asList(0.8, 1.2));
+
+        WebResponse response = routeFinder.handleRoute("profile.json");
+        validResponse("profile.json", response);
+
+        JSONArray parsed;
+        try {
+            parsed = new JSONArray(new String(response.bytes));
+            JSONObject profile = parsed.getJSONObject(0);
+            JSONObject defaultBlock = profile.getJSONObject("store").getJSONObject("Default");
+
+            assertWithMessage("units")
+                    .that(defaultBlock.getString("units"))
+                    .isEqualTo("mg/dl");
+
+            JSONObject carbratio = defaultBlock.getJSONArray("carbratio").getJSONObject(0);
+            assertWithMessage("carbratio time")
+                    .that(carbratio.getString("time"))
+                    .isEqualTo("00:00");
+            assertWithMessage("carbratio value")
+                    .that(carbratio.getDouble("value"))
+                    .isEqualTo(12.0);
+
+            JSONObject sens = defaultBlock.getJSONArray("sens").getJSONObject(0);
+            assertWithMessage("sens value")
+                    .that(sens.getDouble("value"))
+                    .isEqualTo(45.0);
+
+            assertWithMessage("carbs_hr")
+                    .that(defaultBlock.getDouble("carbs_hr"))
+                    .isEqualTo(30.0);
+
+            JSONArray basal = defaultBlock.getJSONArray("basal");
+            assertWithMessage("basal segment count")
+                    .that(basal.length())
+                    .isEqualTo(2);
+            assertWithMessage("basal segment 0 time")
+                    .that(basal.getJSONObject(0).getString("time"))
+                    .isEqualTo("00:00");
+            assertWithMessage("basal segment 0 value")
+                    .that(basal.getJSONObject(0).getDouble("value"))
+                    .isEqualTo(0.8);
+            assertWithMessage("basal segment 1 time")
+                    .that(basal.getJSONObject(1).getString("time"))
+                    .isEqualTo("12:00");
+            assertWithMessage("basal segment 1 value")
+                    .that(basal.getJSONObject(1).getDouble("value"))
+                    .isEqualTo(1.2);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+
+        // also reachable via the nightscout style api/v1 path
+        response = routeFinder.handleRoute("api/v1/profile.json");
+        validResponse("api/v1/profile.json", response);
     }
 
     @Test


### PR DESCRIPTION
#### summary:

  - New GET /profile.json and /api/v1/profile.json endpoints on xDrip's built-in web server, following the same pattern as the existing sgv.json/status.json/treatments.json handlers.
  - Returns a Nightscout-compatible profile document sourced from ProfileEditor (carb ratio + insulin sensitivity per time block) and BasalProfile (active basal rate segments), plus the app's global carb absorption rate (carbs_hr).
  - Lets Nightscout-aware clients (AAPS, xDrip followers, etc.) pull xDrip's active profile the same way they'd pull it from a Nightscout server.

  Response shape:

```
[{"defaultProfile":"Default","store":{"Default":{"carbratio":[{"time":"07:01","timeAsSeconds":25260,"value":7},{"time":"11:01","timeAsSeconds":39660,"value":7},{"time":"15:01","timeAsSeconds":54060,"value":8},{"time":"22:01","timeAsSeconds":79260,"value":7}],"sens":[{"time":"07:01","timeAsSeconds":25260,"value":1.5},{"time":"11:01","timeAsSeconds":39660,"value":1.1},{"time":"15:01","timeAsSeconds":54060,"value":1.2},{"time":"22:01","timeAsSeconds":79260,"value":1.1}],"basal":[{"time":"00:00","timeAsSeconds":0,"value":0.67},{"time":"01:00","timeAsSeconds":3600,"value":0.67},{"time":"02:00","timeAsSeconds":7200,"value":0.67},{"time":"03:00","timeAsSeconds":10800,"value":0.67},{"time":"04:00","timeAsSeconds":14400,"value":0.67},{"time":"05:00","timeAsSeconds":18000,"value":0.67},{"time":"06:00","timeAsSeconds":21600,"value":0.67},{"time":"07:00","timeAsSeconds":25200,"value":0.67},{"time":"08:00","timeAsSeconds":28800,"value":0.67},{"time":"09:00","timeAsSeconds":32400,"value":0.67},{"time":"10:00","timeAsSeconds":36000,"value":0.67},{"time":"11:00","timeAsSeconds":39600,"value":0.67},{"time":"12:00","timeAsSeconds":43200,"value":0.67},{"time":"13:00","timeAsSeconds":46800,"value":0.67},{"time":"14:00","timeAsSeconds":50400,"value":0.67},{"time":"15:00","timeAsSeconds":54000,"value":0.67},{"time":"16:00","timeAsSeconds":57600,"value":0.67},{"time":"17:00","timeAsSeconds":61200,"value":0.67},{"time":"18:00","timeAsSeconds":64800,"value":0.67},{"time":"19:00","timeAsSeconds":68400,"value":0.67},{"time":"20:00","timeAsSeconds":72000,"value":0.67},{"time":"21:00","timeAsSeconds":75600,"value":0.67},{"time":"22:00","timeAsSeconds":79200,"value":0.67},{"time":"23:00","timeAsSeconds":82800,"value":0.67}],"carbs_hr":30,"units":"mmol","timezone":"Europe\/London"}},"startDate":"2026-07-08T12:57:32Z","mills":1783515452922,"units":"mmol"}]
```

  Implementation:

  - WebServiceProfile.java (new) — builds the JSON response.
  - RouteFinder.java — registers both routes.
  - WebServiceModule.java / Singleton.java — Dagger wiring required for every web service in this codebase.
  - RouteFinderTest.java — regression test covering carbratio/sens defaults, basal segments, carbs_hr, and both route paths.

  Notes

  - Same api-secret auth as other endpoints.
