### PR TITLE
Don't set CATEGORY_ALARM unconditionally in XdripNotificationCompat.build()

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompat.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompat.java
@@ -27,8 +27,6 @@ public class XdripNotificationCompat extends NotificationCompat {
         builder.setGroup(null);
         builder.setGroupSummary(false);
 
-        builder.setCategory(NotificationCompat.CATEGORY_ALARM);
-
         final Notification n = builder.build();
 
         UserError.Log.d(TAG, "NotifCompat: chan=" + id +

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
@@ -1,0 +1,61 @@
+package com.eveningoutpost.dexdrip.utilitymodels;
+
+import static com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels.BG_ALERT_CHANNEL;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import androidx.core.app.NotificationCompat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import lombok.val;
+
+/**
+ * Tests for {@link XdripNotificationCompat}.
+ * <p>
+ * The alarm category is what tells a paired watch that a notification is an alarm, and some watches
+ * drop notifications carrying it. Deciding whether an alert is an alarm belongs to the caller:
+ * {@code AlertPlayer} sets the category only when the alert overrides silent mode. This helper must
+ * therefore carry a caller's category through untouched, and never add one of its own.
+ *
+ * @author Asbjørn Aarrestad - 2026.07
+ */
+public class XdripNotificationCompatTest extends RobolectricTestWithConfig {
+
+    @Test
+    public void buildDoesNotAddACategoryOfItsOwn() {
+        // :: Setup
+        val builder = alertBuilder();
+
+        // :: Act
+        val notification = XdripNotificationCompat.build(builder);
+
+        // :: Verify
+        assertWithMessage("category of a notification the caller left uncategorised")
+                .that(notification.category).isNull();
+    }
+
+    @Test
+    public void buildKeepsTheCategorySetByTheCaller() {
+        // :: Setup
+        val builder = alertBuilder();
+        builder.setCategory(NotificationCompat.CATEGORY_ALARM);
+
+        // :: Act
+        val notification = XdripNotificationCompat.build(builder);
+
+        // :: Verify
+        assertWithMessage("category set by the caller, as AlertPlayer does when overriding silent mode")
+                .that(notification.category).isEqualTo(NotificationCompat.CATEGORY_ALARM);
+    }
+
+    private NotificationCompat.Builder alertBuilder() {
+        val builder = new NotificationCompat.Builder(RuntimeEnvironment.getApplication().getApplicationContext(), BG_ALERT_CHANNEL);
+        builder.setContentTitle("title");
+        builder.setContentText("content");
+        builder.setVibrate(new long[]{123, 456, 789});
+        return builder;
+    }
+}


### PR DESCRIPTION
Fixes the regression reported in #4625: a Suunto watch stopped showing xDrip alerts after 2026.07.12, because its companion app ignores notifications carrying the alarm category.

`XdripNotificationCompat.build()` now sets `CATEGORY_ALARM` on every notification passing through it. Before, only `AlertPlayer` set it, and only when the alert had "Override Silent Mode" ticked and the volume profile was not vibrate-only or silent.

Most users see no change: the default alerts are created with Override Silent Mode on, so they already carried the category. It only affects users who turned it off — which is exactly what the reporter did, precisely because the watch drops alarm-category notifications.

Measured on the real app (Android 16, same database and alert config, only this line differing, number icon on so the ongoing channel is at `IMPORTANCE_DEFAULT`):

| build | alert category | alert grouped | ongoing grouped |
|---|---|---|---|
| current | `alarm` | yes | no (`overrideGroupKey=null`) |
| this PR | none | yes | no |

The category is not what keeps the ongoing notification out of the Android 16 alert cluster (#4611). Posting the same burst with and without it groups identically; what separates them is the channel importance split, and that is untouched here. This holds with the number icon on as well, where the ongoing channel is created at `IMPORTANCE_DEFAULT` rather than `IMPORTANCE_LOW`.

Tests: two Robolectric tests. Without the fix, `buildDoesNotAddACategoryOfItsOwn` fails with `expected: null but was: alarm`. The second one guards the behaviour that has to survive — a category set by the caller, as `AlertPlayer` does, is passed through untouched. Full `./gradlew test` green.
