### PR TITLE
fix: detect source unit from companion app package name in UiBasedCollector

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
@@ -371,7 +371,7 @@ public class UiBasedCollector extends NotificationListenerService {
         int mgdl = -1;
         try {
             val ftext = filterString(text);
-            if (Unitized.usingMgDl()) {
+            if (sourcePackageUsesMgDl()) {
                 mgdl = Integer.parseInt(ftext);
             } else {
                 if (isValidMmol(ftext)) {
@@ -385,6 +385,24 @@ public class UiBasedCollector extends NotificationListenerService {
             UserError.Log.d(TAG, "Got exception in tryExtractString: " + e);
         }
         return mgdl;
+    }
+
+    /**
+     * Determine if the source companion app sends values in mg/dL based on its package name.
+     * Many companion apps encode their unit in the package name (e.g. .mmol, .mmoll, .mgdl).
+     * Falls back to xDrip's own unit preference if the package name doesn't indicate a unit.
+     */
+    boolean sourcePackageUsesMgDl() {
+        if (lastPackage != null) {
+            val pkg = lastPackage.toLowerCase();
+            if (pkg.endsWith(".mmol") || pkg.endsWith(".mmoll") || pkg.contains(".mmol.")) {
+                return false;
+            }
+            if (pkg.endsWith(".mgdl") || pkg.contains(".mgdl.")) {
+                return true;
+            }
+        }
+        return Unitized.usingMgDl();
     }
 
     boolean handleNewValue(final int mgdl) {

--- a/app/src/test/java/com/eveningoutpost/dexdrip/services/UiBasedCollectorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/services/UiBasedCollectorTest.java
@@ -239,6 +239,58 @@ public class UiBasedCollectorTest extends RobolectricTestWithConfig {
                 .that(ui.handleNewValue(start + Constants.MINUTE_IN_MS * 10, 100)).isTrue();
     }
 
+    @Test
+    public void sourcePackageUsesMgDlTest() {
+        val i = new UiBasedCollector();
+
+        // No package set - falls back to xDrip preference
+        i.lastPackage = null;
+        // Default xDrip unit in test is mg/dL
+        assertWithMessage("null package uses default").that(i.sourcePackageUsesMgDl()).isTrue();
+
+        // CamAPS mmol variants
+        i.lastPackage = "com.camdiab.fx_alert.mmoll";
+        assertWithMessage("camaps mmoll").that(i.sourcePackageUsesMgDl()).isFalse();
+        i.lastPackage = "com.camdiab.fx_alert.hx.mmoll";
+        assertWithMessage("camaps hx mmoll").that(i.sourcePackageUsesMgDl()).isFalse();
+        i.lastPackage = "com.camdiab.fx_alert.mmoll.ca";
+        assertWithMessage("camaps mmoll ca").that(i.sourcePackageUsesMgDl()).isFalse();
+
+        // CamAPS mgdl variants
+        i.lastPackage = "com.camdiab.fx_alert.mgdl";
+        assertWithMessage("camaps mgdl").that(i.sourcePackageUsesMgDl()).isTrue();
+        i.lastPackage = "com.camdiab.fx_alert.hx.mgdl";
+        assertWithMessage("camaps hx mgdl").that(i.sourcePackageUsesMgDl()).isTrue();
+
+        // Dexcom mmol variants
+        i.lastPackage = "com.dexcom.g6.region1.mmol";
+        assertWithMessage("dexcom mmol").that(i.sourcePackageUsesMgDl()).isFalse();
+        i.lastPackage = "com.dexcom.g6.region4.mmol";
+        assertWithMessage("dexcom region4 mmol").that(i.sourcePackageUsesMgDl()).isFalse();
+
+        // Dexcom mgdl variants
+        i.lastPackage = "com.dexcom.g6.region2.mgdl";
+        assertWithMessage("dexcom mgdl").that(i.sourcePackageUsesMgDl()).isTrue();
+
+        // Packages without unit in name fall back to default
+        i.lastPackage = "com.dexcom.g7";
+        assertWithMessage("g7 no unit suffix").that(i.sourcePackageUsesMgDl()).isTrue();
+        i.lastPackage = "com.medtronic.diabetes.guardian";
+        assertWithMessage("medtronic no unit suffix").that(i.sourcePackageUsesMgDl()).isTrue();
+    }
+
+    @Test
+    public void tryExtractStringMmolPackageTest() {
+        val i = new UiBasedCollector();
+
+        // Simulate CamAPS mmol sending "7.1" when xDrip is set to mg/dL
+        i.lastPackage = "com.camdiab.fx_alert.mmoll";
+        val result = i.tryExtractString("7.1");
+        // 7.1 mmol/L = ~128 mg/dL
+        assertWithMessage("mmol package parses 7.1 as mmol").that(result).isAtLeast(127);
+        assertWithMessage("mmol package parses 7.1 as mmol").that(result).isAtMost(129);
+    }
+
     /**
      * Characterization: jam detection rejects after Medtronic threshold (9 repeats).
      * Readings spaced at 10-min intervals to pass dedup but increment jam counter.


### PR DESCRIPTION
Split out of #4529 so it can be reviewed on its own merits.

Many companion apps encode their glucose unit in the package name (e.g. `.mmol`, `.mmoll`, `.mgdl`). UiBasedCollector previously interpreted scraped values using xDrip's own display unit preference, so an mmol/L value from a companion app could be parsed as mg/dL (or vice versa) when the two disagreed. This detects the source unit from the companion package name and falls back to xDrip's preference when the name carries no unit hint.

Includes unit tests for the package-name detection.