### PR TITLE
[cleanup] Replace android.preference.PreferenceManager with androidx (Batch 2: 4 files)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/LicenseAgreementActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/LicenseAgreementActivity.java
@@ -3,7 +3,7 @@ package com.eveningoutpost.dexdrip;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/DBSearchUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/DBSearchUtil.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError.Log;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Pref.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Pref.java
@@ -1,7 +1,7 @@
 package com.eveningoutpost.dexdrip.utilitymodels;
 
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayAbstract.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayAbstract.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.BatteryManager;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import com.eveningoutpost.dexdrip.BestGlucose;
 import com.eveningoutpost.dexdrip.models.BgReading;

--- a/app/src/test/java/com/eveningoutpost/dexdrip/LicenseAgreementActivityTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/LicenseAgreementActivityTest.java
@@ -1,0 +1,140 @@
+package com.eveningoutpost.dexdrip;
+
+import android.widget.Button;
+import android.widget.CheckBox;
+
+import androidx.preference.PreferenceManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Behavioural tests for {@link LicenseAgreementActivity}.
+ * <p>
+ * The activity's contract is a round trip: the stored I_understand preference decides whether the
+ * agreement checkbox is ticked on open, and pressing Save writes the checkbox state back. Both
+ * ends are asserted through the view hierarchy and the preference store, so the tests survive the
+ * android.preference -> androidx PreferenceManager swap only if that contract is unchanged.
+ *
+ * @author Asbjørn Aarrestad - 2026.07
+ */
+public class LicenseAgreementActivityTest extends RobolectricTestWithConfig {
+
+    private static final String PREF_KEY = "I_understand";
+
+    // --- Setup ---
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+    }
+
+    // --- Preference drives the checkbox ---
+
+    /**
+     * The checkbox follows the stored preference in both directions. Asserting both within one
+     * test is deliberate: a "false leaves it unticked" assertion on its own would also pass if the
+     * preference read were deleted entirely, since the underlying field defaults to false. Only the
+     * contrast proves the value is actually read.
+     */
+    @Test
+    public void checkboxFollowsStoredPreference() {
+        // :: Setup
+        storeUnderstood(true);
+
+        // :: Act
+        CheckBox checkBoxAfterTrue = checkBox(openActivity());
+
+        // :: Verify
+        assertThat(checkBoxAfterTrue.isChecked()).isTrue();
+
+        // :: Setup
+        storeUnderstood(false);
+
+        // :: Act
+        CheckBox checkBoxAfterFalse = checkBox(openActivity());
+
+        // :: Verify
+        assertThat(checkBoxAfterFalse.isChecked()).isFalse();
+    }
+
+    /** With no preference stored at all, the agreement starts unaccepted. */
+    @Test
+    public void checkboxIsUntickedWhenPreferenceUnset() {
+        // :: Act
+        LicenseAgreementActivity activity = openActivity();
+
+        // :: Verify
+        assertThat(checkBox(activity).isChecked()).isFalse();
+    }
+
+    // --- Save writes the checkbox back ---
+
+    /** Ticking the checkbox and pressing Save stores true. */
+    @Test
+    public void saveStoresTrueWhenCheckboxTicked() {
+        // :: Setup
+        LicenseAgreementActivity activity = openActivity();
+        checkBox(activity).setChecked(true);
+
+        // :: Act
+        saveButton(activity).performClick();
+
+        // :: Verify
+        assertThat(storedUnderstood()).isTrue();
+    }
+
+    /** Unticking the checkbox and pressing Save stores false. */
+    @Test
+    public void saveStoresFalseWhenCheckboxUnticked() {
+        // :: Setup
+        storeUnderstood(true);
+        LicenseAgreementActivity activity = openActivity();
+        checkBox(activity).setChecked(false);
+
+        // :: Act
+        saveButton(activity).performClick();
+
+        // :: Verify
+        assertThat(storedUnderstood()).isFalse();
+    }
+
+    // --- Helpers ---
+
+    private LicenseAgreementActivity openActivity() {
+        return Robolectric.buildActivity(LicenseAgreementActivity.class).create().get();
+    }
+
+    /**
+     * onCreate wraps its whole view setup in a catch for UnsupportedOperationException and simply
+     * calls finish(), which would leave the views absent and surface here as a confusing NPE.
+     * Fail with a clear message instead, so the cause is not mistaken for a broken assertion.
+     */
+    private CheckBox checkBox(LicenseAgreementActivity activity) {
+        CheckBox checkBox = activity.findViewById(R.id.agreeCheckBox);
+        assertThat(checkBox).isNotNull(); // activity aborted its own setup; see onCreate's catch
+        return checkBox;
+    }
+
+    private Button saveButton(LicenseAgreementActivity activity) {
+        Button button = activity.findViewById(R.id.saveButton);
+        assertThat(button).isNotNull(); // activity aborted its own setup; see onCreate's catch
+        return button;
+    }
+
+    private void storeUnderstood(boolean value) {
+        PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext())
+                .edit().putBoolean(PREF_KEY, value).commit();
+    }
+
+    private boolean storedUnderstood() {
+        return PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext())
+                .getBoolean(PREF_KEY, false);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/stats/DBSearchUtilTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/stats/DBSearchUtilTest.java
@@ -1,0 +1,176 @@
+package com.eveningoutpost.dexdrip.stats;
+
+import androidx.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.models.BgReading;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Behavioural tests for the range counts in {@link DBSearchUtil}.
+ * <p>
+ * The counts classify stored readings against the highValue/lowValue preferences, interpreting
+ * them in whichever unit the units preference names. Asserting the same seeded readings under both
+ * mgdl and equivalent mmol thresholds pins the preference read and its rescaling, so the tests
+ * survive the android.preference -> androidx PreferenceManager swap only if that is unchanged.
+ *
+ * @author Asbjørn Aarrestad - 2026.07
+ */
+public class DBSearchUtilTest extends RobolectricTestWithConfig {
+
+    private int originalStatsState;
+
+    // --- Setup ---
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+
+        // The ActiveAndroid database is process-wide and is not reset between test methods or
+        // classes, so start from a known-empty table and leave it that way (see tearDown).
+        BgReading.deleteALL();
+
+        originalStatsState = StatsActivity.state;
+        StatsActivity.state = StatsActivity.D7;                 // deterministic 7-day window
+
+        seedReadings();
+    }
+
+    @After
+    public void tearDown() {
+        BgReading.deleteALL();
+        StatsActivity.state = originalStatsState; // mutable public static shared with other tests
+    }
+
+    // --- Classification in mgdl ---
+
+    /** With high=170 / low=70 mgdl the seeded 50/120/300 readings split one to each bucket. */
+    @Test
+    public void classifiesSeededReadings_mgdl() {
+        // :: Setup
+        setThresholds("mgdl", "170", "70");
+
+        // :: Act
+        int below = below();
+        int inRange = inRange();
+        int above = above();
+
+        // :: Verify
+        assertThat(below).isEqualTo(1);
+        assertThat(inRange).isEqualTo(1);
+        assertThat(above).isEqualTo(1);
+    }
+
+    // --- Same classification in mmol ---
+
+    /**
+     * The equivalent mmol thresholds (9.4 mmol ~ 169.4 mgdl, 3.9 mmol ~ 70.3 mgdl) must reproduce
+     * the mgdl split exactly. This is what proves the units preference is read and applied, rather
+     * than the stored numbers being used raw as mgdl.
+     */
+    @Test
+    public void classifiesSeededReadings_mmolMatchesMgdl() {
+        // :: Setup
+        setThresholds("mmol", "9.4", "3.9");
+
+        // :: Act
+        int below = below();
+        int inRange = inRange();
+        int above = above();
+
+        // :: Verify
+        assertThat(below).isEqualTo(1);
+        assertThat(inRange).isEqualTo(1);
+        assertThat(above).isEqualTo(1);
+    }
+
+    // --- Thresholds actually move the boundary ---
+
+    /**
+     * Raising the high threshold above every reading empties the above-range bucket and moves
+     * that reading into range. A count that ignored the highValue preference would not change.
+     */
+    @Test
+    public void raisingHighThresholdEmptiesAboveRange() {
+        // :: Setup
+        setThresholds("mgdl", "400", "70");
+
+        // :: Act
+        int above = above();
+        int inRange = inRange();
+
+        // :: Verify
+        assertThat(above).isEqualTo(0);
+        assertThat(inRange).isEqualTo(2);
+    }
+
+    /**
+     * Lowering the low threshold below every reading empties the below-range bucket and moves
+     * that reading into range.
+     */
+    @Test
+    public void loweringLowThresholdEmptiesBelowRange() {
+        // :: Setup
+        setThresholds("mgdl", "170", "40");
+
+        // :: Act
+        int below = below();
+        int inRange = inRange();
+
+        // :: Verify
+        assertThat(below).isEqualTo(0);
+        assertThat(inRange).isEqualTo(2);
+    }
+
+    // --- Helpers ---
+
+    private int below() {
+        return DBSearchUtil.noReadingsBelowRange(xdrip.getAppContext());
+    }
+
+    private int inRange() {
+        return DBSearchUtil.noReadingsInRange(xdrip.getAppContext());
+    }
+
+    private int above() {
+        return DBSearchUtil.noReadingsAboveRange(xdrip.getAppContext());
+    }
+
+    private void setThresholds(String units, String highValue, String lowValue) {
+        PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext())
+                .edit()
+                .putString("units", units)
+                .putString("highValue", highValue)
+                .putString("lowValue", lowValue)
+                .commit();
+    }
+
+    /**
+     * Seeds three readings inside the 7-day window: one clearly low, one mid-range, one high. All
+     * are above the CUTOFF of 38 and unsynced, which the counting queries require.
+     */
+    private void seedReadings() {
+        insertReading(50.0);
+        insertReading(120.0);
+        insertReading(300.0);
+    }
+
+    private void insertReading(final double calculatedValue) {
+        final BgReading bg = new BgReading();
+        bg.calculated_value = calculatedValue;
+        bg.raw_data = calculatedValue;
+        bg.timestamp = JoH.tsl() - Constants.HOUR_IN_MS;
+        bg.save();
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayAbstractTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayAbstractTest.java
@@ -1,0 +1,163 @@
+package com.eveningoutpost.dexdrip.utilitymodels.pebble;
+
+import androidx.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.utils.DexCollectionType;
+import com.eveningoutpost.dexdrip.xdrip;
+import com.getpebble.android.kit.util.PebbleDictionary;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Behavioural tests for the preference-backed accessors on {@link PebbleDisplayAbstract}.
+ * <p>
+ * getBatteryString() and getDexCollectionType() translate stored preferences into the values sent
+ * to a Pebble watch. Context is injected through the real initDisplay() entry point rather than by
+ * touching the protected field, so the tests assert the public contract and survive the
+ * android.preference -> androidx PreferenceManager swap only if that contract is unchanged.
+ *
+ * @author Asbjørn Aarrestad - 2026.07
+ */
+public class PebbleDisplayAbstractTest extends RobolectricTestWithConfig {
+
+    private TestPebbleDisplay display;
+
+    // --- Setup ---
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+        display = new TestPebbleDisplay();
+        display.initDisplay(xdrip.getAppContext(), null, null); // public injection point
+    }
+
+    // --- getBatteryString ---
+
+    /** An unset battery key reads as "0"; a stored level is rendered as its decimal string. */
+    @Test
+    public void getBatteryString_rendersStoredLevel() {
+        // :: Act
+        String unset = display.getBatteryString("batch2-unset-battery");
+
+        // :: Verify
+        assertThat(unset).isEqualTo("0");
+
+        // :: Setup
+        storeInt("batch2-battery", 42);
+
+        // :: Act
+        String stored = display.getBatteryString("batch2-battery");
+
+        // :: Verify
+        assertThat(stored).isEqualTo("42");
+    }
+
+    /** A different stored level yields a different string — the read is not a constant. */
+    @Test
+    public void getBatteryString_tracksChangesToStoredLevel() {
+        // :: Setup
+        storeInt("batch2-battery-tracking", 7);
+
+        // :: Act
+        String first = display.getBatteryString("batch2-battery-tracking");
+
+        // :: Verify
+        assertThat(first).isEqualTo("7");
+
+        // :: Setup
+        storeInt("batch2-battery-tracking", 93);
+
+        // :: Act
+        String second = display.getBatteryString("batch2-battery-tracking");
+
+        // :: Verify
+        assertThat(second).isEqualTo("93");
+    }
+
+    // --- getDexCollectionType ---
+
+    /** With no stored collection method the documented DexbridgeWixel default applies. */
+    @Test
+    public void getDexCollectionType_defaultsToDexbridgeWixel() {
+        // :: Setup
+        PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext())
+                .edit().remove("dex_collection_method").commit();
+
+        // :: Act
+        DexCollectionType type = display.getDexCollectionType();
+
+        // :: Verify
+        assertThat(type).isEqualTo(DexCollectionType.DexbridgeWixel);
+    }
+
+    /** A stored collection method is resolved to its enum value rather than the default. */
+    @Test
+    public void getDexCollectionType_readsStoredMethod() {
+        // :: Setup
+        storeString("dex_collection_method", "Follower");
+
+        // :: Act
+        DexCollectionType type = display.getDexCollectionType();
+
+        // :: Verify
+        assertThat(type).isEqualTo(DexCollectionType.Follower);
+    }
+
+    /** isDexBridgeWixel follows the stored collection method in both directions. */
+    @Test
+    public void isDexBridgeWixel_followsStoredMethod() {
+        // :: Setup
+        storeString("dex_collection_method", "DexbridgeWixel");
+
+        // :: Act
+        boolean whenWixel = display.isDexBridgeWixel();
+
+        // :: Verify
+        assertThat(whenWixel).isTrue();
+
+        // :: Setup
+        storeString("dex_collection_method", "Follower");
+
+        // :: Act
+        boolean whenFollower = display.isDexBridgeWixel();
+
+        // :: Verify
+        assertThat(whenFollower).isFalse();
+    }
+
+    // --- Helpers ---
+
+    private void storeInt(String key, int value) {
+        PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext())
+                .edit().putInt(key, value).commit();
+    }
+
+    private void storeString(String key, String value) {
+        PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext())
+                .edit().putString(key, value).commit();
+    }
+
+    /**
+     * Minimal concrete subclass. PebbleDisplayAbstract already implements 5 of the 7
+     * PebbleDisplayInterface methods; only these two remain abstract.
+     */
+    private static class TestPebbleDisplay extends PebbleDisplayAbstract {
+
+        @Override
+        public void startDeviceCommand() {
+            // no-op: not under test
+        }
+
+        @Override
+        public void receiveData(int transactionId, PebbleDictionary data) {
+            // no-op: not under test
+        }
+    }
+}


