### PR TITLE
Fix followers being left with a stale collector status

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
@@ -516,11 +516,14 @@ public class GcmActivity extends FauxActivity {
         return false;
     }
 
-    public static void sendNanoStatusUpdate(final String prefix, final String json) {
+    // returns true when the update was actually queued for sending
+    public static boolean sendNanoStatusUpdate(final String prefix, final String json) {
         if (JoH.pratelimit("gcm-nscu" + prefix, 30)) {
             UserError.Log.d(TAG, "Sending nano status update: " + prefix + " " + json);
             sendMessage("nscu" + prefix, json);
+            return true;
         }
+        return false;
     }
 
     public static void sendMimeoGraphUpdate(final String json) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NanoStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NanoStatus.java
@@ -187,9 +187,14 @@ public class NanoStatus {
                 UserError.Log.d(TAG, "keepfollower updated called: " + prefix + " " + rateLimit);
                 if (rateLimit == 0 || JoH.pratelimit("keep-follower-updated" + prefix, rateLimit)) {
                     final String serialized = SpannableSerializer.serializeSpannableString(nanoStatusColor(prefix.equals("") ? "collector" : prefix));
-                    if (PersistentStore.updateStringIfDifferent(LAST_COLLECTOR_STATUS_STORE + prefix, serialized)) {
-                        Inevitable.task("update-follower-to-nanostatus" + prefix, 500, () ->
-                                GcmActivity.sendNanoStatusUpdate(prefix, PersistentStore.getString(LAST_COLLECTOR_STATUS_STORE + prefix)));
+                    // record what was sent, not what was computed, so an update which never
+                    // went out is retried instead of being remembered as delivered
+                    if (!serialized.equals(PersistentStore.getString(LAST_COLLECTOR_STATUS_STORE + prefix))) {
+                        Inevitable.task("update-follower-to-nanostatus" + prefix, 500, () -> {
+                            if (GcmActivity.sendNanoStatusUpdate(prefix, serialized)) {
+                                PersistentStore.setString(LAST_COLLECTOR_STATUS_STORE + prefix, serialized);
+                            }
+                        });
                     }
                 } else {
                     UserError.Log.d(TAG, "Ratelimiting keepFollowerUpdated check on " + prefix + " @ " + rateLimit);


### PR DESCRIPTION
A follower can keep showing an old collector status indefinitely - most visibly "Searching for <transmitter>" long after the master has found the sensor and is collecting normally again.

The master sends its status only when the text changes, and marks it as sent by storing it before the send is attempted. The send can then not happen at all: sendNanoStatusUpdate() drops the update when its 30 second rate limit is in effect, which is easily hit while a sensor start moves the status through several values, and the send is deferred by half a second so it is also lost if the process dies first. Either way the stored value already matches what was computed, so the update is never retried and the follower is stuck with whatever it last received.

Store the status once it has actually been handed to the sender, so a dropped update is simply picked up again on the next cycle.