### PR TITLE
Add Medtrum Follower source to get glucose values from Medtrum EasyView service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -884,6 +884,9 @@
             android:name=".cgm.nsfollow.NightscoutFollowService"
             android:foregroundServiceType="dataSync" />
         <service
+            android:name=".cgm.medtrumfollow.MedtrumFollowService"
+            android:foregroundServiceType="dataSync" />
+        <service
             android:name=".insulin.inpen.InPenService"
             android:foregroundServiceType="connectedDevice|location" />
         <service

--- a/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
@@ -217,7 +217,7 @@ public class MegaStatus extends FloatingLocaleActivityWithScreenshot {
                 addAsection(NIGHTSCOUT_FOLLOW, "Nightscout Follow Status");
             }
             if(dexCollectionType.equals(MedtrumFollow)) {
-                addAsection(MEDTRUM_FOLLOW, "Medtrum Follow Status");
+                addAsection(MEDTRUM_FOLLOW, "Medtrum follow status");
             }
             if(dexCollectionType.equals(SHFollow)) {
                 addAsection(SHARE_FOLLOW, "Dex Share Follow Status");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
@@ -10,6 +10,7 @@ import static com.eveningoutpost.dexdrip.Home.startWatchUpdaterService;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.DexcomG5;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.GluPro;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.Medtrum;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.MedtrumFollow;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.NSFollow;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.SHFollow;
 import static com.eveningoutpost.dexdrip.utils.DexCollectionType.WebFollow;
@@ -62,6 +63,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.ShotStateStore;
 import com.eveningoutpost.dexdrip.utilitymodels.StatusItem;
 import com.eveningoutpost.dexdrip.utilitymodels.UploaderQueue;
 import com.eveningoutpost.dexdrip.cgm.medtrum.MedtrumCollectionService;
+import com.eveningoutpost.dexdrip.cgm.medtrumfollow.MedtrumFollowService;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.NightscoutFollowService;
 import com.eveningoutpost.dexdrip.cgm.sharefollow.ShareFollowService;
 import com.eveningoutpost.dexdrip.cgm.webfollow.WebFollowService;
@@ -134,6 +136,7 @@ public class MegaStatus extends FloatingLocaleActivityWithScreenshot {
     private static final String BLUEJAY_STATUS = "BlueJay";
     private static final String INPEN_STATUS = "InPen";
     private static final String NIGHTSCOUT_FOLLOW = "Nightscout Follow";
+    private static final String MEDTRUM_FOLLOW = "Medtrum Follow";
     private static final String SHARE_FOLLOW = "Dex Share Follow";
     private static final String WEB_FOLLOW = "Web Follower";
     private static final String CARELINK_FOLLOW = "CareLink Follow";
@@ -213,6 +216,9 @@ public class MegaStatus extends FloatingLocaleActivityWithScreenshot {
             if(dexCollectionType.equals(NSFollow)) {
                 addAsection(NIGHTSCOUT_FOLLOW, "Nightscout Follow Status");
             }
+            if(dexCollectionType.equals(MedtrumFollow)) {
+                addAsection(MEDTRUM_FOLLOW, "Medtrum Follow Status");
+            }
             if(dexCollectionType.equals(SHFollow)) {
                 addAsection(SHARE_FOLLOW, "Dex Share Follow Status");
             }
@@ -278,6 +284,9 @@ public class MegaStatus extends FloatingLocaleActivityWithScreenshot {
                 break;
             case NIGHTSCOUT_FOLLOW:
                 la.addRows(NightscoutFollowService.megaStatus());
+                break;
+            case MEDTRUM_FOLLOW:
+                la.addRows(MedtrumFollowService.megaStatus());
                 break;
             case SHARE_FOLLOW:
                 la.addRows(ShareFollowService.megaStatus());

--- a/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/MegaStatus.java
@@ -136,7 +136,7 @@ public class MegaStatus extends FloatingLocaleActivityWithScreenshot {
     private static final String BLUEJAY_STATUS = "BlueJay";
     private static final String INPEN_STATUS = "InPen";
     private static final String NIGHTSCOUT_FOLLOW = "Nightscout Follow";
-    private static final String MEDTRUM_FOLLOW = "Medtrum Follow";
+    private static final String MEDTRUM_FOLLOW = "Medtrum follow";
     private static final String SHARE_FOLLOW = "Dex Share Follow";
     private static final String WEB_FOLLOW = "Web Follower";
     private static final String CARELINK_FOLLOW = "CareLink Follow";

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/EntryProcessor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/EntryProcessor.java
@@ -42,7 +42,7 @@ final class EntryProcessor {
             }
             bg.sensor = sensor;
             bg.sensor_uuid = sensor.uuid;
-            bg.source_info = "Medtrum Follow";
+            bg.source_info = "Medtrum follow";
             bg.save();
             Inevitable.task("medtrum-follow-post-process", 500, () -> bg.postProcess(false));
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/EntryProcessor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/EntryProcessor.java
@@ -1,0 +1,51 @@
+package com.eveningoutpost.dexdrip.cgm.medtrumfollow;
+
+import com.eveningoutpost.dexdrip.models.BgReading;
+import com.eveningoutpost.dexdrip.models.Sensor;
+import com.eveningoutpost.dexdrip.models.UserError;
+import com.eveningoutpost.dexdrip.utilitymodels.Inevitable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static com.eveningoutpost.dexdrip.models.BgReading.SPECIAL_FOLLOWER_PLACEHOLDER;
+
+final class EntryProcessor {
+
+    private static final String TAG = "MedtrumFollowEP";
+
+    private EntryProcessor() {
+    }
+
+    static synchronized void processEntries(final List<MedtrumFollowData.Entry> entries) {
+        if (entries == null || entries.isEmpty()) return;
+
+        final Sensor sensor = Sensor.createDefaultIfMissing();
+        Collections.sort(entries, (left, right) -> Long.compare(left.timestamp, right.timestamp));
+
+        for (final MedtrumFollowData.Entry entry : entries) {
+            if (entry == null || entry.timestamp <= 0 || entry.glucose <= 0) continue;
+            if (BgReading.getForPreciseTimestamp(entry.timestamp, 10_000) != null) continue;
+
+            UserError.Log.d(TAG, "New EasyView entry at " + entry.timestamp + ": " + entry.glucose);
+            final BgReading bg = new BgReading();
+            bg.uuid = UUID.randomUUID().toString();
+            bg.timestamp = entry.timestamp;
+            bg.calculated_value = entry.glucose;
+            bg.raw_data = SPECIAL_FOLLOWER_PLACEHOLDER;
+            bg.filtered_data = entry.glucose;
+            if (entry.trendName != null) {
+                bg.calculated_value_slope = BgReading.slopefromName(entry.trendName);
+            } else {
+                bg.hide_slope = true;
+            }
+            bg.sensor = sensor;
+            bg.sensor_uuid = sensor.uuid;
+            bg.source_info = "Medtrum Follow";
+            bg.save();
+            Inevitable.task("medtrum-follow-post-process", 500, () -> bg.postProcess(false));
+        }
+    }
+}
+

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollow.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollow.java
@@ -1,0 +1,57 @@
+package com.eveningoutpost.dexdrip.cgm.medtrumfollow;
+
+import com.eveningoutpost.dexdrip.BuildConfig;
+import com.google.gson.JsonObject;
+
+import retrofit2.Call;
+import retrofit2.http.Field;
+import retrofit2.http.FormUrlEncoded;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.Headers;
+import retrofit2.http.POST;
+import retrofit2.http.Query;
+
+interface MedtrumFollow {
+
+    String APP_TAG = "v=1.2.70(112);n=eyfo;p=android";
+
+    @Headers({
+            "AppTag: " + APP_TAG,
+            "User-Agent: xDrip+ " + BuildConfig.VERSION_NAME
+    })
+    @FormUrlEncoded
+    @POST("mobile/ajax/login")
+    Call<JsonObject> login(@Header("DevInfo") String deviceInfo,
+                           @Field("user_type") String userType,
+                           @Field("user_name") String username,
+                           @Field("password") String password,
+                           @Field("deviceToken") String deviceToken,
+                           @Field("platform") String platform,
+                           @Field("apptype") String appType,
+                           @Field("push_platform") String pushPlatform,
+                           @Field("app_version") String appVersion,
+                           @Field("device_name") String deviceName,
+                           @Field("bundleID") String bundleId);
+
+    @Headers({
+            "AppTag: " + APP_TAG,
+            "User-Agent: xDrip+ " + BuildConfig.VERSION_NAME
+    })
+    @GET("mobile/ajax/monitor?flag=monitor_list")
+    Call<JsonObject> getMonitor(@Header("DevInfo") String deviceInfo,
+                                @Header("Cookie") String cookie);
+
+    @Headers({
+            "AppTag: " + APP_TAG,
+            "User-Agent: xDrip+ " + BuildConfig.VERSION_NAME
+    })
+    @GET("mobile/ajax/download")
+    Call<JsonObject> getGraph(@Header("DevInfo") String deviceInfo,
+                              @Header("Cookie") String cookie,
+                              @Query("flag") String flag,
+                              @Query("st") String start,
+                              @Query("et") String end,
+                              @Query("user_name") String username);
+}
+

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowData.java
@@ -1,0 +1,203 @@
+package com.eveningoutpost.dexdrip.cgm.medtrumfollow;
+
+import androidx.annotation.Nullable;
+
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class MedtrumFollowData {
+
+    private static final double MIN_GLUCOSE_MG_DL = 36d;
+    private static final double MAX_GLUCOSE_MG_DL = 600d;
+
+    static final class Entry {
+        final long timestamp;
+        final double glucose;
+        @Nullable final String trendName;
+
+        Entry(final long timestamp, final double glucose, @Nullable final String trendName) {
+            this.timestamp = timestamp;
+            this.glucose = glucose;
+            this.trendName = trendName;
+        }
+    }
+
+    static final class Result {
+        final List<Entry> entries;
+        final String patient;
+        final String error;
+
+        Result(final List<Entry> entries, final String patient, final String error) {
+            this.entries = entries;
+            this.patient = patient;
+            this.error = error;
+        }
+
+        boolean isSuccessful() {
+            return error == null;
+        }
+    }
+
+    private MedtrumFollowData() {
+    }
+
+    static Result parseMonitor(final JsonObject response, final String configuredPatient) {
+        final String responseError = responseError(response);
+        if (responseError != null) return new Result(new ArrayList<>(), "", responseError);
+
+        final JsonArray monitors = getArray(response, "monitorlist");
+        if (monitors == null || monitors.size() == 0) {
+            return new Result(new ArrayList<>(), "", "No followed patients returned by EasyView");
+        }
+
+        JsonObject selected = null;
+        final String wanted = configuredPatient == null ? "" : configuredPatient.trim();
+        for (final JsonElement element : monitors) {
+            if (!element.isJsonObject()) continue;
+            final JsonObject candidate = element.getAsJsonObject();
+            final String username = getString(candidate, "username");
+            if ((!wanted.isEmpty() && wanted.equalsIgnoreCase(username))
+                    || (wanted.isEmpty() && candidate.has("sensor_status"))) {
+                selected = candidate;
+                break;
+            }
+        }
+        if (selected == null) {
+            return new Result(new ArrayList<>(), wanted, wanted.isEmpty()
+                    ? "No patient with sensor data returned by EasyView"
+                    : "Configured EasyView patient was not found");
+        }
+
+        final String patient = getString(selected, "username");
+        final JsonObject sensor = getObject(selected, "sensor_status");
+        if (sensor == null) return new Result(new ArrayList<>(), patient, "Patient has no sensor data");
+
+        final double glucose = getDouble(sensor, "glucose", 0);
+        final long timestamp = getLong(sensor, "updateTime", 0) * 1000L;
+        if (glucose <= 0 || timestamp <= 0) {
+            return new Result(new ArrayList<>(), patient, sensorStateError(sensor));
+        }
+
+        final double glucoseMgDl = toMgDl(glucose);
+        if (!isValidGlucose(glucoseMgDl)) {
+            return new Result(new ArrayList<>(), patient, "EasyView returned an out-of-range glucose value");
+        }
+        final List<Entry> entries = new ArrayList<>();
+        entries.add(new Entry(timestamp, glucoseMgDl, trendName((int) getLong(sensor, "glucoseRate", -1))));
+        return new Result(entries, patient, null);
+    }
+
+    static Result parseGraph(final JsonObject response, final long notBefore) {
+        final String responseError = responseError(response);
+        if (responseError != null) return new Result(new ArrayList<>(), "", responseError);
+
+        final List<Entry> entries = new ArrayList<>();
+        final JsonArray data = getArray(response, "data");
+        if (data == null) return new Result(entries, "", null);
+        for (final JsonElement element : data) {
+            if (!element.isJsonArray()) continue;
+            final JsonArray row = element.getAsJsonArray();
+            if (row.size() < 4) continue;
+            try {
+                final long timestamp = (long) (row.get(1).getAsDouble() * 1000L);
+                final double glucose = row.get(3).getAsDouble();
+                final double glucoseMgDl = toMgDl(glucose);
+                if (timestamp >= notBefore && isValidGlucose(glucoseMgDl)) {
+                    entries.add(new Entry(timestamp, glucoseMgDl, null));
+                }
+            } catch (RuntimeException ignored) {
+                // Ignore malformed individual history rows while retaining valid values.
+            }
+        }
+        return new Result(entries, "", null);
+    }
+
+    static String responseError(final JsonObject response) {
+        if (response == null) return "Empty response from EasyView";
+        final String result = getString(response, "res");
+        if (!result.isEmpty() && !"OK".equalsIgnoreCase(result)) {
+            final String message = getString(response, "msg");
+            return message.isEmpty() ? "EasyView returned " + result : message;
+        }
+        return null;
+    }
+
+    private static String sensorStateError(final JsonObject sensor) {
+        final long sequence = getLong(sensor, "sequence", -1);
+        if (sequence >= 0 && sequence <= 15) return "EasyView sensor is warming up";
+        final long calibrationAt = getLong(sensor, "nextSequenceNeedCalibrate", Long.MAX_VALUE);
+        if (sequence >= calibrationAt) return "EasyView sensor needs calibration";
+        return "EasyView returned no valid glucose value";
+    }
+
+    private static double toMgDl(final double value) {
+        return value <= MAX_GLUCOSE_MG_DL / Constants.MMOLL_TO_MGDL
+                ? value * Constants.MMOLL_TO_MGDL : value;
+    }
+
+    private static boolean isValidGlucose(final double valueMgDl) {
+        return valueMgDl >= MIN_GLUCOSE_MG_DL && valueMgDl <= MAX_GLUCOSE_MG_DL;
+    }
+
+    @Nullable
+    private static String trendName(final int trend) {
+        switch (trend) {
+            case 1: return "FortyFiveUp";
+            case 2: return "SingleUp";
+            case 3: return "DoubleUp";
+            case 4: return "FortyFiveDown";
+            case 5: return "SingleDown";
+            case 6: return "DoubleDown";
+            case 0:
+            case 8: return "Flat";
+            default: return null;
+        }
+    }
+
+    private static JsonArray getArray(final JsonObject object, final String name) {
+        try {
+            return object.has(name) && object.get(name).isJsonArray() ? object.getAsJsonArray(name) : null;
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static JsonObject getObject(final JsonObject object, final String name) {
+        try {
+            return object.has(name) && object.get(name).isJsonObject() ? object.getAsJsonObject(name) : null;
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static String getString(final JsonObject object, final String name) {
+        try {
+            return object.has(name) && !object.get(name).isJsonNull() ? object.get(name).getAsString() : "";
+        } catch (RuntimeException e) {
+            return "";
+        }
+    }
+
+    private static long getLong(final JsonObject object, final String name, final long fallback) {
+        try {
+            return object.has(name) && !object.get(name).isJsonNull() ? object.get(name).getAsLong() : fallback;
+        } catch (RuntimeException e) {
+            return fallback;
+        }
+    }
+
+    private static double getDouble(final JsonObject object, final String name, final double fallback) {
+        try {
+            return object.has(name) && !object.get(name).isJsonNull() ? object.get(name).getAsDouble() : fallback;
+        } catch (RuntimeException e) {
+            return fallback;
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowData.java
@@ -137,7 +137,7 @@ final class MedtrumFollowData {
 
     private static double toMgDl(final double value) {
         return value <= MAX_GLUCOSE_MG_DL / Constants.MMOLL_TO_MGDL
-                ? value * Constants.MMOLL_TO_MGDL : value;
+                ? Math.round(value * Constants.MMOLL_TO_MGDL) : value;
     }
 
     private static boolean isValidGlucose(final double valueMgDl) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowDownloader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowDownloader.java
@@ -1,7 +1,10 @@
 package com.eveningoutpost.dexdrip.cgm.medtrumfollow;
 
+import static com.eveningoutpost.dexdrip.xdrip.gs;
+
 import android.os.Build;
 
+import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.models.BgReading;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError;
@@ -65,11 +68,11 @@ final class MedtrumFollowDownloader {
 
     void download() {
         if (username.isEmpty() || password.isEmpty()) {
-            setStatus("Please enter EasyView username and password");
+            setStatus(gs(R.string.please_enter_easyview_username_and_password));
             return;
         }
         if (!inFlight.compareAndSet(false, true)) {
-            UserError.Log.d(TAG, "Download already in progress");
+            UserError.Log.d(TAG, gs(R.string.download_already_in_progress));
             return;
         }
         final BgReading last = BgReading.lastNoSenssor();
@@ -86,7 +89,7 @@ final class MedtrumFollowDownloader {
     }
 
     private void login(final long notBefore, final boolean alreadyRetried) {
-        setStatus("Logging in to Medtrum EasyView");
+        setStatus(gs(R.string.logging_in_to_medtrum_easyview));
         service.login(deviceInfo(), "M", username, password, "xdrip", "google", "Follow",
                         "google", APP_VERSION, Build.MODEL, BUNDLE_ID)
                 .enqueue(new Callback<JsonObject>() {
@@ -94,12 +97,12 @@ final class MedtrumFollowDownloader {
                     public void onResponse(final Call<JsonObject> call, final Response<JsonObject> response) {
                         final String error = responseError(response);
                         if (error != null) {
-                            finish("EasyView login failed: " + error);
+                            finish(gs(R.string.easyview_login_failed) + error);
                             return;
                         }
                         cookie = extractCookie(response);
                         if (cookie.isEmpty()) {
-                            finish("EasyView login did not return a session cookie");
+                            finish(gs(R.string.easyview_login_did_not_return_a_session_cookie));
                             return;
                         }
                         getMonitor(notBefore, alreadyRetried);
@@ -107,7 +110,7 @@ final class MedtrumFollowDownloader {
 
                     @Override
                     public void onFailure(final Call<JsonObject> call, final Throwable throwable) {
-                        finish("EasyView login connection error: " + throwable.getMessage());
+                        finish(gs(R.string.easyview_login_connection_error) + throwable.getMessage());
                     }
                 });
     }
@@ -141,7 +144,7 @@ final class MedtrumFollowDownloader {
 
             @Override
             public void onFailure(final Call<JsonObject> call, final Throwable throwable) {
-                finish("EasyView download connection error: " + throwable.getMessage());
+                finish(gs(R.string.easyview_download_connection_error) + throwable.getMessage());
             }
         });
     }
@@ -177,7 +180,7 @@ final class MedtrumFollowDownloader {
         if (!alreadyRetried) {
             login(notBefore, true);
         } else {
-            finish("EasyView download failed: " + error);
+            finish(gs(R.string.easyview_download_failed) + error);
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowDownloader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowDownloader.java
@@ -1,0 +1,220 @@
+package com.eveningoutpost.dexdrip.cgm.medtrumfollow;
+
+import android.os.Build;
+
+import com.eveningoutpost.dexdrip.models.BgReading;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.models.UserError;
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.eveningoutpost.dexdrip.utilitymodels.OkHttpWrapper;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+import com.eveningoutpost.dexdrip.tidepool.InfoInterceptor;
+import com.google.gson.JsonObject;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import lombok.Getter;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+final class MedtrumFollowDownloader {
+
+    private static final String TAG = "MedtrumFollowDL";
+    private static final long MAX_BACKFILL = Constants.DAY_IN_MS;
+    private static final String APP_VERSION = "1.2.70(112)";
+    private static final String BUNDLE_ID = "com.medtrum.easyfollowforandroidmg";
+
+    private final String username;
+    private final String password;
+    private final String patient;
+    private final String baseUrl;
+    private final MedtrumFollow service;
+    private final AtomicBoolean inFlight = new AtomicBoolean(false);
+
+    private volatile String cookie = "";
+    @Getter private volatile String status = "";
+    @Getter private volatile String selectedPatient = "";
+
+    MedtrumFollowDownloader() {
+        username = Pref.getString("medtrum_follow_user", "").trim();
+        password = Pref.getString("medtrum_follow_password", "");
+        patient = Pref.getString("medtrum_follow_patient", "").trim();
+        baseUrl = serverUrl(Pref.getString("medtrum_follow_server", "eu"));
+        service = new Retrofit.Builder()
+                .baseUrl(baseUrl)
+                .client(OkHttpWrapper.getClient().newBuilder()
+                        .addInterceptor(new InfoInterceptor(TAG))
+                        .build())
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(MedtrumFollow.class);
+    }
+
+    static String serverUrl(final String topLevelDomain) {
+        final String tld = "fr".equalsIgnoreCase(topLevelDomain) ? "fr" : "eu";
+        return "https://easyview.medtrum." + tld + "/";
+    }
+
+    void download() {
+        if (username.isEmpty() || password.isEmpty()) {
+            setStatus("Please enter EasyView username and password");
+            return;
+        }
+        if (!inFlight.compareAndSet(false, true)) {
+            UserError.Log.d(TAG, "Download already in progress");
+            return;
+        }
+        final BgReading last = BgReading.lastNoSenssor();
+        final long notBefore = Math.max(last == null ? 0 : last.timestamp + 1, JoH.tsl() - MAX_BACKFILL);
+        if (cookie.isEmpty()) {
+            login(notBefore, false);
+        } else {
+            getMonitor(notBefore, false);
+        }
+    }
+
+    void invalidateSession() {
+        cookie = "";
+    }
+
+    private void login(final long notBefore, final boolean alreadyRetried) {
+        setStatus("Logging in to Medtrum EasyView");
+        service.login(deviceInfo(), "M", username, password, "xdrip", "google", "Follow",
+                        "google", APP_VERSION, Build.MODEL, BUNDLE_ID)
+                .enqueue(new Callback<JsonObject>() {
+                    @Override
+                    public void onResponse(final Call<JsonObject> call, final Response<JsonObject> response) {
+                        final String error = responseError(response);
+                        if (error != null) {
+                            finish("EasyView login failed: " + error);
+                            return;
+                        }
+                        cookie = extractCookie(response);
+                        if (cookie.isEmpty()) {
+                            finish("EasyView login did not return a session cookie");
+                            return;
+                        }
+                        getMonitor(notBefore, alreadyRetried);
+                    }
+
+                    @Override
+                    public void onFailure(final Call<JsonObject> call, final Throwable throwable) {
+                        finish("EasyView login connection error: " + throwable.getMessage());
+                    }
+                });
+    }
+
+    private void getMonitor(final long notBefore, final boolean alreadyRetried) {
+        setStatus("Downloading glucose from EasyView");
+        service.getMonitor(deviceInfo(), cookie).enqueue(new Callback<JsonObject>() {
+            @Override
+            public void onResponse(final Call<JsonObject> call, final Response<JsonObject> response) {
+                final String error = responseError(response);
+                if (error != null) {
+                    retryLoginOrFinish(notBefore, alreadyRetried, error);
+                    return;
+                }
+                final MedtrumFollowData.Result current = MedtrumFollowData.parseMonitor(response.body(), patient);
+                if (!current.isSuccessful()) {
+                    if (MedtrumFollowData.responseError(response.body()) != null) {
+                        retryLoginOrFinish(notBefore, alreadyRetried, current.error);
+                    } else {
+                        finish(current.error);
+                    }
+                    return;
+                }
+                selectedPatient = current.patient;
+                if (!selectedPatient.isEmpty() && notBefore < JoH.tsl() - (3 * Constants.MINUTE_IN_MS)) {
+                    getHistory(notBefore, current.entries);
+                } else {
+                    complete(current.entries);
+                }
+            }
+
+            @Override
+            public void onFailure(final Call<JsonObject> call, final Throwable throwable) {
+                finish("EasyView download connection error: " + throwable.getMessage());
+            }
+        });
+    }
+
+    private void getHistory(final long notBefore, final List<MedtrumFollowData.Entry> current) {
+        final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH);
+        service.getGraph(deviceInfo(), cookie, "sg", format.format(new Date(notBefore)),
+                        format.format(new Date()), selectedPatient)
+                .enqueue(new Callback<JsonObject>() {
+                    @Override
+                    public void onResponse(final Call<JsonObject> call, final Response<JsonObject> response) {
+                        final List<MedtrumFollowData.Entry> combined = new ArrayList<>();
+                        if (response.isSuccessful()) {
+                            final MedtrumFollowData.Result history = MedtrumFollowData.parseGraph(response.body(), notBefore);
+                            if (history.isSuccessful()) combined.addAll(history.entries);
+                        } else {
+                            UserError.Log.w(TAG, "History download failed with HTTP " + response.code());
+                        }
+                        combined.addAll(current);
+                        complete(combined);
+                    }
+
+                    @Override
+                    public void onFailure(final Call<JsonObject> call, final Throwable throwable) {
+                        UserError.Log.w(TAG, "History download failed: " + throwable.getMessage());
+                        complete(current);
+                    }
+                });
+    }
+
+    private void retryLoginOrFinish(final long notBefore, final boolean alreadyRetried, final String error) {
+        cookie = "";
+        if (!alreadyRetried) {
+            login(notBefore, true);
+        } else {
+            finish("EasyView download failed: " + error);
+        }
+    }
+
+    private void complete(final List<MedtrumFollowData.Entry> entries) {
+        EntryProcessor.processEntries(entries);
+        MedtrumFollowService.updateBgReceiveDelay();
+        MedtrumFollowService.scheduleWakeUp();
+        finish("");
+    }
+
+    private void finish(final String message) {
+        setStatus(message);
+        inFlight.set(false);
+    }
+
+    private void setStatus(final String message) {
+        status = message == null || message.isEmpty() ? "" : JoH.hourMinuteString() + ": " + message;
+        if (!status.isEmpty()) UserError.Log.d(TAG, status);
+    }
+
+    private static String responseError(final Response<JsonObject> response) {
+        if (!response.isSuccessful()) return "HTTP " + response.code();
+        return MedtrumFollowData.responseError(response.body());
+    }
+
+    private static String extractCookie(final Response<?> response) {
+        final List<String> values = response.headers().values("Set-Cookie");
+        if (values.isEmpty()) return "";
+        final String value = values.get(0);
+        final int separator = value.indexOf(';');
+        return (separator >= 0 ? value.substring(0, separator) : value).trim();
+    }
+
+    private static String deviceInfo() {
+        return "Android " + Build.VERSION.RELEASE + ";" + Build.MANUFACTURER + " "
+                + Build.DEVICE + ";Android " + Build.VERSION.RELEASE;
+    }
+}
+
+

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowService.java
@@ -1,5 +1,7 @@
 package com.eveningoutpost.dexdrip.cgm.medtrumfollow;
 
+import static com.eveningoutpost.dexdrip.xdrip.gs;
+
 import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
@@ -9,6 +11,7 @@ import android.text.SpannableString;
 
 import androidx.annotation.Nullable;
 
+import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.models.BgReading;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError;
@@ -122,19 +125,19 @@ public class MedtrumFollowService extends ForegroundService {
     public static List<StatusItem> megaStatus() {
         final List<StatusItem> statuses = new ArrayList<>();
         final BgReading lastBg = BgReading.lastNoSenssor();
-        statuses.add(new StatusItem("Latest BG", lastBg == null ? "n/a"
-                : JoH.niceTimeScalar(JoH.msSince(lastBg.timestamp)) + " ago"));
-        statuses.add(new StatusItem("BG receive delay", bgReceiveDelay <= 0 ? "n/a"
+        statuses.add(new StatusItem(gs(R.string.latest_bg), lastBg == null ? gs(R.string.n_a)
+                : JoH.niceTimeScalar(JoH.msSince(lastBg.timestamp)) + gs(R.string.ago)));
+        statuses.add(new StatusItem(gs(R.string.bg_receive_delay), bgReceiveDelay <= 0 ? gs(R.string.n_a)
                 : JoH.niceTimeScalar(bgReceiveDelay)));
-        statuses.add(new StatusItem("Last poll", lastPoll <= 0 ? "n/a"
-                : JoH.niceTimeScalar(JoH.msSince(lastPoll)) + " ago"));
-        statuses.add(new StatusItem("Next poll in", wakeupTime <= 0 ? "n/a"
+        statuses.add(new StatusItem(gs(R.string.last_poll), lastPoll <= 0 ? gs(R.string.n_a)
+                : JoH.niceTimeScalar(JoH.msSince(lastPoll)) + gs(R.string.ago)));
+        statuses.add(new StatusItem(gs(R.string.next_poll_in), wakeupTime <= 0 ? gs(R.string.n_a)
                 : JoH.niceTimeScalar(wakeupTime - JoH.tsl())));
         if (downloader != null && !downloader.getSelectedPatient().isEmpty()) {
-            statuses.add(new StatusItem("EasyView patient", downloader.getSelectedPatient()));
+            statuses.add(new StatusItem(gs(R.string.easyview_patient), downloader.getSelectedPatient()));
         }
         if (downloader != null && !downloader.getStatus().isEmpty()) {
-            statuses.add(new StatusItem("Last state", downloader.getStatus()));
+            statuses.add(new StatusItem(gs(R.string.last_state), downloader.getStatus()));
         }
         return statuses;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowService.java
@@ -1,0 +1,159 @@
+package com.eveningoutpost.dexdrip.cgm.medtrumfollow;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.os.IBinder;
+import android.os.PowerManager;
+import android.text.SpannableString;
+
+import androidx.annotation.Nullable;
+
+import com.eveningoutpost.dexdrip.models.BgReading;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.models.UserError;
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.eveningoutpost.dexdrip.utilitymodels.Inevitable;
+import com.eveningoutpost.dexdrip.utilitymodels.StatusItem;
+import com.eveningoutpost.dexdrip.cgm.nsfollow.utils.Anticipate;
+import com.eveningoutpost.dexdrip.utils.DexCollectionType;
+import com.eveningoutpost.dexdrip.utils.framework.BuggySamsung;
+import com.eveningoutpost.dexdrip.utils.framework.ForegroundService;
+import com.eveningoutpost.dexdrip.utils.framework.WakeLockTrampoline;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MedtrumFollowService extends ForegroundService {
+
+    private static final String TAG = "MedtrumFollow";
+    private static final long SAMPLE_PERIOD = 2 * Constants.MINUTE_IN_MS;
+
+    private static volatile long wakeupTime;
+    private static volatile long lastWakeup;
+    private static volatile long lastPoll;
+    private static volatile long bgReceiveDelay;
+    private static volatile long lastBgTime;
+    private static BuggySamsung buggySamsung;
+    private static MedtrumFollowDownloader downloader;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        resetInstance();
+    }
+
+    @Override
+    public int onStartCommand(final Intent intent, final int flags, final int startId) {
+        final PowerManager.WakeLock wakeLock = JoH.getWakeLock("MedtrumFollow-osc", 60_000);
+        try {
+            if (DexCollectionType.getDexCollectionType() != DexCollectionType.MedtrumFollow) {
+                stopSelf();
+                return START_NOT_STICKY;
+            }
+            if (buggySamsung == null) buggySamsung = new BuggySamsung(TAG);
+            buggySamsung.evaluate(wakeupTime);
+            wakeupTime = 0;
+            lastWakeup = JoH.tsl();
+            scheduleWakeUp();
+
+            final ConnectivityManager connectivityManager =
+                    (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+            if (connectivityManager == null || connectivityManager.getActiveNetwork() == null) {
+                UserError.Log.d(TAG, "No network available; skipping poll");
+                return START_STICKY;
+            }
+
+            final BgReading last = BgReading.lastNoSenssor();
+            if (last == null || JoH.msSince(last.timestamp) > SAMPLE_PERIOD) {
+                if (JoH.ratelimit("last-medtrum-follow-poll", 5)) {
+                    Inevitable.task("Medtrum-Follow-Work", 200, () -> {
+                        getDownloader().download();
+                        lastPoll = JoH.tsl();
+                    });
+                }
+            } else {
+                UserError.Log.d(TAG, "Already have recent reading: " + JoH.msSince(last.timestamp));
+            }
+        } finally {
+            JoH.releaseWakeLock(wakeLock);
+        }
+        return START_STICKY;
+    }
+
+    private static synchronized MedtrumFollowDownloader getDownloader() {
+        if (downloader == null) downloader = new MedtrumFollowDownloader();
+        return downloader;
+    }
+
+    public static synchronized void resetInstanceAndInvalidateSession() {
+        if (downloader != null) downloader.invalidateSession();
+        resetInstance();
+    }
+
+    public static synchronized void resetInstance() {
+        downloader = null;
+    }
+
+    static void scheduleWakeUp() {
+        final BgReading lastBg = BgReading.lastNoSenssor();
+        final long last = lastBg == null ? 0 : lastBg.timestamp;
+        final long grace = 10 * Constants.SECOND_IN_MS;
+        final long next = Anticipate.next(JoH.tsl(), last, SAMPLE_PERIOD, grace) + grace;
+        wakeupTime = next;
+        JoH.wakeUpIntent(xdrip.getAppContext(), JoH.msTill(next),
+                WakeLockTrampoline.getPendingIntent(MedtrumFollowService.class,
+                        Constants.MEDTRUM_FOLLOW_SERVICE_FAILOVER_ID));
+    }
+
+    static void updateBgReceiveDelay() {
+        final BgReading lastBg = BgReading.lastNoSenssor();
+        if (lastBg != null && lastBg.timestamp != lastBgTime) {
+            bgReceiveDelay = JoH.msSince(lastBg.timestamp);
+            lastBgTime = lastBg.timestamp;
+        }
+    }
+
+    public static boolean isCollecting() {
+        return JoH.msSince(lastWakeup) < 15 * Constants.MINUTE_IN_MS;
+    }
+
+    public static List<StatusItem> megaStatus() {
+        final List<StatusItem> statuses = new ArrayList<>();
+        final BgReading lastBg = BgReading.lastNoSenssor();
+        statuses.add(new StatusItem("Latest BG", lastBg == null ? "n/a"
+                : JoH.niceTimeScalar(JoH.msSince(lastBg.timestamp)) + " ago"));
+        statuses.add(new StatusItem("BG receive delay", bgReceiveDelay <= 0 ? "n/a"
+                : JoH.niceTimeScalar(bgReceiveDelay)));
+        statuses.add(new StatusItem("Last poll", lastPoll <= 0 ? "n/a"
+                : JoH.niceTimeScalar(JoH.msSince(lastPoll)) + " ago"));
+        statuses.add(new StatusItem("Next poll in", wakeupTime <= 0 ? "n/a"
+                : JoH.niceTimeScalar(wakeupTime - JoH.tsl())));
+        if (downloader != null && !downloader.getSelectedPatient().isEmpty()) {
+            statuses.add(new StatusItem("EasyView patient", downloader.getSelectedPatient()));
+        }
+        if (downloader != null && !downloader.getStatus().isEmpty()) {
+            statuses.add(new StatusItem("Last state", downloader.getStatus()));
+        }
+        return statuses;
+    }
+
+    public static SpannableString nanoStatus() {
+        if (downloader == null || downloader.getStatus().isEmpty()) return null;
+        return new SpannableString(downloader.getStatus());
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(final Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        resetInstance();
+    }
+}
+

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Constants.java
@@ -59,6 +59,7 @@ public class Constants {
     public static final int BACKUP_ACTIVITY_ID = 1029;
     public static final int CARELINK_SERVICE_FAILOVER_ID = 1030;
     public static final int GLUPRO_SERVICE_FAILOVER_ID = 1031;
+    public static final int MEDTRUM_FOLLOW_SERVICE_FAILOVER_ID = 1032;
 
     static final int NIGHTSCOUT_ERROR_NOTIFICATION_ID = 2001;
     public static final int HEALTH_CONNECT_RESPONSE_ID = 2002;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionHelper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionHelper.java
@@ -12,6 +12,7 @@ import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.services.Ob1G5CollectionService;
 import com.eveningoutpost.dexdrip.utilitymodels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+import com.eveningoutpost.dexdrip.cgm.medtrumfollow.MedtrumFollowService;
 import com.eveningoutpost.dexdrip.cgm.sharefollow.ShareFollowService;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.CareLinkFollowService;
 import com.eveningoutpost.dexdrip.plugin.Dialog;
@@ -81,6 +82,22 @@ public class DexCollectionHelper {
                             Home.staticRefreshBGCharts();
                             CollectionServiceStarter.restartCollectionServiceBackground();
                         });
+                break;
+
+            case MedtrumFollow:
+                textSettingDialog(activity,
+                        "medtrum_follow_user", "EasyView username",
+                        "Enter the dedicated EasyView follower (caregiver) username or email",
+                        InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
+                        () -> textSettingDialog(activity,
+                                "medtrum_follow_password", "EasyView password",
+                                "Enter the EasyView follower password",
+                                InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD,
+                                () -> {
+                                    Home.staticRefreshBGCharts();
+                                    MedtrumFollowService.resetInstanceAndInvalidateSession();
+                                    CollectionServiceStarter.restartCollectionServiceBackground();
+                                }));
                 break;
 
             case SHFollow:

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionHelper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionHelper.java
@@ -21,6 +21,7 @@ import com.eveningoutpost.dexdrip.xdrip;
 import static com.eveningoutpost.dexdrip.services.Ob1G5CollectionService.clearDataWhenTransmitterIdEntered;
 import static com.eveningoutpost.dexdrip.ui.dialog.QuickSettingsDialogs.booleanSettingDialog;
 import static com.eveningoutpost.dexdrip.ui.dialog.QuickSettingsDialogs.textSettingDialog;
+import static com.eveningoutpost.dexdrip.xdrip.gs;
 
 /**
  * Created by jamorham on 02/03/2018.
@@ -86,12 +87,12 @@ public class DexCollectionHelper {
 
             case MedtrumFollow:
                 textSettingDialog(activity,
-                        "medtrum_follow_user", "EasyView username",
-                        "Enter the dedicated EasyView follower (caregiver) username or email",
+                        "medtrum_follow_user", gs(R.string.title_medtrum_follow_user),
+                        gs(R.string.enter_easyview_follower_email),
                         InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
                         () -> textSettingDialog(activity,
-                                "medtrum_follow_password", "EasyView password",
-                                "Enter the EasyView follower password",
+                                "medtrum_follow_password", gs(R.string.title_medtrum_follow_password),
+                                gs(R.string.enter_easyview_follower_password),
                                 InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD,
                                 () -> {
                                     Home.staticRefreshBGCharts();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
@@ -12,6 +12,7 @@ import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.MockDataSource;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.cgm.medtrum.MedtrumCollectionService;
+import com.eveningoutpost.dexdrip.cgm.medtrumfollow.MedtrumFollowService;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.NightscoutFollowService;
 import com.eveningoutpost.dexdrip.cgm.sharefollow.ShareFollowService;
 import com.eveningoutpost.dexdrip.cgm.webfollow.WebFollowService;
@@ -52,6 +53,7 @@ public enum DexCollectionType {
     WebFollow("WebFollower"),
     CLFollow("CLFollower"),
     Medtrum("Medtrum"),
+    MedtrumFollow("MedtrumFollower"),
     UiBased("UiBased"),
     GluPro("GluPro"),
     Disabled("Disabled"),
@@ -97,13 +99,13 @@ public enum DexCollectionType {
         Collections.addAll(usesXbridge, DexbridgeWixel, WifiDexBridgeWixel);
         Collections.addAll(usesFiltered, DexbridgeWixel, WifiDexBridgeWixel, DexcomG5, WifiWixel, Follower, Mock); // Bluetooth and Wifi+Bluetooth need dynamic mode
         Collections.addAll(usesLibre, LimiTTer, LibreAlarm, LimiTTerWifi, LibreWifi, LibreReceiver);
-        Collections.addAll(isPassive, NSEmulator, NSFollow, SHFollow, WebFollow, LibreReceiver, UiBased, CLFollow, AidexReceiver);
-        Collections.addAll(canNotStartStopOrCal, NSFollow, SHFollow, WebFollow, UiBased, CLFollow, Disabled); // Collectors that cannot start/stop sensor or submit calibration
+        Collections.addAll(isPassive, NSEmulator, NSFollow, SHFollow, WebFollow, MedtrumFollow, LibreReceiver, UiBased, CLFollow, AidexReceiver);
+        Collections.addAll(canNotStartStopOrCal, NSFollow, SHFollow, WebFollow, MedtrumFollow, UiBased, CLFollow, Disabled); // Collectors that cannot start/stop sensor or submit calibration
         Collections.addAll(alwaysNativeCal, Follower, GluPro); // always allow calibration entry
         Collections.addAll(usesBattery, BluetoothWixel, DexbridgeWixel, WifiBlueToothWixel, WifiDexBridgeWixel, Follower, LimiTTer, LibreAlarm, LimiTTerWifi, LibreWifi); // parakeet separate
         Collections.addAll(usesDexcomRaw, BluetoothWixel, DexbridgeWixel, WifiWixel, WifiBlueToothWixel, DexcomG5, WifiDexBridgeWixel, Mock);
         Collections.addAll(usesTransmitterBattery, WifiWixel, BluetoothWixel, DexbridgeWixel, WifiBlueToothWixel, WifiDexBridgeWixel); // G4 transmitter battery
-        Collections.addAll(newerCollector, NSFollow, SHFollow, WebFollow, CLFollow, GluPro);
+        Collections.addAll(newerCollector, NSFollow, SHFollow, WebFollow, MedtrumFollow, CLFollow, GluPro);
     }
 
 
@@ -228,6 +230,8 @@ public enum DexCollectionType {
                 return WifiCollectionService.class;
             case Medtrum:
                 return MedtrumCollectionService.class;
+            case MedtrumFollow:
+                return MedtrumFollowService.class;
             case Follower:
             case LibreReceiver:
                 return DoNothingService.class;
@@ -317,6 +321,8 @@ public enum DexCollectionType {
                 return "Network libre";
             case NSFollow:
                 return "Nightscout";
+            case MedtrumFollow:
+                return "Medtrum EasyView";
             case SHFollow:
                 return "Share";
             case UiBased:
@@ -384,6 +390,8 @@ public enum DexCollectionType {
             case NSFollow:
                 long samplePeriodInMinutes = Pref.getStringToInt("nsfollow_sample_period_in_minutes", 5);
                 return Constants.MINUTE_IN_MS * Math.max(1, samplePeriodInMinutes);
+            case MedtrumFollow:
+                return 2 * Constants.MINUTE_IN_MS;
             case Mock:
                 int mockInterval = Pref.getInt(MockDataSource.PREF_INTERVAL, 5) ;
                 return mockInterval * Constants.MINUTE_IN_MS;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -69,6 +69,7 @@ import com.eveningoutpost.dexdrip.calibrations.PluggableCalibration;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.CareLinkFollowService;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth.CareLinkAuthType;
 import com.eveningoutpost.dexdrip.cgm.dex.TxIdHelper;
+import com.eveningoutpost.dexdrip.cgm.medtrumfollow.MedtrumFollowService;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.NightscoutFollow;
 import com.eveningoutpost.dexdrip.cgm.sharefollow.ShareFollowService;
 import com.eveningoutpost.dexdrip.cgm.webfollow.Cpref;
@@ -1403,6 +1404,25 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             final Preference nsFollowUrl = findPreference("nsfollow_url");
             final Preference nsFollowSamplePeriod = findPreference("nsfollow_sample_period_in_minutes"); // Show the Nightscout follow sample period setting only when NS follow is the data source
             final Preference nsFollowLag = findPreference("nsfollow_lag"); // Show the Nightscout follow wake delay setting only when NS follow is the data source
+            final Preference medtrumFollowUser = findPreference("medtrum_follow_user");
+            final Preference medtrumFollowPassword = findPreference("medtrum_follow_password");
+            final Preference medtrumFollowServer = findPreference("medtrum_follow_server");
+            final Preference medtrumFollowPatient = findPreference("medtrum_follow_patient");
+            final Preference.OnPreferenceChangeListener medtrumFollowListener = (preference, newValue) -> {
+                MedtrumFollowService.resetInstanceAndInvalidateSession();
+                CollectionServiceStarter.restartCollectionServiceBackground();
+                return true;
+            };
+            medtrumFollowUser.setOnPreferenceChangeListener(medtrumFollowListener);
+            medtrumFollowPassword.setOnPreferenceChangeListener(medtrumFollowListener);
+            medtrumFollowServer.setOnPreferenceChangeListener(medtrumFollowListener);
+            medtrumFollowPatient.setOnPreferenceChangeListener(medtrumFollowListener);
+            if (collectionType != DexCollectionType.MedtrumFollow) {
+                collectionCategory.removePreference(medtrumFollowUser);
+                collectionCategory.removePreference(medtrumFollowPassword);
+                collectionCategory.removePreference(medtrumFollowServer);
+                collectionCategory.removePreference(medtrumFollowPatient);
+            }
             try {
                 nsFollowUrl.setOnPreferenceChangeListener((preference, newValue) -> {
                     NightscoutFollow.resetInstance();
@@ -2605,6 +2625,18 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                         collectionCategory.addPreference(nsFollowDownload);
                         collectionCategory.addPreference(nsFollowSamplePeriod);
                         collectionCategory.addPreference(nsFollowLag);
+                    }
+
+                    if (collectionType == DexCollectionType.MedtrumFollow) {
+                        collectionCategory.addPreference(medtrumFollowUser);
+                        collectionCategory.addPreference(medtrumFollowPassword);
+                        collectionCategory.addPreference(medtrumFollowServer);
+                        collectionCategory.addPreference(medtrumFollowPatient);
+                    } else {
+                        collectionCategory.removePreference(medtrumFollowUser);
+                        collectionCategory.removePreference(medtrumFollowPassword);
+                        collectionCategory.removePreference(medtrumFollowServer);
+                        collectionCategory.removePreference(medtrumFollowPatient);
                     }
 
                     if (collectionType == DexCollectionType.Follower) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -15,6 +15,7 @@
         <item>Libre (patched App)</item>
         <item>640G / EverSense</item>
         <item>Medtrum A6</item>
+        <item>Medtrum Follower</item>
         <item>Nightscout Follower</item>
         <item>Dex Share Follower</item>
         <item>Web Follower</item>
@@ -40,6 +41,7 @@
         <item>LibreReceiver</item>
         <item>NSEmulator</item>
         <item>Medtrum</item>
+        <item>MedtrumFollower</item>
         <item>NSFollower</item>
         <item>SHFollower</item>
         <item>WebFollower</item>
@@ -48,6 +50,15 @@
         <item>AidexReceiver</item>
         <item>CLFollower</item>
         <item>Disabled</item>
+    </string-array>
+
+    <string-array name="medtrum_follow_server_entries">
+        <item>Europe (.eu)</item>
+        <item>France (.fr)</item>
+    </string-array>
+    <string-array name="medtrum_follow_server_values">
+        <item>eu</item>
+        <item>fr</item>
     </string-array>
 
      <string-array name="EnableStreamingMethods">

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -15,7 +15,7 @@
         <item>Libre (patched App)</item>
         <item>640G / EverSense</item>
         <item>Medtrum A6</item>
-        <item>Medtrum Follower</item>
+        <item>Medtrum follower</item>
         <item>Nightscout Follower</item>
         <item>Dex Share Follower</item>
         <item>Web Follower</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2106,4 +2106,20 @@
     <string name="click">Click</string>
     <string name="to_use_this_instead">to use this instead?</string>
     <string name="the_transmitter_id_you_have_entered_is_incorrect">The transmitter ID or pairing code you have entered is incorrect and would not work.\n\nPlease double-check the details and try again.</string>
+    <string name="please_enter_easyview_username_and_password">Please enter EasyView username and password</string>
+    <string name="download_already_in_progress">Download already in progress</string>
+    <string name="logging_in_to_medtrum_easyview">Logging in to Medtrum EasyView</string>
+    <string name="easyview_login_failed">"EasyView login failed: "</string>
+    <string name="easyview_login_did_not_return_a_session_cookie">EasyView login did not return a session cookie</string>
+    <string name="easyview_login_connection_error">"EasyView login connection error: "</string>
+    <string name="easyview_download_connection_error">"EasyView download connection error: "</string>
+    <string name="easyview_download_failed">"EasyView download failed: "</string>
+    <string name="latest_bg">Latest BG</string>
+    <string name="ago">" ago"</string>
+    <string name="bg_receive_delay">BG receive delay</string>
+    <string name="n_a">n/a</string>
+    <string name="last_poll">Last poll</string>
+    <string name="next_poll_in">Next poll in</string>
+    <string name="easyview_patient">EasyView patient</string>
+    <string name="last_state">Last state</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2107,6 +2107,8 @@
     <string name="to_use_this_instead">to use this instead?</string>
     <string name="the_transmitter_id_you_have_entered_is_incorrect">The transmitter ID or pairing code you have entered is incorrect and would not work.\n\nPlease double-check the details and try again.</string>
     <string name="please_enter_easyview_username_and_password">Please enter EasyView username and password</string>
+    <string name="enter_easyview_follower_email">Enter the dedicated EasyView follower (caregiver) username or email</string>
+    <string name="enter_easyview_follower_password">Enter the EasyView follower password</string>
     <string name="download_already_in_progress">Download already in progress</string>
     <string name="logging_in_to_medtrum_easyview">Logging in to Medtrum EasyView</string>
     <string name="easyview_login_failed">"EasyView login failed: "</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1386,6 +1386,14 @@
     <string name="title_medtrum_use_native">Medtrum Native</string>
     <string name="summary_medtrum_a_hex">Hex diagnostic test value</string>
     <string name="title_medtrum_a_hex">Medtrum Debug</string>
+    <string name="title_medtrum_follow_user">EasyView username</string>
+    <string name="summary_medtrum_follow_user">Username or email address of the dedicated EasyView follower account</string>
+    <string name="title_medtrum_follow_password">EasyView password</string>
+    <string name="summary_medtrum_follow_password">Password of the dedicated EasyView follower account</string>
+    <string name="title_medtrum_follow_server">EasyView server</string>
+    <string name="summary_medtrum_follow_server">Server region used by the EasyView account</string>
+    <string name="title_medtrum_follow_patient">Followed patient</string>
+    <string name="summary_medtrum_follow_patient">Patient username or email; leave empty to use the first patient with sensor data</string>
     <string name="summary_nsfollow_url">Web address for following</string>
     <string name="title_nsfollow_url">Nightscout Follow URL</string>
     <string name="summary_nsfollow_download_treatments">Also download treatments from Nightscout as follower</string>

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -188,6 +188,37 @@
             android:title="@string/title_medtrum_a_hex" />
         <EditTextPreference
             android:defaultValue=""
+            android:inputType="textNoSuggestions|textEmailAddress"
+            android:key="medtrum_follow_user"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:summary="@string/summary_medtrum_follow_user"
+            android:title="@string/title_medtrum_follow_user" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:inputType="textPassword"
+            android:key="medtrum_follow_password"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:summary="@string/summary_medtrum_follow_password"
+            android:title="@string/title_medtrum_follow_password" />
+        <ListPreference
+            android:defaultValue="eu"
+            android:entries="@array/medtrum_follow_server_entries"
+            android:entryValues="@array/medtrum_follow_server_values"
+            android:key="medtrum_follow_server"
+            android:summary="@string/summary_medtrum_follow_server"
+            android:title="@string/title_medtrum_follow_server" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:inputType="textNoSuggestions|textEmailAddress"
+            android:key="medtrum_follow_patient"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:summary="@string/summary_medtrum_follow_patient"
+            android:title="@string/title_medtrum_follow_patient" />
+        <EditTextPreference
+            android:defaultValue=""
             android:inputType="textNoSuggestions|textVisiblePassword"
             android:key="nsfollow_url"
             android:maxLines="1"

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowDataTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/medtrumfollow/MedtrumFollowDataTest.java
@@ -1,0 +1,109 @@
+package com.eveningoutpost.dexdrip.cgm.medtrumfollow;
+
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.google.gson.JsonParser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MedtrumFollowDataTest {
+
+    @Test
+    public void selectsConfiguredPatientAndConvertsMmol() {
+        final String json = "{\"res\":\"OK\",\"monitorlist\":["
+                + "{\"username\":\"first@example.com\"},"
+                + "{\"username\":\"patient@example.com\",\"sensor_status\":{"
+                + "\"glucose\":7.1,\"glucoseRate\":3,\"updateTime\":1752563388}}]}";
+
+        final MedtrumFollowData.Result result = MedtrumFollowData.parseMonitor(
+                new JsonParser().parse(json).getAsJsonObject(), "PATIENT@example.com");
+
+        assertTrue(result.isSuccessful());
+        assertEquals("patient@example.com", result.patient);
+        assertEquals(1, result.entries.size());
+        assertEquals(1752563388000L, result.entries.get(0).timestamp);
+        assertEquals(7.1 * Constants.MMOLL_TO_MGDL, result.entries.get(0).glucose, 0.001);
+        assertEquals("DoubleUp", result.entries.get(0).trendName);
+    }
+
+    @Test
+    public void choosesFirstPatientWithSensorAndKeepsMgDl() {
+        final String json = "{\"monitorlist\":["
+                + "{\"username\":\"no-sensor@example.com\"},"
+                + "{\"username\":\"sensor@example.com\",\"sensor_status\":{"
+                + "\"glucose\":128,\"glucoseRate\":8,\"updateTime\":100}}]}";
+
+        final MedtrumFollowData.Result result = MedtrumFollowData.parseMonitor(
+                new JsonParser().parse(json).getAsJsonObject(), "");
+
+        assertTrue(result.isSuccessful());
+        assertEquals("sensor@example.com", result.patient);
+        assertEquals(128, result.entries.get(0).glucose, 0);
+        assertEquals("Flat", result.entries.get(0).trendName);
+    }
+
+    @Test
+    public void reportsWarmupInsteadOfImportingZero() {
+        final String json = "{\"res\":\"OK\",\"monitorlist\":[{\"username\":\"p\","
+                + "\"sensor_status\":{\"glucose\":0,\"updateTime\":100,\"sequence\":15}}]}";
+
+        final MedtrumFollowData.Result result = MedtrumFollowData.parseMonitor(
+                new JsonParser().parse(json).getAsJsonObject(), "p");
+
+        assertFalse(result.isSuccessful());
+        assertTrue(result.error.contains("warming up"));
+        assertTrue(result.entries.isEmpty());
+    }
+
+    @Test
+    public void rejectsOutOfRangeGlucose() {
+        final String json = "{\"monitorlist\":[{\"username\":\"p\",\"sensor_status\":{"
+                + "\"glucose\":999,\"updateTime\":100}}]}";
+
+        final MedtrumFollowData.Result result = MedtrumFollowData.parseMonitor(
+                new JsonParser().parse(json).getAsJsonObject(), "p");
+
+        assertFalse(result.isSuccessful());
+        assertTrue(result.error.contains("out-of-range"));
+    }
+
+    @Test
+    public void parsesValidGraphRowsAndSkipsMalformedOrOldRows() {
+        final String json = "{\"res\":\"OK\",\"data\":["
+                + "[\"id1\",100,11.7,4.8,\"C\",0],"
+                + "[\"bad\"],"
+                + "[\"id2\",200,12.0,5.0,\"C\",0]]}";
+
+        final MedtrumFollowData.Result result = MedtrumFollowData.parseGraph(
+                new JsonParser().parse(json).getAsJsonObject(), 150000L);
+
+        assertTrue(result.isSuccessful());
+        assertEquals(1, result.entries.size());
+        assertEquals(200000L, result.entries.get(0).timestamp);
+        assertEquals(5.0 * Constants.MMOLL_TO_MGDL, result.entries.get(0).glucose, 0.001);
+        assertNull(result.entries.get(0).trendName);
+    }
+
+    @Test
+    public void exposesServerErrorMessage() {
+        final MedtrumFollowData.Result result = MedtrumFollowData.parseMonitor(
+                new JsonParser().parse("{\"res\":\"Err\",\"msg\":\"Invalid session\"}")
+                        .getAsJsonObject(), "");
+
+        assertFalse(result.isSuccessful());
+        assertEquals("Invalid session", result.error);
+    }
+
+    @Test
+    public void onlyAllowsKnownServerDomains() {
+        assertEquals("https://easyview.medtrum.eu/", MedtrumFollowDownloader.serverUrl("eu"));
+        assertEquals("https://easyview.medtrum.fr/", MedtrumFollowDownloader.serverUrl("fr"));
+        assertEquals("https://easyview.medtrum.eu/", MedtrumFollowDownloader.serverUrl("evil.example"));
+    }
+}
+
+

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java
@@ -40,6 +40,7 @@ public enum DexCollectionType {
     NSFollow("NSFollower"),
     SHFollow("SHFollower"),
     Medtrum("Medtrum"),
+    MedtrumFollow("MedtrumFollower"),
     Disabled("Disabled"),
     Mock("Mock"),
     Manual("Manual"),
@@ -186,6 +187,7 @@ public enum DexCollectionType {
             case Medtrum:
                 return MedtrumCollectionService.class;
             case Follower:
+            case MedtrumFollow:
             case LibreReceiver:
                 return DoNothingService.class;
             case NSFollow:
@@ -265,6 +267,8 @@ public enum DexCollectionType {
                 return "Network libre";
             case NSFollow:
                 return "Nightscout";
+            case MedtrumFollow:
+                return "Medtrum EasyView";
             case SHFollow:
                 return "Share";
 


### PR DESCRIPTION
Please see https://github.com/NightscoutFoundation/xDrip/discussions/3429#discussioncomment-17865504 for more details.

I implemented a medtrum-follower source with AI support that was proposed in the linked discussion above to get glucose values from the Medtrum EasyView service. 
Additional information about the API was fed to the AI from https://github.com/rodecker/medtrum-tray and https://github.com/pachi81/GlucoDataHandler, thanks to these authors for their work.

The glucose values are only available when you have an Internet connection, similar to a Nightscout follower setup.

The prerequisites to use the feature are as follows:

* Create an additional account with a different e-mail address as a "caregiver" on the [Medtrum Easy View](https://easyview.medtrum.eu/v3/#/login/login) system
* After loggin in as the caregiver, add a connection to the main patient account by entering the e-mail address of the primary patient account you use with your EasyPatch app
* In the EasyPatch App, go to Settings -> Account Security and add the newly created caregiver account with the secondary e-mail address as a remote follower

In xDrip, then select "Medtrum Follower" as the source and enter the mail address of your secondary caregiver account as "EasyView Username" and its password under "EasyView Password".