### PR DESCRIPTION
## Why

`android.preference.*` was deprecated wholesale in API 29 and is no longer maintained. xDrip
already ships `androidx.preference` and already uses it in parts of the app, so today the codebase
carries **two** preference frameworks and each file silently picks one. That is the thing being
removed here, one small batch at a time.

Three reasons this is worth doing rather than leaving alone:

- **It unblocks Category 3.** The real work — `Preferences.java` and the
  `PreferenceFragmentCompat` migration — cannot be reviewed on its own merits while ~56 unrelated
  files still import the old `PreferenceManager`. Getting the mechanical swaps out of the way first
  means the interesting PR is only about the interesting change.
- **It removes deprecation warnings** from the build, so the ones that remain still mean something.
- **Small batches, because this is medical software.** A 56-file sweep is unreviewable. Five files
  or fewer per PR is reviewable in a sitting, and a regression has a small blast radius.

**Why it is safe:** both `PreferenceManager` classes return the *same* default `SharedPreferences`
file. No user data moves, no key is renamed, nothing is migrated. That claim is not asked for on
trust — it is what the tests below assert, and what the emulator run demonstrates.

## What

Category 2 (Batch 2) of the deprecated-API cleanup started in #4479, continuing #4595. Four files,
**one import line each**, no logic changes:

