### PR TITLE
Ns readonly treatment download

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/DoNothingService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/DoNothingService.java
@@ -21,6 +21,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.ForegroundServiceStarter;
 import com.eveningoutpost.dexdrip.utilitymodels.InstalledApps;
 import com.eveningoutpost.dexdrip.utilitymodels.NanoStatus;
+import com.eveningoutpost.dexdrip.utilitymodels.NightscoutUploader;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utilitymodels.StatusItem;
 import com.eveningoutpost.dexdrip.ui.helpers.Span;
@@ -139,6 +140,14 @@ public class DoNothingService extends Service {
                 if (minsago > 6) {
                     if (Home.get_follower()) GcmActivity.requestPing();
                     sleep_time = (minsago < 60) ? ((minsago / 6) * 1000) : 1000; // increase sleep time up to 10s for first hour or revert
+                }
+
+                if (Home.get_follower()) {
+                    // read-only Nightscout treatments download (BG checks / notes entered in
+                    // AAPS) also from the background, not only when the Home screen is opened
+                    // - no-op unless cloud_storage_api_download_enable is set, internally rate
+                    // limited and never uploads anything
+                    NightscoutUploader.launchDownloadRest();
                 }
 
                 try {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutTreatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutTreatments.java
@@ -28,6 +28,7 @@ public class NightscoutTreatments {
 
     private static final HashSet<String> bad_uuids = new HashSet<>();
     private static final HashSet<String> bad_bloodtest_uuids = new HashSet<>();
+    private static final HashSet<String> logged_non_finger_ids = new HashSet<>();
 
     public static boolean processTreatmentResponse(final String response) throws Exception {
         boolean new_data = false;
@@ -90,7 +91,9 @@ public class NightscoutTreatments {
                                 UserError.Log.d(TAG, "Already a bloodtest with uuid: " + uuid);
                         }
                     } else {
-                        if (JoH.quietratelimit("blood-test-type-finger", 2)) {
+                        // the same entries reappear in every download pass - complain only once
+                        // per entry, but keep rechecking so a later edit to Finger gets imported
+                        if (logged_non_finger_ids.add(nightscout_id)) {
                             UserError.Log.e(TAG, "Cannot use bloodtest which is not type Finger: " + tr.getString("glucoseType"));
                         }
                     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutTreatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutTreatments.java
@@ -1,5 +1,6 @@
 package com.eveningoutpost.dexdrip.utilitymodels;
 
+import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.models.BloodTest;
 import com.eveningoutpost.dexdrip.models.DateUtil;
@@ -30,6 +31,7 @@ public class NightscoutTreatments {
 
     public static boolean processTreatmentResponse(final String response) throws Exception {
         boolean new_data = false;
+        boolean new_bloodtest = false;
 
         final JSONArray jsonArray = new JSONArray(response);
         for (int i = 0; i < jsonArray.length(); i++) {
@@ -77,6 +79,7 @@ public class NightscoutTreatments {
                                 bt.uuid = uuid; // override random uuid with nightscout one
                                 bt.saveit();
                                 new_data = true;
+                                new_bloodtest = true;
                                 UserError.Log.ueh(TAG, "Received new Bloodtest data from Nightscout: " + BgGraphBuilder.unitized_string_with_units_static(mgdl) + " @ " + JoH.dateTimeText(timestamp));
                             } else {
                                 UserError.Log.d(TAG, "Error creating bloodtest record: " + mgdl + " mgdl " + tr.toString());
@@ -204,6 +207,11 @@ public class NightscoutTreatments {
                     }
                 }
             }
+        }
+        if (new_bloodtest) {
+            // fan newly downloaded blood tests out over xDrip sync so other family
+            // devices get the marker without downloading from Nightscout themselves
+            GcmActivity.syncBloodTests();
         }
         return new_data;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
@@ -190,13 +190,34 @@ public class NightscoutUploader {
     }
 
     public static void launchDownloadRest() {
-        if (Pref.getBooleanDefaultFalse("cloud_storage_api_enable")
-                && Pref.getBooleanDefaultFalse("cloud_storage_api_download_enable")) {
+        // Download does not require upload (cloud_storage_api_enable) to be on: with only
+        // the download switch enabled this is a read-only Nightscout treatments client,
+        // e.g. so a device can receive BG checks / notes entered in AAPS via Nightscout
+        // while something else (AAPS) remains the sole uploader.
+        if (Pref.getBooleanDefaultFalse("cloud_storage_api_download_enable")
+                && haveValidBaseUrl()) {
             if (JoH.ratelimit("cloud_treatment_download", 60)) {
                 final NightscoutUploader uploader = new NightscoutUploader(xdrip.getAppContext());
                 uploader.downloadRest(500);
             }
         }
+    }
+
+    // quietly skip download when the base url is unset, template or unparseable
+    private static boolean haveValidBaseUrl() {
+        final String base = Pref.getString("cloud_storage_api_base", "").trim();
+        if (base.isEmpty() || base.contains("{") || base.contains("}")) return false;
+        for (String url : base.split(" ")) {
+            url = url.trim();
+            if (url.isEmpty()) continue;
+            try {
+                new URI(url);
+                return true;
+            } catch (URISyntaxException e) {
+                // try any further space separated entries
+            }
+        }
+        return false;
     }
 
     public static boolean isNightscoutCompatible(String url) {

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -53,7 +53,6 @@
                     android:title="@string/send_display_glucose" />
                 <EditTextPreference
                     android:defaultValue="@string/pref_default_api_url"
-                    android:dependency="cloud_storage_api_enable"
                     android:dialogMessage="@string/pref_message_api_url"
                     android:dialogTitle="@string/pref_dialog_api_url"
                     android:inputType="textUri"
@@ -63,11 +62,9 @@
 
                 <PreferenceScreen
                     android:key="download_treatments_screen"
-                    android:title="@string/title_cloud_storage_api_download_enable"
-                    android:dependency="cloud_storage_api_enable">
+                    android:title="@string/title_cloud_storage_api_download_enable">
                     <SwitchPreference
                         android:defaultValue="true"
-                        android:dependency="cloud_storage_api_enable"
                         android:key="cloud_storage_api_download_enable"
                         android:summary="@string/summary_cloud_storage_api_download_enable"
                         android:switchTextOff="@string/short_off_text_for_switches"


### PR DESCRIPTION
# Let xDrip read AAPS-entered BG checks (and notes) from Nightscout, without turning on upload

**The problem**

A finger BG check entered in AAPS never appears in xDrip. This is by design on the AAPS side, not a bug you can see: AAPS broadcasts *carbs and insulin* to xDrip locally (its XdripPlugin sends them straight over), but it does **not** broadcast therapy events like BG checks — those it sends only to Nightscout. So the only way xDrip can obtain an AAPS BG check is to read it back from Nightscout. Today xDrip refuses to download treatments from Nightscout unless the *upload* master switch is also on — which would make xDrip a second uploader to a site AAPS already uploads to, duplicating everything.

**How to reproduce** (xDrip + AAPS on one phone, AAPS uploading to Nightscout):

- Enter **carbs** in AAPS → appears in xDrip within seconds (local broadcast).
- Enter a **BG check** in AAPS → never reaches xDrip; it goes only to Nightscout.

(Verified by watching the broadcasts: carbs go out as `info.nightscout.client.NEW_FOOD` to xDrip; the BG check produces no broadcast toward xDrip at all, only an NSClientV3 upload. xDrip's own AAPS receiver even has a commented-out `mgdl` read at `NSClientReceiver.java:303`, but it's moot — AAPS sends nothing to read.)

**What this changes**

- Download no longer depends on the upload switch. Upload remains its own switch, default off, and with it off xDrip **never uploads** — this is a read-only Nightscout treatment client, not "upload disabled."
- The Base URL and download screen are freed from the upload dependency, and download is skipped quietly when the URL is unset/placeholder/invalid instead of throwing.
- Downloaded blood tests are fanned out over xDrip Sync, so in a family the other phones receive them without each configuring Nightscout.
- A non-Finger entry (e.g. an AAPS BG check defaults to type *Sensor*) is logged once instead of every download pass.

**What this is not**

- **Not a second data source.** Glucose readings still come from the single configured source (xDrip Sync, Dexcom, etc.). Only *treatments* are pulled — the same treatment download that already exists, minus the upload gate.
- **Not the Nightscout-follower data source.** This is the *Cloud Upload → Nightscout* treatment download, which is independent of the data source. That's deliberate: it serves a device whose readings arrive some other way (in my case, Dexcom or xDrip Sync) while its treatments live in Nightscout.

**For the reviewer — the open question**

The confusion seen in comments is probably about the names of the settings and their placement: a read-only download option living under *Cloud Upload* menu reads oddly. The suggested alternative — make the *Nightscout-follower* data source download treatments — wouldn't serve this case, because the reading source here is Dex or xDrip Sync+ Follower or anything else, so switching to Nightscout follower is not an option - nightscout is not a source, but a supplement for the data which is not received over the other existing channels, like local broadcast from AAPS. If we could rename "Cloud Upload" to "Cloud Sync", that would probably remove the discrepancy.  Also, the Enabled switch in the root of Nightscout Sync would probably have to be renamed to "Enable Uploads". That is your call and I'm happy to make any required changes to the settings, which I tried to keep minimal with this PR.

**Why it's worth the complexity**

Any AAPS user can now see AAPS-entered BG checks in xDrip's graph — with xDrip's 10-minute delayed marker and a visual match against sensor values, which AAPS doesn't offer — and keep BG checks, carbs and insulin all in one place, entered once in AAPS.

---