### PR TITLE
Fix crash loop when Wear OS integration is enabled

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/CollectionServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/CollectionServiceStarter.java
@@ -251,7 +251,7 @@ public class CollectionServiceStarter {
             if (prefs.getBoolean("wear_sync", false)) {//KS
                 boolean enable_wearG5 = prefs.getBoolean("enable_wearG5", false);
                 boolean force_wearG5 = prefs.getBoolean("force_wearG5", false);
-                startServiceCompat(WatchUpdaterService.class);
+                startPlainServiceCompat(WatchUpdaterService.class);
                 if (!enable_wearG5 || (enable_wearG5 && !force_wearG5)) { //don't start if Wear G5 Collector Service is active
                     startBtWixelService();
                 }
@@ -276,7 +276,7 @@ public class CollectionServiceStarter {
             if (prefs.getBoolean("wear_sync", false)) {//KS
                 boolean enable_wearG5 = prefs.getBoolean("enable_wearG5", false);
                 boolean force_wearG5 = prefs.getBoolean("force_wearG5", false);
-                startServiceCompat(new Intent(context, WatchUpdaterService.class));
+                startPlainServiceCompat(new Intent(context, WatchUpdaterService.class));
                 if (!enable_wearG5 || (enable_wearG5 && !force_wearG5)) { //don't start if Wear G5 Collector Service is active
                     startBtShareService();
                 }
@@ -293,7 +293,7 @@ public class CollectionServiceStarter {
             if (prefs.getBoolean("wear_sync", false)) {//KS
                 boolean enable_wearG5 = prefs.getBoolean("enable_wearG5", false);
                 boolean force_wearG5 = prefs.getBoolean("force_wearG5", false);
-                startServiceCompat(new Intent(context, WatchUpdaterService.class));
+                startPlainServiceCompat(new Intent(context, WatchUpdaterService.class));
                 if (!enable_wearG5 || (enable_wearG5 && !force_wearG5)) { //don't start if Wear G5 Collector Service is active
                     startBtG5Service();
                 } else {
@@ -318,7 +318,7 @@ public class CollectionServiceStarter {
             if (prefs.getBoolean("wear_sync", false)) {//KS
                 boolean enable_wearG5 = prefs.getBoolean("enable_wearG5", false);
                 boolean force_wearG5 = prefs.getBoolean("force_wearG5", false);
-                startServiceCompat(new Intent(context, WatchUpdaterService.class));
+                startPlainServiceCompat(new Intent(context, WatchUpdaterService.class));
                 if (!enable_wearG5 || (enable_wearG5 && !force_wearG5)) { //don't start if Wear G5 Collector Service is active
                     startBtWixelService();
                 }
@@ -511,6 +511,21 @@ public class CollectionServiceStarter {
         } catch (Exception e) {
             // If foreground fails (e.g. app is already in foreground), fall back to standard start
             mContext.startService(intent);
+        }
+    }
+
+    private void startPlainServiceCompat(final Class service) {
+        startPlainServiceCompat(new Intent(xdrip.getAppContext(), service));
+    }
+
+    // Starts a service which does not run itself in the foreground.
+    @SuppressWarnings("ConstantConditions")
+    private void startPlainServiceCompat(final Intent intent) {
+        try {
+            Log.d(TAG, String.format("Starting service: %s", intent.getComponent().getClassName()));
+            mContext.startService(intent);
+        } catch (Exception e) {
+            Log.e(TAG, "Could not start service: " + e);
         }
     }
 


### PR DESCRIPTION
With wear_sync enabled, the app is killed by Android roughly every 30 seconds:

  FATAL EXCEPTION: main
  android.app.RemoteServiceException$ForegroundServiceDidNotStartInTime
  Exception: Context.startForegroundService() did not then call
  Service.startForeground(): ServiceRecord{... .wearintegration.
  WatchUpdaterService ...}
      at CollectionServiceStarter.startServiceCompat(...:510)
      at CollectionServiceStarter.start(...)

startForegroundService() is a promise that the started service will call startForeground() shortly afterwards. WatchUpdaterService never does: it is a WearableListenerService, it holds no ongoing notification, and unlike the collectors (and PebbleWatchSync, which extends ForegroundService) it declares no android:foregroundServiceType in the manifest. It was never meant to be a foreground service - everywhere else in the app it is started with a plain startService(), see Home and NewDataObserver. The file's own TODO already states the invariant this violates: "everything started here must be capable of being foreground if it is started with compat".

The existing try/catch cannot help, because the exception is delivered asynchronously on the main looper seconds after the start call has returned successfully.

Start it plainly instead. The crash is most visible while readings are missing - a sensor change, a pairing problem - because MissedReadingService then restarts the collector every couple of minutes and each restart re-issues the doomed call, so the app crash loops exactly when it is most needed. Losing the app also loses its foreground collector, so this compounds rather than recovers.

Existing behaviour is otherwise unchanged: collectors and the pebble service still start with startForegroundService(), and a plain start is safe from the background while a collector foreground service is running, which is how the app already starts this service from NewDataObserver on every new reading.

Fixes #4672