- `utilitymodels/Pref`
- `LicenseAgreementActivity`
- `utilitymodels/pebble/PebbleDisplayAbstract`
- `stats/DBSearchUtil`

```diff
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
```

Production diff is 4 files × (1 insertion, 1 deletion). Everything else in the diff is tests.

## Scope correction to #4479

While selecting files for this batch, two of them turned out **not** to be simple import swaps, so
the claim in #4479 that the whole category is `getDefaultSharedPreferences()`-only needs narrowing:

- `ColorCache.java:43` and `app/.../xdrip.java:95-101` call `PreferenceManager.setDefaultValues()`.
  That call **inflates the preference XML**, so under androidx it needs the XML's classes to extend
  `androidx.preference.Preference`. It is Category 3 work, not a one-liner. Both files have been
  moved out of Category 2 (58 → 56) and into Category 3 (8+1 → 8+3, alongside `Preferences.java`).
- The two are not equally visible if broken. `xdrip.java`'s call is unguarded, so a failure is a
  crash. `ColorCache`'s sits inside `catch (Exception e) {}`, so a failure is **swallowed** — the
  colour defaults would simply never load, with nothing in the log. Worth knowing before anyone
  attempts it.
- `wear/src/main/res/xml/preferences.xml` contains only stock tags, so `wear/xdrip.java` is
  **unproven, not broken**. I am not claiming it fails; I have not shown that it does.

