### PR TITLE
Never return a null bolus insulin profile once profiles are loaded

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinManager.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinManager.java
@@ -151,6 +151,12 @@ public class InsulinManager {
 
     public static Insulin getBolusProfile() {
         checkInitialized();
+        if (bolusProfile == null && profiles != null && !profiles.isEmpty()) {
+            // profiles loaded but the pointer was never set (partial init / publish race):
+            // fall back to the same default LoadDisabledProfilesFromPrefs() uses, so a legacy
+            // dose never produces an empty injection list and IoB never silently reads zero.
+            bolusProfile = profiles.get(0);
+        }
         return bolusProfile;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/Treatments.java
@@ -188,7 +188,8 @@ public class Treatments extends Model {
     }
 
     // take a simple insulin value and produce a list assuming it is bolus insulin - for legacy conversion
-    static private List<InsulinInjection> convertLegacyDoseToBolusInjectionList(final double insulinSum) {
+    // package-private so the #4617 regression test can exercise the legacy IoB conversion directly
+    static List<InsulinInjection> convertLegacyDoseToBolusInjectionList(final double insulinSum) {
         final ArrayList<InsulinInjection> injections = new ArrayList<>();
         val profile = InsulinManager.getBolusProfile();
         if (profile != null) {

--- a/app/src/test/java/com/eveningoutpost/dexdrip/insulin/InsulinManagerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/insulin/InsulinManagerTest.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
  * <p>Regression coverage for xDrip discussion #4617: in legacy (single-insulin) mode a null
  * bolus profile made the injection list come back empty, so IoB/COB/prediction silently vanished.
  *
- * @author Asbjørn Aarrestad - 2026.07 - asbjorn@aarrestad.com
+ * @author Asbjørn Aarrestad - 2026.07
  */
 public class InsulinManagerTest extends RobolectricTestWithConfig {
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/insulin/InsulinManagerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/insulin/InsulinManagerTest.java
@@ -1,0 +1,55 @@
+package com.eveningoutpost.dexdrip.insulin;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+/**
+ * Tests for {@link InsulinManager} bolus-profile invariant.
+ *
+ * <p>Regression coverage for xDrip discussion #4617: in legacy (single-insulin) mode a null
+ * bolus profile made the injection list come back empty, so IoB/COB/prediction silently vanished.
+ *
+ * @author Asbjørn Aarrestad - 2026.07 - asbjorn@aarrestad.com
+ */
+public class InsulinManagerTest extends RobolectricTestWithConfig {
+
+    /** Force a private static field, to simulate a partially-initialized manager. */
+    private static void setStaticField(final String name, final Object value) throws Exception {
+        final Field f = InsulinManager.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(null, value);
+    }
+
+    @Test
+    public void getBolusProfile_fallsBackToFirstProfile_whenPointerNullButProfilesLoaded() throws Exception {
+        // :: Setup - load profiles (this also sets bolusProfile), then simulate the broken state
+        final ArrayList<Insulin> profiles = InsulinManager.getDefaultInstance();
+        setStaticField("bolusProfile", null);
+
+        // :: Act
+        final Insulin result = InsulinManager.getBolusProfile();
+
+        // :: Verify - never null; falls back to the first (default) profile
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo(profiles.get(0).getName());
+    }
+
+    @Test
+    public void getBolusProfile_keepsSelectedProfile_whenAlreadySet() {
+        // :: Setup - select a specific, non-default profile
+        final ArrayList<Insulin> profiles = InsulinManager.getDefaultInstance();
+        InsulinManager.setBolusProfile(profiles.get(1));
+
+        // :: Act
+        final Insulin result = InsulinManager.getBolusProfile();
+
+        // :: Verify - the fallback must not clobber a genuine selection
+        assertThat(result.getName()).isEqualTo(profiles.get(1).getName());
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/TreatmentsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/TreatmentsTest.java
@@ -6,6 +6,7 @@ import com.eveningoutpost.dexdrip.insulin.InsulinManager;
 
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -155,5 +156,26 @@ public class TreatmentsTest extends RobolectricTestWithConfig {
         assertWithMessage("test before").that(before).isEqualTo(30);
         assertWithMessage("test after").that(after).isEqualTo(5);
         Treatments.delete_all();
+    }
+
+    /** Force a private static InsulinManager field, to simulate a partially-initialized manager. */
+    private static void setInsulinManagerField(final String name, final Object value) throws Exception {
+        final Field f = InsulinManager.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(null, value);
+    }
+
+    @Test
+    public void legacyDose_convertsToInjection_whenBolusPointerWasNull() throws Exception {
+        // :: Setup - profiles loaded, but simulate the broken null-pointer state (#4617)
+        InsulinManager.getDefaultInstance();
+        setInsulinManagerField("bolusProfile", null);
+
+        // :: Act - the exact conversion the legacy IoB path runs for a plain insulin dose
+        final List<InsulinInjection> injections = Treatments.convertLegacyDoseToBolusInjectionList(2.0);
+
+        // :: Verify - a usable injection is produced, so IoB will not silently read zero
+        assertThat(injections).hasSize(1);
+        assertThat(injections.get(0).getUnits()).isEqualTo(2.0);
     }
 }


### PR DESCRIPTION
### Problem
In legacy (single-insulin) mode, IoB, COB and the predictive-simulation line
can disappear together, even though treatments are being logged and predictive
simulation is enabled. Reported in
https://github.com/NightscoutFoundation/xDrip/discussions/4617

### Root cause
`InsulinManager.checkInitialized()` guarantees only that the profile list is
loaded, not that the `bolusProfile` pointer is set. Once the app reaches
`profiles != null && bolusProfile == null` (e.g. a partial init where `profiles`
is published before the pointer is assigned), it never self-heals, because
`checkInitialized()` skips re-init while `profiles` is non-null. In legacy mode
`Treatments.convertLegacyDoseToBolusInjectionList()` then returns an empty
injection list for the null profile, so IoB computes to 0 and the display goes
blank. Opening the insulin settings screen re-runs
`LoadDisabledProfilesFromPrefs()`, which sets the pointer — which is why the
issue appears to fix itself temporarily.

### Fix
`getBolusProfile()` falls back to `profiles.get(0)` — the same default
`LoadDisabledProfilesFromPrefs()` already uses — when the pointer is null while
profiles are loaded. The normal (pointer-set) path is unchanged.

### Tests
- `InsulinManagerTest`: fallback fires when the pointer is null; a genuine
  selection is not clobbered.
- `TreatmentsTest`: the legacy conversion produces a usable injection when the
  pointer was null (reproduces the reported symptom).
  `convertLegacyDoseToBolusInjectionList` is relaxed to package-private so the
  test drives the real path.

Full `./gradlew test` passes.

### Not in this PR
Scoped to the leak point. The underlying init ordering (the likely source of the
null) and the matching null-guard on `getBasalProfile()` are left as separate
changes — they touch startup init and aren't deterministically testable here.
