### PR TITLE
tests: wait for conditions instead of sleeping (suite 86.8s → 55.3s)

### DIFF
--- a/app/src/test/java/com/eveningoutpost/dexdrip/Await.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/Await.java
@@ -1,0 +1,63 @@
+package com.eveningoutpost.dexdrip;
+
+import static org.robolectric.Shadows.shadowOf;
+
+import android.os.Looper;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Waits for a condition to hold instead of sleeping for a fixed duration.
+ * <p>
+ * Retrofit delivers {@code enqueue()} callbacks on a background OkHttp thread and posts the
+ * result to the Android main looper. Robolectric's PAUSED looper does not run on its own, so
+ * a test must drain it before the effect of a callback is visible. Sleeping a fixed 300 ms and
+ * draining once is a bet that 300 ms is enough — a bet that does not hold on a loaded machine.
+ * <p>
+ * <b>This class never throws and never asserts.</b> The condition it waits on is normally the
+ * same one the test is about to assert, so throwing here would pre-empt the real assertion and
+ * replace a precise Truth message ("expected 88.0 but was 65.0") with an uninformative timeout.
+ * Waiting is an optimisation; the assertion that follows remains the only oracle.
+ *
+ * @author Asbjørn Aarrestad - 2026.07
+ */
+public final class Await {
+
+    /**
+     * Generous on purpose. Nothing is paid when the condition holds quickly, so a high cap
+     * costs nothing in the normal case while tolerating a slow or heavily loaded machine.
+     */
+    private static final long DEFAULT_TIMEOUT_MS = 2000L;
+
+    private static final long POLL_INTERVAL_MS = 5L;
+
+    private Await() {
+    }
+
+    /** Waits up to {@link #DEFAULT_TIMEOUT_MS} for the condition to hold. */
+    public static void awaitAtMost(final BooleanSupplier condition) {
+        awaitAtMost(condition, DEFAULT_TIMEOUT_MS);
+    }
+
+    /**
+     * Drains the main looper and re-evaluates the condition every {@value #POLL_INTERVAL_MS} ms
+     * until it holds or the cap elapses. Returns normally in both cases.
+     */
+    public static void awaitAtMost(final BooleanSupplier condition, final long timeoutMs) {
+        // System.nanoTime(), not JoH.tsl(): this measures real wall clock. JoH.tsl() can be
+        // moved by ShadowSystemClock — PersistTest advances it by 100 hours — and a cap
+        // measured against a frozen or fast-forwarded clock does not work.
+        final long deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000L;
+        while (true) {
+            shadowOf(Looper.getMainLooper()).idle();
+            if (condition.getAsBoolean()) return;
+            if (System.nanoTime() >= deadlineNanos) return;
+            try {
+                Thread.sleep(POLL_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/AwaitTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/AwaitTest.java
@@ -1,0 +1,46 @@
+package com.eveningoutpost.dexdrip;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Behavioural tests for {@link Await}.
+ *
+ * @author Asbjørn Aarrestad - 2026.07
+ */
+public class AwaitTest extends RobolectricTestWithConfig {
+
+    // ===== Returns as soon as the condition holds ================================================
+
+    @Test
+    public void awaitAtMost_returnsOnTheAttemptWhereTheConditionFirstHolds() {
+        // :: Setup — the condition becomes true on the third evaluation
+        final AtomicInteger evaluations = new AtomicInteger();
+
+        // :: Act
+        final long startNanos = System.nanoTime();
+        Await.awaitAtMost(() -> evaluations.incrementAndGet() >= 3, 2000);
+        final long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+
+        // :: Verify — it stopped evaluating immediately, well inside the cap
+        assertThat(evaluations.get()).isEqualTo(3);
+        assertThat(elapsedMs).isLessThan(500L);
+    }
+
+    // ===== Gives up at the cap ===================================================================
+
+    @Test
+    public void awaitAtMost_returnsAtTheCap_whenTheConditionNeverHolds() {
+        // :: Act
+        final long startNanos = System.nanoTime();
+        Await.awaitAtMost(() -> false, 100);
+        final long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+
+        // :: Verify — it waited out the cap and returned rather than throwing
+        assertThat(elapsedMs).isAtLeast(100L);
+        assertThat(elapsedMs).isLessThan(1500L);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/AwaitTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/AwaitTest.java
@@ -2,8 +2,12 @@ package com.eveningoutpost.dexdrip;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import android.os.Handler;
+import android.os.Looper;
+
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -42,5 +46,23 @@ public class AwaitTest extends RobolectricTestWithConfig {
         // :: Verify — it waited out the cap and returned rather than throwing
         assertThat(elapsedMs).isAtLeast(100L);
         assertThat(elapsedMs).isLessThan(1500L);
+    }
+
+    // ===== Drains the paused main looper =========================================================
+
+    @Test
+    public void awaitAtMost_runsTasksPostedToTheMainLooper() throws Exception {
+        // :: Setup — a background thread posts to the main looper, which Robolectric leaves paused
+        final AtomicBoolean ran = new AtomicBoolean(false);
+        final Handler main = new Handler(Looper.getMainLooper());
+        final Thread poster = new Thread(() -> main.post(() -> ran.set(true)));
+        poster.start();
+        poster.join();
+
+        // :: Act
+        Await.awaitAtMost(ran::get, 1000);
+
+        // :: Verify — the posted task ran, which only happens if the looper was drained
+        assertThat(ran.get()).isTrue();
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/alert/PersistTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/alert/PersistTest.java
@@ -16,6 +16,10 @@ import java.time.Duration;
 
 import lombok.val;
 
+// Required: without instrumenting JoH, ShadowSystemClock.advanceBy() does not reach
+// JoH.tsl(), and the "expired" assertions below fail (measured 2026-07-26). This forces
+// a second Robolectric classloader for this class, which is the source of its slower
+// runtime relative to the rest of the suite.
 @Config(instrumentedPackages = {"com.eveningoutpost.dexdrip.models.JoH"})
 public class PersistTest extends RobolectricTestWithConfig {
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/alert/PersistTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/alert/PersistTest.java
@@ -19,8 +19,6 @@ import lombok.val;
 // Required for correctness, not merely convention: without instrumenting JoH,
 // ShadowSystemClock.advanceBy() does not reach JoH.tsl() and the "expired" assertions
 // below fail. Verified 2026-07-26 by removing it — both tests failed.
-// It is believed to cost a second Robolectric classloader; that was never measured,
-// because the correctness failure settled the question first.
 @Config(instrumentedPackages = {"com.eveningoutpost.dexdrip.models.JoH"})
 public class PersistTest extends RobolectricTestWithConfig {
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/alert/PersistTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/alert/PersistTest.java
@@ -16,10 +16,11 @@ import java.time.Duration;
 
 import lombok.val;
 
-// Required: without instrumenting JoH, ShadowSystemClock.advanceBy() does not reach
-// JoH.tsl(), and the "expired" assertions below fail (measured 2026-07-26). This forces
-// a second Robolectric classloader for this class, which is the source of its slower
-// runtime relative to the rest of the suite.
+// Required for correctness, not merely convention: without instrumenting JoH,
+// ShadowSystemClock.advanceBy() does not reach JoH.tsl() and the "expired" assertions
+// below fail. Verified 2026-07-26 by removing it — both tests failed.
+// It is believed to cost a second Robolectric classloader; that was never measured,
+// because the correctness failure settled the question first.
 @Config(instrumentedPackages = {"com.eveningoutpost.dexdrip.models.JoH"})
 public class PersistTest extends RobolectricTestWithConfig {
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/JugglucoEmulatorContractTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/JugglucoEmulatorContractTest.java
@@ -1,9 +1,7 @@
 package com.eveningoutpost.dexdrip.cgm.nsfollow;
 
+import static com.eveningoutpost.dexdrip.Await.awaitAtMost;
 import static com.google.common.truth.Truth.assertThat;
-import static org.robolectric.Shadows.shadowOf;
-
-import android.os.Looper;
 
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.models.BgReading;
@@ -59,11 +57,6 @@ public class JugglucoEmulatorContractTest extends RobolectricTestWithConfig {
         BgReading.deleteALL();
     }
 
-    private static void awaitCallbacks() throws InterruptedException {
-        Thread.sleep(400);
-        shadowOf(Looper.getMainLooper()).idle();
-    }
-
     /** A Juggluco-shaped dispatcher: {@code entriesBody} for entries, 400 for devicestatus. */
     private void useJugglucoDispatcher(final String entriesBody) {
         server.setDispatcher(new Dispatcher() {
@@ -99,7 +92,7 @@ public class JugglucoEmulatorContractTest extends RobolectricTestWithConfig {
 
         // :: Act
         NightscoutFollow.work(true);
-        awaitCallbacks();
+        awaitAtMost(() -> !NsServerCapabilities.supportsDeviceStatus(url));
 
         // :: Verify — the follower reached the server (no parse crash), and devicestatus is disabled
         assertThat(server.getRequestCount()).isGreaterThan(0);
@@ -116,7 +109,7 @@ public class JugglucoEmulatorContractTest extends RobolectricTestWithConfig {
 
         // :: Act
         NightscoutFollow.work(true);
-        awaitCallbacks();
+        awaitAtMost(() -> BgReading.getForPreciseTimestamp(ts, 10_000) != null);
 
         // :: Verify — the reading landed in the DB
         assertThat(BgReading.getForPreciseTimestamp(ts, 10_000)).isNotNull();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusFallbackTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusFallbackTest.java
@@ -1,9 +1,7 @@
 package com.eveningoutpost.dexdrip.cgm.nsfollow;
 
+import static com.eveningoutpost.dexdrip.Await.awaitAtMost;
 import static com.google.common.truth.Truth.assertThat;
-import static org.robolectric.Shadows.shadowOf;
-
-import android.os.Looper;
 
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.models.JoH;
@@ -52,11 +50,6 @@ public class NightscoutFollowDeviceStatusFallbackTest extends RobolectricTestWit
         NightscoutFollow.resetInstance();
     }
 
-    private static void awaitCallbacks() throws InterruptedException {
-        Thread.sleep(400);
-        shadowOf(Looper.getMainLooper()).idle();
-    }
-
     /** entries/treatments respond OK; devicestatus is rejected with 400 like Juggluco's wrongpath(). */
     private void useDeviceStatus400Dispatcher() {
         server.setDispatcher(new Dispatcher() {
@@ -81,7 +74,7 @@ public class NightscoutFollowDeviceStatusFallbackTest extends RobolectricTestWit
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
+        awaitAtMost(() -> !NsServerCapabilities.supportsDeviceStatus(url));
 
         // :: Verify — limitation recorded
         assertThat(NsServerCapabilities.supportsDeviceStatus(url)).isFalse();
@@ -100,15 +93,17 @@ public class NightscoutFollowDeviceStatusFallbackTest extends RobolectricTestWit
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
+        // Anchor on the entries request, which is always sent. Without this the count can be 0,
+        // the loop below never runs, and the test passes vacuously.
+        awaitAtMost(() -> server.getRequestCount() > 0);
 
         // :: Verify — no devicestatus request was made
         final int count = server.getRequestCount();
+        assertThat(count).isAtLeast(1);
         for (int i = 0; i < count; i++) {
             final RecordedRequest r = server.takeRequest(1, TimeUnit.SECONDS);
-            if (r != null && r.getPath() != null) {
-                assertThat(r.getPath()).doesNotContain("devicestatus");
-            }
+            assertThat(r).isNotNull();
+            assertThat(r.getPath()).doesNotContain("devicestatus");
         }
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusWorkTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusWorkTest.java
@@ -12,6 +12,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.mockwebserver.Dispatcher;
@@ -82,10 +84,16 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitAtMost(() -> server.getRequestCount() > 0);
+        awaitAtMost(() -> server.getRequestCount() >= 3);
 
-        // :: Verify — at least one request reached the server
-        assertThat(server.getRequestCount()).isGreaterThan(0);
+        // :: Verify — a devicestatus request was among those sent
+        final List<String> paths = new ArrayList<>();
+        for (int i = 0; i < server.getRequestCount(); i++) {
+            final RecordedRequest r = server.takeRequest(1, TimeUnit.SECONDS);
+            assertThat(r).isNotNull();
+            paths.add(r.getPath());
+        }
+        assertThat(paths.toString()).contains("devicestatus");
     }
 
     @Test
@@ -106,8 +114,9 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
         int requestCount = server.getRequestCount();
         assertThat(requestCount).isAtLeast(1);
         for (int i = 0; i < requestCount; i++) {
-            String path = server.takeRequest(1, TimeUnit.SECONDS).getPath();
-            assertThat(path).doesNotContain("devicestatus");
+            final RecordedRequest r = server.takeRequest(1, TimeUnit.SECONDS);
+            assertThat(r).isNotNull();
+            assertThat(r.getPath()).doesNotContain("devicestatus");
         }
     }
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusWorkTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusWorkTest.java
@@ -12,8 +12,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.mockwebserver.Dispatcher;
@@ -31,6 +31,9 @@ import okhttp3.mockwebserver.RecordedRequest;
 public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithConfig {
 
     private MockWebServer server;
+
+    /** Paths of every request the dispatcher has served, in arrival order. */
+    private final List<String> requestPaths = new CopyOnWriteArrayList<>();
 
     @Before
     public void setUpServer() throws Exception {
@@ -51,7 +54,9 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
 
     /**
      * Configure the server with a path-aware dispatcher so that concurrent requests
-     * receive the correct responses regardless of arrival order.
+     * receive the correct responses regardless of arrival order. Every path served is
+     * recorded in {@link #requestPaths}, which unlike {@code takeRequest()} does not
+     * consume the request and can therefore be polled while waiting.
      *
      * @param deviceStatusBody JSON body to return for {@code /devicestatus} requests
      */
@@ -59,6 +64,7 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
         server.setDispatcher(new Dispatcher() {
             @Override
             public MockResponse dispatch(RecordedRequest request) {
+                requestPaths.add(String.valueOf(request.getPath()));
                 if (request.getPath() != null && request.getPath().contains("devicestatus")) {
                     return new MockResponse().setBody(deviceStatusBody);
                 }
@@ -76,24 +82,17 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
     // ===== Rate limiting =========================================================================
 
     @Test
-    public void work_sendsDeviceStatusRequest_whenNotRateLimited() throws Exception {
-        // :: Setup — entries, treatments, devicestatus responses
-        server.enqueue(new MockResponse().setBody("[]"));   // entries
-        server.enqueue(new MockResponse().setBody("[]"));   // treatments (if requested)
-        server.enqueue(new MockResponse().setBody("[{\"uploaderBattery\":77,\"date\":1700000000000}]"));
+    public void work_sendsDeviceStatusRequest_whenNotRateLimited() {
+        // :: Setup
+        usePathDispatcher("[{\"uploaderBattery\":77,\"date\":1700000000000}]");
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitAtMost(() -> server.getRequestCount() >= 3);
+        awaitAtMost(() -> requestPaths.toString().contains("devicestatus"));
 
-        // :: Verify — a devicestatus request was among those sent
-        final List<String> paths = new ArrayList<>();
-        for (int i = 0; i < server.getRequestCount(); i++) {
-            final RecordedRequest r = server.takeRequest(1, TimeUnit.SECONDS);
-            assertThat(r).isNotNull();
-            paths.add(r.getPath());
-        }
-        assertThat(paths.toString()).contains("devicestatus");
+        // :: Verify — a devicestatus request was among those sent. Waiting on the same
+        // condition is not vacuous: if it never arrives the wait expires and this fails.
+        assertThat(requestPaths.toString()).contains("devicestatus");
     }
 
     @Test

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusWorkTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusWorkTest.java
@@ -41,6 +41,10 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
         PumpStatus.setReservoir(-1);
         // Clear rate limiter so devicestatus fetch is not throttled
         JoH.clearRatelimit("nsfollow-devicestatus");
+        // uploaderCharging is a static volatile Boolean that Robolectric does not reset between
+        // tests. The charging tests wait for it to become non-null, so a value left over from a
+        // sibling test would satisfy that wait instantly and hand a stale value to the assertion.
+        NightscoutFollowService.clearUploaderStatus();
     }
 
     /**

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusWorkTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowDeviceStatusWorkTest.java
@@ -1,9 +1,7 @@
 package com.eveningoutpost.dexdrip.cgm.nsfollow;
 
+import static com.eveningoutpost.dexdrip.Await.awaitAtMost;
 import static com.google.common.truth.Truth.assertThat;
-import static org.robolectric.Shadows.shadowOf;
-
-import android.os.Looper;
 
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.models.JoH;
@@ -46,21 +44,6 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
     }
 
     /**
-     * Wait for OkHttp async callbacks and drain the Android main looper.
-     * <p>
-     * Retrofit posts {@code enqueue()} callbacks to the Android main looper. In Robolectric's
-     * PAUSED looper mode the main looper does not run automatically, so we must:
-     * <ol>
-     *   <li>Sleep briefly to let OkHttp complete the request and post to the main looper.</li>
-     *   <li>Call {@code shadowOf(getMainLooper()).idle()} to drain all pending tasks.</li>
-     * </ol>
-     */
-    private static void awaitCallbacks() throws InterruptedException {
-        Thread.sleep(300);
-        shadowOf(Looper.getMainLooper()).idle();
-    }
-
-    /**
      * Configure the server with a path-aware dispatcher so that concurrent requests
      * receive the correct responses regardless of arrival order.
      *
@@ -95,9 +78,7 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
 
         // :: Act
         NightscoutFollow.work(false);
-        // Wait for OkHttp async callbacks: pump/drain the main looper until
-        // Retrofit delivers its callbacks from the background OkHttp thread.
-        awaitCallbacks();
+        awaitAtMost(() -> server.getRequestCount() > 0);
 
         // :: Verify — at least one request reached the server
         assertThat(server.getRequestCount()).isGreaterThan(0);
@@ -113,11 +94,13 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
+        // Anchor on the entries request, which is always sent, before counting. Without this
+        // the count can be 0, the loop below never runs, and the test passes vacuously.
+        awaitAtMost(() -> server.getRequestCount() > 0);
 
         // :: Verify — devicestatus request was NOT made (only entries/treatments hit the server)
-        // Drain all requests made, confirm none hit the devicestatus path
         int requestCount = server.getRequestCount();
+        assertThat(requestCount).isAtLeast(1);
         for (int i = 0; i < requestCount; i++) {
             String path = server.takeRequest(1, TimeUnit.SECONDS).getPath();
             assertThat(path).doesNotContain("devicestatus");
@@ -133,7 +116,7 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
+        awaitAtMost(() -> PumpStatus.getBattery() == 88.0);
 
         // :: Verify
         assertThat(PumpStatus.getBattery()).isWithin(0.001).of(88.0);
@@ -146,7 +129,7 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
+        awaitAtMost(() -> PumpStatus.getReservoirString().contains("14.5"));
 
         // :: Verify
         assertThat(PumpStatus.getReservoirString()).contains("14.5");
@@ -159,7 +142,7 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
+        awaitAtMost(() -> PumpStatus.getBattery() == 65.0);
 
         // :: Verify
         assertThat(PumpStatus.getBattery()).isWithin(0.001).of(65.0);
@@ -174,7 +157,7 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
+        awaitAtMost(() -> NightscoutFollowService.uploaderCharging != null);
 
         // :: Verify — false is non-null, charging row will show "No"
         assertThat(NightscoutFollowService.uploaderCharging).isFalse();
@@ -187,7 +170,7 @@ public class NightscoutFollowDeviceStatusWorkTest extends RobolectricTestWithCon
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
+        awaitAtMost(() -> NightscoutFollowService.uploaderCharging != null);
 
         // :: Verify
         assertThat(NightscoutFollowService.uploaderCharging).isTrue();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowEntriesWorkTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutFollowEntriesWorkTest.java
@@ -1,9 +1,6 @@
 package com.eveningoutpost.dexdrip.cgm.nsfollow;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.robolectric.Shadows.shadowOf;
-
-import android.os.Looper;
 
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.models.BgReading;
@@ -16,8 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.mockwebserver.MockResponse;
@@ -54,19 +49,21 @@ public class NightscoutFollowEntriesWorkTest extends RobolectricTestWithConfig {
         BgReading.deleteALL();
     }
 
-    private static void awaitCallbacks() throws InterruptedException {
-        Thread.sleep(300);
-        shadowOf(Looper.getMainLooper()).idle();
-    }
-
-    /** Collects all requests the server received during the test. */
-    private List<String> drainRequestPaths() throws InterruptedException {
-        List<String> paths = new ArrayList<>();
+    /**
+     * Blocks until a request whose path contains {@code needle} arrives, and returns its path.
+     * <p>
+     * Unlike {@link com.eveningoutpost.dexdrip.Await}, this throws when nothing arrives: these
+     * tests assert on the <em>contents</em> of a request, so if it never came there is nothing
+     * to assert against and a named failure is the useful outcome.
+     */
+    private String awaitRequestPathContaining(String needle) throws InterruptedException {
         RecordedRequest r;
-        while ((r = server.takeRequest(500, TimeUnit.MILLISECONDS)) != null) {
-            paths.add(r.getPath());
+        while ((r = server.takeRequest(2, TimeUnit.SECONDS)) != null) {
+            if (r.getPath() != null && r.getPath().contains(needle)) {
+                return r.getPath();
+            }
         }
-        return paths;
+        throw new AssertionError("No request arrived with a path containing: " + needle);
     }
 
     private BgReading insertReading(long timestamp) {
@@ -94,15 +91,9 @@ public class NightscoutFollowEntriesWorkTest extends RobolectricTestWithConfig {
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
 
         // :: Verify — entries request contains find[date][$gt]=<lastTs>
-        List<String> paths = drainRequestPaths();
-        String entriesPath = paths.stream()
-                .filter(p -> p.contains("entries"))
-                .findFirst()
-                .orElse("");
-        String decoded = URLDecoder.decode(entriesPath, "UTF-8");
+        String decoded = URLDecoder.decode(awaitRequestPathContaining("entries"), "UTF-8");
         assertThat(decoded).contains("find[date][$gt]=" + lastTs);
     }
 
@@ -119,15 +110,9 @@ public class NightscoutFollowEntriesWorkTest extends RobolectricTestWithConfig {
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
 
         // :: Verify — count param is present alongside date filter
-        List<String> paths = drainRequestPaths();
-        String entriesPath = paths.stream()
-                .filter(p -> p.contains("entries"))
-                .findFirst()
-                .orElse("");
-        assertThat(entriesPath).contains("count=");
+        assertThat(awaitRequestPathContaining("entries")).contains("count=");
     }
 
     // ===== Safety limit is fixed 2880 (24h at 1-min × 2) ====================================
@@ -145,15 +130,9 @@ public class NightscoutFollowEntriesWorkTest extends RobolectricTestWithConfig {
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
 
         // :: Verify — safety count is exactly 2880 regardless of sample period
-        List<String> paths = drainRequestPaths();
-        String entriesPath = paths.stream()
-                .filter(p -> p.contains("entries"))
-                .findFirst()
-                .orElse("");
-        assertThat(entriesPath).contains("count=2880");
+        assertThat(awaitRequestPathContaining("entries")).contains("count=2880");
     }
 
     // ===== 24-hour time cap on date filter ===================================================
@@ -173,15 +152,9 @@ public class NightscoutFollowEntriesWorkTest extends RobolectricTestWithConfig {
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
 
         // :: Verify — date filter uses ~now-24h, not the 30h-old reading timestamp
-        List<String> paths = drainRequestPaths();
-        String entriesPath = paths.stream()
-                .filter(p -> p.contains("entries"))
-                .findFirst()
-                .orElse("");
-        String decoded = URLDecoder.decode(entriesPath, "UTF-8");
+        String decoded = URLDecoder.decode(awaitRequestPathContaining("entries"), "UTF-8");
         String afterGt = decoded.substring(decoded.indexOf("find[date][$gt]=") + "find[date][$gt]=".length());
         long actualCutoff = Long.parseLong(afterGt.split("&")[0]);
         assertThat(actualCutoff).isGreaterThan(thirtyHoursAgo);
@@ -202,14 +175,9 @@ public class NightscoutFollowEntriesWorkTest extends RobolectricTestWithConfig {
 
         // :: Act
         NightscoutFollow.work(false);
-        awaitCallbacks();
 
         // :: Verify — entries request has count but no date filter
-        List<String> paths = drainRequestPaths();
-        String entriesPath = paths.stream()
-                .filter(p -> p.contains("entries"))
-                .findFirst()
-                .orElse("");
+        String entriesPath = awaitRequestPathContaining("entries");
         assertThat(entriesPath).contains("count=");
         String decoded = URLDecoder.decode(entriesPath, "UTF-8");
         assertThat(decoded).doesNotContain("find[date][$gt]");

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploaderCallerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploaderCallerTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -45,6 +46,16 @@ public class NightscoutUploaderCallerTest extends RobolectricTestWithConfig {
     private static final String EXPECTED_HASHED_SECRET =
             Hashing.sha1().hashBytes(SECRET.getBytes(Charsets.UTF_8)).toString();
 
+    /**
+     * Test URLs must use a host containing a dot. {@code NightscoutUploader.TryResolveName()}
+     * treats a dotless host as an mDNS candidate, appends ".local" and blocks for
+     * {@code Mdns.NORMAL_RESOLVE_TIMEOUT_MS} (5 s) before falling back to the original URL.
+     * {@code server.getHostName()} returns "localhost", which triggers exactly that.
+     * The address is pinned rather than derived from the server: an IPv6 loopback appears
+     * in a URI as "[::1]", which is also dotless and would take the same slow path.
+     */
+    private static final String LOOPBACK_HOST = "127.0.0.1";
+
     private MockWebServer server;
     private SharedPreferences prefs;
 
@@ -52,7 +63,7 @@ public class NightscoutUploaderCallerTest extends RobolectricTestWithConfig {
     public void setUpServer() throws IOException {
         super.setUp();
         server = new MockWebServer();
-        server.start();
+        server.start(InetAddress.getByName(LOOPBACK_HOST), 0);
         prefs = PreferenceManager.getDefaultSharedPreferences(
                 org.robolectric.RuntimeEnvironment.application);
     }
@@ -67,8 +78,7 @@ public class NightscoutUploaderCallerTest extends RobolectricTestWithConfig {
     @Test
     public void uploadRest_hashesSecretWithSha1_andSendsAsApiSecretHeader() throws Exception {
         // :: Setup
-        final String baseUrl = "http://" + SECRET + "@" + server.getHostName()
-                + ":" + server.getPort() + "/api/v1/";
+        final String baseUrl = baseUrl();
         prefs.edit()
                 .putBoolean("cloud_storage_api_enable", true)
                 .putString("cloud_storage_api_base", baseUrl)
@@ -103,8 +113,7 @@ public class NightscoutUploaderCallerTest extends RobolectricTestWithConfig {
         // :: Setup
         final long timestamp = 1700000000000L;
         final double bgValue = 185.0;
-        final String baseUrl = "http://" + SECRET + "@" + server.getHostName()
-                + ":" + server.getPort() + "/api/v1/";
+        final String baseUrl = baseUrl();
         prefs.edit()
                 .putBoolean("cloud_storage_api_enable", true)
                 .putString("cloud_storage_api_base", baseUrl)
@@ -146,8 +155,7 @@ public class NightscoutUploaderCallerTest extends RobolectricTestWithConfig {
     @Test
     public void uploadRest_whenServerReturns500_returnsFalse() throws Exception {
         // :: Setup
-        final String baseUrl = "http://" + SECRET + "@" + server.getHostName()
-                + ":" + server.getPort() + "/api/v1/";
+        final String baseUrl = baseUrl();
         prefs.edit()
                 .putBoolean("cloud_storage_api_enable", true)
                 .putString("cloud_storage_api_base", baseUrl)
@@ -216,6 +224,11 @@ public class NightscoutUploaderCallerTest extends RobolectricTestWithConfig {
         return bg;
     }
 
+    /** Base URL with embedded secret, pointed at the mock server. */
+    private String baseUrl() {
+        return "http://" + SECRET + "@" + LOOPBACK_HOST + ":" + server.getPort() + "/api/v1/";
+    }
+
     private void enqueueSuccessResponses(int count) {
         for (int i = 0; i < count; i++) {
             server.enqueue(new MockResponse().setResponseCode(200)
@@ -224,21 +237,20 @@ public class NightscoutUploaderCallerTest extends RobolectricTestWithConfig {
     }
 
     /**
-     * Finds the first request whose path matches the given prefix.
-     * Drains up to 10 requests from the server within a short timeout.
+     * Returns the first POST request whose path starts with the given prefix,
+     * or null if none arrives. Returns as soon as it matches: draining further
+     * would block until {@code takeRequest} times out.
      */
     private RecordedRequest findRequestByPath(String pathPrefix) throws InterruptedException {
-        RecordedRequest match = null;
         for (int i = 0; i < 10; i++) {
             final RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
-            if (req == null) break;
-            if (req.getPath() != null && req.getPath().startsWith(pathPrefix) && "POST".equals(req.getMethod())) {
-                if (match == null) {
-                    match = req;
-                }
+            if (req == null) return null;
+            if (req.getPath() != null && req.getPath().startsWith(pathPrefix)
+                    && "POST".equals(req.getMethod())) {
+                return req;
             }
         }
-        return match;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Test-only change. No file outside `app/src/test/` is touched.

Six test classes waited for async Retrofit callbacks by sleeping a fixed 300–400 ms and then draining Robolectric's paused main looper once. This replaces that with polling for the condition the test is about to assert.

## Result

`:app:testFastDebugUnitTest` 86.8s → 55.3s (three clean runs, 55.3s each). 549 → 552 tests, 0 failures.

| Class | Before | After |
|---|---:|---:|
| `NightscoutUploaderCallerTest` | 19.595s | 0.515s |
| `NightscoutFollowEntriesWorkTest` | 4.635s | 0.492s |
| `NightscoutFollowDeviceStatusWorkTest` | 2.835s | ~1.45s ¹ |
| `JugglucoEmulatorContractTest` | 1.074s | 0.369s |
| `NightscoutFollowDeviceStatusFallbackTest` | 0.984s | 0.202s |

¹ The raw XML says 6.320s, but the class now sorts first in the suite and absorbs Robolectric's one-time sandbox bootstrap: first test 5.085s, the other six 1.234s combined. The same test measured 0.215s when the class did not run first.

## The 19.6s class

`MockWebServer.getHostName()` returns `localhost`. `NightscoutUploader.TryResolveName()` treats a host without a dot as an mDNS candidate, appends `.local` and blocks for `Mdns.NORMAL_RESOLVE_TIMEOUT_MS` (5 s) before falling back to the original URL. Three tests, three lookups, 15 s. The rest was a drain loop that kept calling `takeRequest` after it had already found its match, timing out 2 s twice.

Fixed in the test by starting the server on `127.0.0.1` explicitly. The address is pinned rather than derived from the server because an IPv6 loopback renders as `[::1]` in a URI — also dotless, same slow path.

**This is a production bug, not a test artefact.** Any Nightscout URL with a dotless host blocks the uploader 5 s per attempt (`NightscoutUploader.java:377` and `:485`). Not addressed here — it belongs in its own issue.

## Three tests did not verify what they were named

Found while removing the sleeps; this is the part that is not about speed.

- `work_sendsDeviceStatusRequest_whenNotRateLimited` asserted only `assertThat(server.getRequestCount()).isGreaterThan(0)`. It would have passed with the devicestatus call deleted from production entirely. It now waits for, and asserts on, the devicestatus request itself.
- `work_doesNotSendDeviceStatusRequest_whenRateLimited` and its sibling in `NightscoutFollowDeviceStatusFallbackTest` looped `for (i < server.getRequestCount())` over zero requests and passed on an empty loop. Verified by removing the new anchor: `expected to be at least: 1, but was: 0`. The 300 ms sleep was the only thing hiding it. The fallback one also wrapped its assertion in `if (r != null && r.getPath() != null)`, which skips silently.

Each of the three was verified discriminating by breaking its precondition on purpose and confirming it fails.

## `Await`

New test helper, `app/src/test/java/com/eveningoutpost/dexdrip/Await.java`. Drains the main looper, re-evaluates the condition every 5 ms, gives up after 2 s.

It never throws. The condition it waits on is usually the same one the test is about to assert, so throwing would pre-empt the real assertion and replace `expected 88.0 but was 65.0` with an uninformative timeout. Waiting is an optimisation; the assertion stays the only oracle.

`NightscoutFollowEntriesWorkTest` uses a local helper that *does* throw, because those tests assert on the contents of a request — if it never arrived there is nothing to assert against, and a named failure is the useful outcome.

Timing uses `System.nanoTime()`, not `JoH.tsl()`: `PersistTest` moves `JoH.tsl()` forward 100 hours via `ShadowSystemClock`, and a cap measured against a shifted clock does not work.

## Deliberately not changed

- **`PersistTest`** (~2.9 s) — investigated, left alone. `@Config(instrumentedPackages = {"…models.JoH"})` cannot be removed: without it `ShadowSystemClock.advanceBy()` does not reach `JoH.tsl()` and both tests fail. Verified by removing it. The cost is the second classloader and it is not reducible. Added a comment saying so, so the next person does not repeat the experiment.
- **Timing margin in the two negative tests** — the anchor now fires ~5 ms after the entries request instead of the old fixed 300 ms. Narrower in principle. A probe run passed 60/60 including under 3× CPU oversubscription. The alternative considered — `takeRequest(250 ms)` returning null — costs 250 ms per test in the passing case, which eats most of the win.

## Two choices worth a second opinion

- `Await` sits in `com.eveningoutpost.dexdrip` to match the package of the test classes that use it. A `test`/`support` package would be tidier if you would rather keep helpers separate.
- The three strengthened tests make this more than a pure speedup. Keeping them together was deliberate — the sleeps are what hid the vacuous passes, so the two are the same finding — but they will split cleanly if you want the correctness fixes reviewed on their own.

## Verification

`./gradlew :app:testFastDebugUnitTest :wear:testFastDebugUnitTest` green three times on the final commit. Timings above are from three `cleanTest` runs.