Unit tests that only exercise `getDefaultSharedPreferences()` stay green while `setDefaultValues()`
breaks, which is why this was worth catching by reading rather than by testing.

**Batch 1 is unaffected.** I re-checked all five files merged in #4595 — none of them calls
`setDefaultValues()`; they are pure `getDefaultSharedPreferences()` swaps as described.

## Tests

Three new test classes, 13 tests. Each was run against the **original** `android.preference`
import and passed, then against the swapped import and passed identically. That ordering is the
whole point: a test that only ever saw the new import proves nothing about the old behaviour.

- `LicenseAgreementActivityTest` (4) — the stored `I_understand` preference decides whether the
  agreement checkbox is ticked on open, and Save writes the checkbox state back. Both directions,
  through the view hierarchy and the preference store.
- `PebbleDisplayAbstractTest` (5) — `getBatteryString()`, `getDexCollectionType()` and
  `isDexBridgeWixel()` translate stored preferences into what is sent to the watch, including the
  default when nothing is stored. Context is injected through the real `initDisplay()` entry point
  rather than by touching the protected field.
- `DBSearchUtilTest` (4) — the range counts classify readings against `highValue`/`lowValue`,
  interpreted in whichever unit `units` names. The same seeded readings are asserted under mgdl and
  under equivalent mmol thresholds, which is what pins the unit rescaling rather than the numbers
  being used raw.

