### PR TITLE
Harden notification-channel fallback and name the shared channels

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
@@ -75,6 +75,8 @@ public class NotificationChannels {
         map.put(BG_PERSISTENT_HIGH_CHANNEL, xdrip.getAppContext().getString(R.string.persistent_high_alert));
         map.put(CALIBRATION_CHANNEL, xdrip.getAppContext().getString(R.string.calibration_alerts));
         map.put(ONGOING_CHANNEL, "Ongoing Notification");
+        map.put(GENERAL_CHANNEL, "General");
+        map.put(SENSOR_EXPIRY_CHANNEL, "Sensor expiry");
     }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompat.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompat.java
@@ -18,8 +18,11 @@ public class XdripNotificationCompat extends NotificationCompat {
         try {
             id = NotificationChannels.getChan(builder).getId();
         } catch (Exception e) {
-            // Fallback to generic alert channel if the guesser fails
-            id = NotificationChannels.BG_ALERT_CHANNEL;
+            // Guesser failed. Fall back to the general channel and make sure it exists,
+            // otherwise the notification is silently dropped on API 26+.
+            id = NotificationChannels.GENERAL_CHANNEL;
+            NotificationChannels.setupGeneralChannel();
+            UserError.Log.e(TAG, "getChan() failed, fell back to GENERAL_CHANNEL: " + e);
         }
         builder.setChannelId(id);
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/JoHShowNotificationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/JoHShowNotificationTest.java
@@ -41,8 +41,10 @@ public class JoHShowNotificationTest extends RobolectricTestWithConfig {
     /** A caller that supplies no channel still gets a notification, on a channel that exists. */
     @Test
     public void nullChannelNotificationIsDeliveredOnAnExistingChannel() {
+        // Act
         JoH.showNotification("title", "body", null, 4242, null, false, false, null, null, null, false);
 
+        // Verify
         final Notification n = delivered(4242);
         assertWithMessage("channel it landed on exists")
                 .that(notificationManager().getNotificationChannel(n.getChannelId()))
@@ -57,9 +59,11 @@ public class JoHShowNotificationTest extends RobolectricTestWithConfig {
      */
     @Test
     public void sensorExpiryChannelNotificationIsDeliveredWithAReadableName() {
+        // Act
         JoH.showNotification("Sensor expiring", "soon", null, 4243,
                 NotificationChannels.SENSOR_EXPIRY_CHANNEL, true, true, null, null, null, true);
 
+        // Verify
         final Notification n = delivered(4243);
         assertWithMessage("channel exists")
                 .that(notificationManager().getNotificationChannel(n.getChannelId()))
@@ -78,8 +82,10 @@ public class JoHShowNotificationTest extends RobolectricTestWithConfig {
      */
     @Test
     public void shorterOverloadWithoutChannelIsDeliveredOnAnExistingChannel() {
+        // Act
         JoH.showNotification("title", "body", null, 4244, false, false, false);
 
+        // Verify
         final Notification n = delivered(4244);
         assertWithMessage("channel it landed on exists")
                 .that(notificationManager().getNotificationChannel(n.getChannelId()))

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/JoHShowNotificationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/JoHShowNotificationTest.java
@@ -31,7 +31,9 @@ public class JoHShowNotificationTest extends RobolectricTestWithConfig {
         assertWithMessage("exactly one notification delivered")
                 .that(shadowOf(notificationManager()).size())
                 .isEqualTo(1);
-        return shadowOf(notificationManager()).getNotification(id);
+        final Notification n = shadowOf(notificationManager()).getNotification(id);
+        assertWithMessage("a notification was posted under id " + id).that(n).isNotNull();
+        return n;
     }
 
     // ---- null channel: the general fallback path ----------------------------
@@ -65,5 +67,22 @@ public class JoHShowNotificationTest extends RobolectricTestWithConfig {
         assertWithMessage("channel name is readable, not the raw id")
                 .that(notificationManager().getNotificationChannel(n.getChannelId()).getName().toString())
                 .startsWith("Sensor expiry");
+    }
+
+    // ---- shorter overloads still deliver -----------------------------------
+
+    /**
+     * A shorter overload that omits the channel id still delivers, on a channel that exists —
+     * i.e. the null → General path is reachable through the whole public surface, not just the
+     * widest overload.
+     */
+    @Test
+    public void shorterOverloadWithoutChannelIsDeliveredOnAnExistingChannel() {
+        JoH.showNotification("title", "body", null, 4244, false, false, false);
+
+        final Notification n = delivered(4244);
+        assertWithMessage("channel it landed on exists")
+                .that(notificationManager().getNotificationChannel(n.getChannelId()))
+                .isNotNull();
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/JoHShowNotificationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/JoHShowNotificationTest.java
@@ -1,0 +1,69 @@
+package com.eveningoutpost.dexdrip.models;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels;
+
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+/**
+ * The public notification entry point must deliver, and must never post to a channel that
+ * does not exist — the failure mode behind the sensor-expiry drop.
+ *
+ * @author Asbjørn Aarrestad - 2026.07
+ */
+public class JoHShowNotificationTest extends RobolectricTestWithConfig {
+
+    private NotificationManager notificationManager() {
+        return (NotificationManager) RuntimeEnvironment.getApplication()
+                .getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    /** Assert exactly one notification was delivered and return the one posted under {@code id}. */
+    private Notification delivered(int id) {
+        assertWithMessage("exactly one notification delivered")
+                .that(shadowOf(notificationManager()).size())
+                .isEqualTo(1);
+        return shadowOf(notificationManager()).getNotification(id);
+    }
+
+    // ---- null channel: the general fallback path ----------------------------
+
+    /** A caller that supplies no channel still gets a notification, on a channel that exists. */
+    @Test
+    public void nullChannelNotificationIsDeliveredOnAnExistingChannel() {
+        JoH.showNotification("title", "body", null, 4242, null, false, false, null, null, null, false);
+
+        final Notification n = delivered(4242);
+        assertWithMessage("channel it landed on exists")
+                .that(notificationManager().getNotificationChannel(n.getChannelId()))
+                .isNotNull();
+    }
+
+    // ---- named channel: the sensor-expiry shape -----------------------------
+
+    /**
+     * Mirrors the real sensor-expiry call: delivered, on an existing channel, and the channel
+     * carries a human-readable name rather than the raw id.
+     */
+    @Test
+    public void sensorExpiryChannelNotificationIsDeliveredWithAReadableName() {
+        JoH.showNotification("Sensor expiring", "soon", null, 4243,
+                NotificationChannels.SENSOR_EXPIRY_CHANNEL, true, true, null, null, null, true);
+
+        final Notification n = delivered(4243);
+        assertWithMessage("channel exists")
+                .that(notificationManager().getNotificationChannel(n.getChannelId()))
+                .isNotNull();
+        assertWithMessage("channel name is readable, not the raw id")
+                .that(notificationManager().getNotificationChannel(n.getChannelId()).getName().toString())
+                .startsWith("Sensor expiry");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
@@ -34,6 +34,7 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
     /** The general fallback channel resolves to a human-readable name, not its raw id. */
     @Test
     public void generalChannelResolvesToAReadableName() {
+        // Act and verify
         assertWithMessage("general channel name")
                 .that(NotificationChannels.getString(NotificationChannels.GENERAL_CHANNEL))
                 .isEqualTo("General");
@@ -42,6 +43,7 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
     /** The sensor-expiry channel resolves to a human-readable name, not its raw id. */
     @Test
     public void sensorExpiryChannelResolvesToAReadableName() {
+        // Act and verify
         assertWithMessage("sensor expiry channel name")
                 .that(NotificationChannels.getString(NotificationChannels.SENSOR_EXPIRY_CHANNEL))
                 .isEqualTo("Sensor expiry");
@@ -50,6 +52,7 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
     /** An id with no mapping is returned unchanged. */
     @Test
     public void unknownChannelIdIsReturnedUnchanged() {
+        // Act and verify
         assertWithMessage("unknown id passthrough")
                 .that(NotificationChannels.getString("no-such-channel-id"))
                 .isEqualTo("no-such-channel-id");
@@ -75,9 +78,11 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
      */
     @Test
     public void differentVibrationYieldsDifferentChannels() {
+        // Act
         final NotificationChannel vibrating = NotificationChannels.getChan(builder().setVibrate(pattern));
         final NotificationChannel silent = NotificationChannels.getChan(builder());
 
+        // Verify
         assertWithMessage("distinct channels for distinct settings")
                 .that(vibrating.getId())
                 .isNotEqualTo(silent.getId());
@@ -86,9 +91,11 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
     /** Identical settings must reuse one channel, not spawn duplicates. */
     @Test
     public void identicalSettingsShareOneChannel() {
+        // Act
         final NotificationChannel first = NotificationChannels.getChan(builder().setVibrate(pattern));
         final NotificationChannel second = NotificationChannels.getChan(builder().setVibrate(pattern));
 
+        // Verify
         assertWithMessage("shared channel for identical settings")
                 .that(first.getId())
                 .isEqualTo(second.getId());
@@ -99,10 +106,12 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
     /** Each setup method registers its channel under the intended readable name. */
     @Test
     public void setupMethodsCreateNamedChannels() {
+        // Act
         NotificationChannels.setupGeneralChannel();
         NotificationChannels.setupSensorExpiryChannel();
         NotificationChannels.setupTestChannel();
 
+        // Verify
         assertWithMessage("general").that(nameOf(NotificationChannels.GENERAL_CHANNEL)).isEqualTo("General");
         assertWithMessage("sensor expiry").that(nameOf(NotificationChannels.SENSOR_EXPIRY_CHANNEL)).isEqualTo("Sensor expiry");
         assertWithMessage("icon test").that(nameOf(NotificationChannels.ICON_TEST_CHANNEL)).isEqualTo("xDrip Icon Test");
@@ -119,9 +128,11 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
     /** The ongoing/foreground channel must be silent and must not vibrate. */
     @Test
     public void ongoingChannelIsSilentAndDoesNotVibrate() {
+        // Act
         final NotificationChannel ongoing = NotificationChannels.getChan(
                 new android.app.Notification.Builder(RuntimeEnvironment.getApplication().getApplicationContext()));
 
+        // Verify
         assertWithMessage("ongoing id").that(ongoing.getId()).isEqualTo(NotificationChannels.ONGOING_CHANNEL);
         assertWithMessage("ongoing is silent").that(ongoing.getSound()).isNull();
         assertWithMessage("ongoing does not vibrate").that(ongoing.shouldVibrate()).isFalse();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
@@ -3,6 +3,9 @@ package com.eveningoutpost.dexdrip.utilitymodels;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
 
 import androidx.core.app.NotificationCompat;
 
@@ -50,5 +53,77 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
         assertWithMessage("unknown id passthrough")
                 .that(NotificationChannels.getString("no-such-channel-id"))
                 .isEqualTo("no-such-channel-id");
+    }
+
+    // ---- customisation property (why the per-hash channels exist) -----------
+
+    private NotificationManager nm() {
+        return (NotificationManager) RuntimeEnvironment.getApplication()
+                .getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    private NotificationCompat.Builder builder() {
+        return new NotificationCompat.Builder(
+                RuntimeEnvironment.getApplication().getApplicationContext(),
+                NotificationChannels.GENERAL_CHANNEL);
+    }
+
+    /**
+     * Notifications that differ in vibration must land on different channels, so a user can
+     * customise them independently. This is the behaviour the dynamic-hash channels exist for
+     * — asserted without reference to the hash encoding itself.
+     */
+    @Test
+    public void differentVibrationYieldsDifferentChannels() {
+        final NotificationChannel vibrating = NotificationChannels.getChan(builder().setVibrate(pattern));
+        final NotificationChannel silent = NotificationChannels.getChan(builder());
+
+        assertWithMessage("distinct channels for distinct settings")
+                .that(vibrating.getId())
+                .isNotEqualTo(silent.getId());
+    }
+
+    /** Identical settings must reuse one channel, not spawn duplicates. */
+    @Test
+    public void identicalSettingsShareOneChannel() {
+        final NotificationChannel first = NotificationChannels.getChan(builder().setVibrate(pattern));
+        final NotificationChannel second = NotificationChannels.getChan(builder().setVibrate(pattern));
+
+        assertWithMessage("shared channel for identical settings")
+                .that(first.getId())
+                .isEqualTo(second.getId());
+    }
+
+    // ---- setup methods create named channels --------------------------------
+
+    /** Each setup method registers its channel under the intended readable name. */
+    @Test
+    public void setupMethodsCreateNamedChannels() {
+        NotificationChannels.setupGeneralChannel();
+        NotificationChannels.setupSensorExpiryChannel();
+        NotificationChannels.setupTestChannel();
+
+        assertWithMessage("general").that(nameOf(NotificationChannels.GENERAL_CHANNEL)).isEqualTo("General");
+        assertWithMessage("sensor expiry").that(nameOf(NotificationChannels.SENSOR_EXPIRY_CHANNEL)).isEqualTo("Sensor expiry");
+        assertWithMessage("icon test").that(nameOf(NotificationChannels.ICON_TEST_CHANNEL)).isEqualTo("xDrip Icon Test");
+    }
+
+    private String nameOf(String channelId) {
+        final NotificationChannel c = nm().getNotificationChannel(channelId);
+        assertWithMessage("channel " + channelId + " exists").that(c).isNotNull();
+        return c.getName().toString();
+    }
+
+    // ---- ongoing channel is unobtrusive -------------------------------------
+
+    /** The ongoing/foreground channel must be silent and must not vibrate. */
+    @Test
+    public void ongoingChannelIsSilentAndDoesNotVibrate() {
+        final NotificationChannel ongoing = NotificationChannels.getChan(
+                new android.app.Notification.Builder(RuntimeEnvironment.getApplication().getApplicationContext()));
+
+        assertWithMessage("ongoing id").that(ongoing.getId()).isEqualTo(NotificationChannels.ONGOING_CHANNEL);
+        assertWithMessage("ongoing is silent").that(ongoing.getSound()).isNull();
+        assertWithMessage("ongoing does not vibrate").that(ongoing.shouldVibrate()).isFalse();
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
@@ -25,4 +25,30 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
         assertWithMessage("got builder by reflection 2").that(mNotification.getClass()).isEqualTo(Notification.class);
         assertWithMessage("got builder by reflection 3").that(mNotification.vibrate).isEqualTo(pattern);
     }
+
+    // ---- name resolution ----------------------------------------------------
+
+    /** The general fallback channel resolves to a human-readable name, not its raw id. */
+    @Test
+    public void generalChannelResolvesToAReadableName() {
+        assertWithMessage("general channel name")
+                .that(NotificationChannels.getString(NotificationChannels.GENERAL_CHANNEL))
+                .isEqualTo("General");
+    }
+
+    /** The sensor-expiry channel resolves to a human-readable name, not its raw id. */
+    @Test
+    public void sensorExpiryChannelResolvesToAReadableName() {
+        assertWithMessage("sensor expiry channel name")
+                .that(NotificationChannels.getString(NotificationChannels.SENSOR_EXPIRY_CHANNEL))
+                .isEqualTo("Sensor expiry");
+    }
+
+    /** An id with no mapping is returned unchanged. */
+    @Test
+    public void unknownChannelIdIsReturnedUnchanged() {
+        assertWithMessage("unknown id passthrough")
+                .that(NotificationChannels.getString("no-such-channel-id"))
+                .isEqualTo("no-such-channel-id");
+    }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
@@ -40,8 +40,10 @@ public class XdripNotificationCompatTest extends RobolectricTestWithConfig {
      */
     @Test
     public void unresolvableBuilderFallsBackToAnExistingGeneralChannel() {
+        // Setup and act
         final Notification n = XdripNotificationCompat.build(builderWithChannel(null));
 
+        // Verify
         assertWithMessage("fallback channel id")
                 .that(n.getChannelId())
                 .isEqualTo(NotificationChannels.GENERAL_CHANNEL);
@@ -55,6 +57,7 @@ public class XdripNotificationCompatTest extends RobolectricTestWithConfig {
     /** build() never emits a notification without a channel, on any path. */
     @Test
     public void buildNeverLeavesANullChannelId() {
+        // Act and verify
         assertWithMessage("resolved builder has a channel")
                 .that(XdripNotificationCompat.build(builderWithChannel(NotificationChannels.GENERAL_CHANNEL)).getChannelId())
                 .isNotNull();
@@ -66,8 +69,10 @@ public class XdripNotificationCompatTest extends RobolectricTestWithConfig {
     /** A resolved notification is delivered on a channel that exists, as an independent alert. */
     @Test
     public void resolvedBuilderIsDeliverableAndNotAGroupSummary() {
+        // Setup and act
         final Notification n = XdripNotificationCompat.build(builderWithChannel(NotificationChannels.GENERAL_CHANNEL));
 
+        // Verify
         assertWithMessage("channel exists")
                 .that(notificationManager().getNotificationChannel(n.getChannelId()))
                 .isNotNull();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
@@ -1,0 +1,78 @@
+package com.eveningoutpost.dexdrip.utilitymodels;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+
+import androidx.core.app.NotificationCompat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+/**
+ * Behaviour of the single funnel every notification passes through before delivery.
+ *
+ * @author Asbjørn Aarrestad - 2026.07
+ */
+public class XdripNotificationCompatTest extends RobolectricTestWithConfig {
+
+    private NotificationManager notificationManager() {
+        return (NotificationManager) RuntimeEnvironment.getApplication()
+                .getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    private NotificationCompat.Builder builderWithChannel(String channelId) {
+        return new NotificationCompat.Builder(
+                RuntimeEnvironment.getApplication().getApplicationContext(), channelId)
+                .setContentTitle("t").setContentText("c");
+    }
+
+    // ---- fallback path (regression) -----------------------------------------
+
+    /**
+     * When the channel guesser cannot resolve a channel, the notification must still be
+     * deliverable: it falls back to the general channel AND that channel exists. Without the
+     * fix the fallback points at a channel that was never created, so it is silently dropped.
+     */
+    @Test
+    public void unresolvableBuilderFallsBackToAnExistingGeneralChannel() {
+        final Notification n = XdripNotificationCompat.build(builderWithChannel(null));
+
+        assertWithMessage("fallback channel id")
+                .that(n.getChannelId())
+                .isEqualTo(NotificationChannels.GENERAL_CHANNEL);
+        assertWithMessage("fallback channel exists")
+                .that(notificationManager().getNotificationChannel(NotificationChannels.GENERAL_CHANNEL))
+                .isNotNull();
+    }
+
+    // ---- invariants ---------------------------------------------------------
+
+    /** build() never emits a notification without a channel, on any path. */
+    @Test
+    public void buildNeverLeavesANullChannelId() {
+        assertWithMessage("resolved builder has a channel")
+                .that(XdripNotificationCompat.build(builderWithChannel(NotificationChannels.GENERAL_CHANNEL)).getChannelId())
+                .isNotNull();
+        assertWithMessage("unresolvable builder has a channel")
+                .that(XdripNotificationCompat.build(builderWithChannel(null)).getChannelId())
+                .isNotNull();
+    }
+
+    /** A resolved notification is delivered on a channel that exists, as an independent alert. */
+    @Test
+    public void resolvedBuilderIsDeliverableAndNotAGroupSummary() {
+        final Notification n = XdripNotificationCompat.build(builderWithChannel(NotificationChannels.GENERAL_CHANNEL));
+
+        assertWithMessage("channel exists")
+                .that(notificationManager().getNotificationChannel(n.getChannelId()))
+                .isNotNull();
+        assertWithMessage("not a group summary")
+                .that((n.flags & Notification.FLAG_GROUP_SUMMARY) != 0)
+                .isFalse();
+    }
+}


### PR DESCRIPTION
## What

Two small hardening fixes in the shared notification path, plus tests for the
whole chain.

1. `XdripNotificationCompat.build()` fell back to `BG_ALERT_CHANNEL` when the
   channel guesser threw. `getChan()` never creates that id (it posts to
   `id + hash`), so on API 26+ the notification is silently dropped. Fall back
   to `GENERAL_CHANNEL` instead and create it if missing, and log the degraded
   path.

2. `GENERAL_CHANNEL` and `SENSOR_EXPIRY_CHANNEL` were missing from the channel
   name map, so they showed under their raw id in Android's channel settings.
   Added the names already used elsewhere ("General", "Sensor expiry").

## Why

The fallback is a safety net, not a routing path — but if it ever fires it must
land on a channel that exists. General is also the channel the null-channel
source fix (#4628) now routes to, so it needs a readable name.

Glucose-alert behaviour is unchanged: those resolve through `getChan()` as
before and never touch the fallback.

Trade-off: the degraded fallback lands on `GENERAL` (IMPORTANCE_DEFAULT) rather
than the per-alert HIGH. That is strictly better than a silent drop.

## Tests

Robolectric, no device needed:
- `JoHShowNotificationTest` — drives `showNotification()` end to end and asserts
  it is delivered on a channel that exists (null-channel, sensor-expiry, and the
  shorter overload).
- `XdripNotificationCompatTest` — the fallback regression: an unresolvable
  builder still delivers on an existing General channel; `build()` never leaves
  a null channel id.
- `NotificationChannelsTest` — extended: channels are keyed by their
  customisation, setup methods create named channels, ongoing channel stays
  silent; kept the reflection canary.

Full `./gradlew test` green.