Full `./gradlew test` green.

### Coverage limitation, stated plainly

`Pref` has **no new test**. Its `SharedPreferences` handle is a private static cache with no reset
seam, so a cross-API "old API writes, new API reads the same file" assertion cannot be written —
the first test to touch it fixes the instance for the rest of the JVM. It rides on the existing
`PrefTest` round-trip, and store identity is proven by the other three files instead. I would
rather say that than add a `@VisibleForTesting` reset seam to production code to make a test
possible.

## Manual emulator test (per the #4479 review condition)

`API34_Phone` (Android 14), FastDebug build of this branch.

**Part 1 — preference search**, the inherited script:

| Step | Result |
|---|---|
| Settings renders, search icon present | ✅ |
| Search opens; `glucose` returns live results | ✅ single- and multi-level breadcrumbs |
| Tap a nested result | ✅ navigates into the correct sub-screen |
| `insulin` | ✅ four-level breadcrumbs resolve |
| `zzqqxx` | ✅ graceful "No results" empty state |

**Part 2 — Statistics**, which is specific to this batch. `DBSearchUtil` backs the Statistics
screens and reads `units` / `highValue` / `lowValue` through the swapped `PreferenceManager`, so
rendering that screen is direct evidence here rather than a ritual carried over from Batch 1.

144 synthetic readings were written into `BgReadings` (12 h, 5-minute spacing, sine 55–260 mg/dL).
Host-side SQL over those rows gives 27 below / 48 in range / 69 above.

The app rendered **`Absolute #s: 48/69/27`** and **`Range Settings: 70 - 170 mg/dl`** — matching
exactly, with the thresholds read back through the swapped code. Had the swap resolved to a
different preference store, the thresholds would have fallen back to the hard-coded defaults and
the counts would not have matched. All three Statistics reports render.

`adb logcat -b crash` empty; no `InflateException`, no `PreferenceParser` errors.

### What this does not cover

- **`PebbleDisplayAbstract`** — no Pebble hardware and no Pebble emulator. Unit tests only, not
  manually verified.
- **`LicenseAgreementActivity`** — first-install screen; the emulator's install was already past
  it, so it was not re-triggered by hand. Covered by its unit tests.
- **`Pref`** — exercised throughout Part 1, but only indirectly, per the limitation above.

## Screenshots

| Settings + search | Search opened | `glucose` |
|---|---|---|
| ![Settings](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch2-search-test/01_prefs.png) | ![Search opened](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch2-search-test/02_search_open.png) | ![glucose](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch2-search-test/03_search_glucose.png) |

| Nested result | `insulin` (deep breadcrumbs) | No-match |
|---|---|---|
| ![nav](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch2-search-test/04_nav_result.png) | ![insulin](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch2-search-test/05_search_insulin.png) | ![no results](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch2-search-test/06_search_nomatch.png) |

| Statistics — range counts | Distribution | Percentile |
|---|---|---|
| ![ranges](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch2-search-test/07_stats_ranges.png) | ![pie](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch2-search-test/08_stats_pie.png) | ![percentile](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch2-search-test/09_stats_percentile.png) |

## After this

52 Category-2 files remain in the app module. `wear/src/main` holds a further 27 with the same
import that no category list tracks — separate track, not this one. Batch 3 next, same shape.
