### PR TITLE
okhttp4 Phase C: swap deprecated RequestBody/ResponseBody.create() argument order

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthenticator.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthenticator.java
@@ -65,6 +65,7 @@ import okhttp3.ConnectionPool;
 import okhttp3.Cookie;
 import okhttp3.FormBody;
 import okhttp3.HttpUrl;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -440,7 +441,7 @@ public class CareLinkAuthenticator {
                 .build();
         requestBuilder = new Request.Builder()
                 .url(url)
-                .post(RequestBody.create(null, new byte[0]))
+                .post(RequestBody.create(new byte[0], (MediaType) null))
                 .addHeader("Accept", "application/json, text/plain, */*")
                 .addHeader("Accept-Language", "en;q=0.9, *;q=0.8")
                 .addHeader("Connection", "keep-alive")

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -666,7 +666,7 @@ public class CareLinkClient {
 
         gson = new GsonBuilder().create();
 
-        requestBody = RequestBody.create(MediaType.get("application/json; charset=utf-8"), gson.toJson(userJson));
+        requestBody = RequestBody.create(gson.toJson(userJson), MediaType.get("application/json; charset=utf-8"));
 
 
         //new endpoint url

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/BaseMessage.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/nsfollow/messages/BaseMessage.java
@@ -18,7 +18,7 @@ public abstract class BaseMessage {
     }
 
     public RequestBody getBody() {
-        return RequestBody.create(MediaType.parse("application/json"), this.toS());
+        return RequestBody.create(this.toS(), MediaType.parse("application/json"));
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/webfollow/Cmd.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/webfollow/Cmd.java
@@ -181,7 +181,7 @@ public class Cmd {
             }
 
             if (json != null) {
-                cb.body(RequestBody.create(JSON, json.toString()));
+                cb.body(RequestBody.create(json.toString(), JSON));
                 cb.contentType(JSON_TYPE);
             }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cloud/nightlite/NightLiteClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cloud/nightlite/NightLiteClient.java
@@ -91,7 +91,7 @@ public class NightLiteClient {
                 val urlString = url.getProtocol() + "://" + url.getHost() + "/upload?" + query;
                 val apiKey = pathElements.get(0);
                 UserError.Log.d(TAG, "url string: " + urlString);
-                val body = RequestBody.create(MediaType.parse("application/octet-stream"), bytes);
+                val body = RequestBody.create(bytes, MediaType.parse("application/octet-stream"));
 
                 val request = new Request.Builder()
                         .url(urlString)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/deposit/WebDeposit.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/deposit/WebDeposit.java
@@ -145,7 +145,7 @@ public class WebDeposit {
             return;
         }
 
-        val body = RequestBody.create(MediaType.parse("application/json"), data.toString().getBytes(StandardCharsets.UTF_8));
+        val body = RequestBody.create(data.toString().getBytes(StandardCharsets.UTF_8), MediaType.parse("application/json"));
         Call<DepositReply1> call;
 
         if ("T".equals(type)) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/sharemodels/ShareRest.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/sharemodels/ShareRest.java
@@ -156,7 +156,7 @@ public class ShareRest {
                                     MediaType contentType = response.body().contentType();
                                     String bodyString = response.body().string();
                                     Log.d(TAG, "Response body: " + bodyString);
-                                    return response.newBuilder().body(ResponseBody.create(contentType, bodyString)).build();
+                                    return response.newBuilder().body(ResponseBody.create(bodyString, contentType)).build();
                                 } else
                                     return response;
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/BaseMessage.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/BaseMessage.java
@@ -18,7 +18,7 @@ public abstract class BaseMessage {
     }
 
     public RequestBody getBody() {
-        return RequestBody.create(MediaType.parse("application/json"), this.toS());
+        return RequestBody.create(this.toS(), MediaType.parse("application/json"));
     }
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/TidepoolUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/tidepool/TidepoolUploader.java
@@ -238,7 +238,7 @@ public class TidepoolUploader {
                 UserError.Log.d(TAG, "Empty data set - marking as succeeded");
                 doCompleted(session);
             } else {
-                final RequestBody body = RequestBody.create(MediaType.parse("application/json"), chunk);
+                final RequestBody body = RequestBody.create(chunk, MediaType.parse("application/json"));
 
                 final Call<MUploadReply> call = session.service.doUpload(session.token, session.datasetReply.getUploadId(), body);
                 status("Uploading");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploader.java
@@ -574,7 +574,7 @@ public class NightscoutUploader {
         }
 
         if (array.length() > 0) {//KS
-            final RequestBody body = RequestBody.create(MediaType.parse("application/json"), array.toString());
+            final RequestBody body = RequestBody.create(array.toString(), MediaType.parse("application/json"));
             final Response<ResponseBody> r = nightscoutService.upload(secret, body).execute();
             if (!r.isSuccessful()) throw new UploaderException(r.message(), r.code());
             checkGzipSupport(r);
@@ -704,7 +704,7 @@ public class NightscoutUploader {
         json.put("dateString", format.format(record.timestamp));
         json.put("sgv", (int) record.calculated_value);
         json.put("direction", record.slopeName());
-        return RequestBody.create(MediaType.parse("application/json"), json.toString());
+        return RequestBody.create(json.toString(), MediaType.parse("application/json"));
     }
 
     private void populateV1APIMeterReadingEntry(JSONArray array, Calibration record) throws Exception {
@@ -857,7 +857,7 @@ public class NightscoutUploader {
             }
             // handle insert types
             if (insert_array.length() != 0) {
-                final RequestBody body = RequestBody.create(MediaType.parse("application/json"), insert_array.toString());
+                final RequestBody body = RequestBody.create(insert_array.toString(), MediaType.parse("application/json"));
                 final Response<ResponseBody> r;
                 if (apiSecret != null) {
                     r = nightscoutService.uploadTreatments(apiSecret, body).execute();
@@ -882,7 +882,7 @@ public class NightscoutUploader {
                     JSONObject item = (JSONObject) upsert_array.get(i);
                     final String match_uuid = item.getString("uuid");
                     item.put("_id", uuid_to_id(match_uuid));
-                    final RequestBody body = RequestBody.create(MediaType.parse("application/json"), item.toString());
+                    final RequestBody body = RequestBody.create(item.toString(), MediaType.parse("application/json"));
                     final Response<ResponseBody> r;
                     if (apiSecret != null) {
                         r = nightscoutService.upsertTreatments(apiSecret, body).execute();
@@ -946,7 +946,7 @@ public class NightscoutUploader {
                 }
                 // send to nightscout - update counter
 
-                final RequestBody body = RequestBody.create(MediaType.parse("application/json"), data.toString());
+                final RequestBody body = RequestBody.create(data.toString(), MediaType.parse("application/json"));
                 Response<ResponseBody> r;
 
                 r = nightscoutService.uploadActivity(apiSecret, body).execute();
@@ -994,7 +994,7 @@ public class NightscoutUploader {
                 }
                 // send to nightscout - update counter
 
-                final RequestBody body = RequestBody.create(MediaType.parse("application/json"), data.toString());
+                final RequestBody body = RequestBody.create(data.toString(), MediaType.parse("application/json"));
                 Response<ResponseBody> r;
 
                 r = nightscoutService.uploadActivity(apiSecret, body).execute();
@@ -1045,7 +1045,7 @@ public class NightscoutUploader {
                 }
                 // send to nightscout - update counter
 
-                final RequestBody body = RequestBody.create(MediaType.parse("application/json"), data.toString());
+                final RequestBody body = RequestBody.create(data.toString(), MediaType.parse("application/json"));
                 Response<ResponseBody> r;
 
                 r = nightscoutService.uploadActivity(apiSecret, body).execute();
@@ -1169,7 +1169,7 @@ public class NightscoutUploader {
                 //}
                 //}
 
-                final RequestBody body = RequestBody.create(MediaType.parse("application/json"), json.toString());
+                final RequestBody body = RequestBody.create(json.toString(), MediaType.parse("application/json"));
                 Response<ResponseBody> r;
                 if (apiSecret != null) {
                     r = nightscoutService.uploadDeviceStatus(apiSecret, body).execute();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutCallbackTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/nsfollow/NightscoutCallbackTest.java
@@ -76,7 +76,7 @@ public class NightscoutCallbackTest extends RobolectricTestWithConfig {
 
         // :: Act
         callback.onResponse(null, Response.error(401,
-                ResponseBody.create(MediaType.parse("text/plain"), "")));
+                ResponseBody.create("", MediaType.parse("text/plain"))));
 
         // :: Verify
         assertThat(populatorCalled.get()).isFalse();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/sharemodels/AuthenticatingCallbackTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/sharemodels/AuthenticatingCallbackTest.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
@@ -76,7 +77,7 @@ public class AuthenticatingCallbackTest extends RobolectricTestWithConfig {
                 };
 
         // :: Act
-        callback.onResponse(dummyCall(), Response.error(500, ResponseBody.create(null, "")));
+        callback.onResponse(dummyCall(), Response.error(500, ResponseBody.create("", (MediaType) null)));
 
         // :: Verify
         assertThat(retryWasCalled.get()).isTrue();
@@ -117,7 +118,7 @@ public class AuthenticatingCallbackTest extends RobolectricTestWithConfig {
                 };
 
         // :: Act
-        callback.onResponse(dummyCall(), Response.error(500, ResponseBody.create(null, "")));
+        callback.onResponse(dummyCall(), Response.error(500, ResponseBody.create("", (MediaType) null)));
 
         // :: Verify
         assertThat(retryWasCalled.get()).isFalse();
@@ -152,7 +153,7 @@ public class AuthenticatingCallbackTest extends RobolectricTestWithConfig {
                 };
 
         // :: Act
-        callback.onResponse(dummyCall(), Response.error(500, ResponseBody.create(null, "")));
+        callback.onResponse(dummyCall(), Response.error(500, ResponseBody.create("", (MediaType) null)));
 
         // :: Verify
         assertThat(capturedThrowable.get()).isSameInstanceAs(networkError);
@@ -187,10 +188,10 @@ public class AuthenticatingCallbackTest extends RobolectricTestWithConfig {
         Call<ResponseBody> call = dummyCall();
 
         // :: Act — first 500 triggers re-auth (synchronous via mock)
-        callback.onResponse(call, Response.error(500, ResponseBody.create(null, "")));
+        callback.onResponse(call, Response.error(500, ResponseBody.create("", (MediaType) null)));
 
         // Second 500 (attempts == 1) must go directly to delegate without re-auth
-        Response<ResponseBody> second500 = Response.error(500, ResponseBody.create(null, ""));
+        Response<ResponseBody> second500 = Response.error(500, ResponseBody.create("", (MediaType) null));
         callback.onResponse(call, second500);
 
         // :: Verify
@@ -289,7 +290,7 @@ public class AuthenticatingCallbackTest extends RobolectricTestWithConfig {
     private void simulateReAuthWithHttpError(int code) {
         Answer<Void> answer = invocation -> {
             Callback<String> cb = invocation.getArgument(0);
-            cb.onResponse(mockGetSessionIdCall, Response.error(code, ResponseBody.create(null, "")));
+            cb.onResponse(mockGetSessionIdCall, Response.error(code, ResponseBody.create("", (MediaType) null)));
             return null;
         };
         doAnswer(answer).when(mockGetSessionIdCall).enqueue(any(Callback.class));

--- a/app/src/test/java/com/eveningoutpost/dexdrip/sharemodels/ShareRestNullContentTypeTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/sharemodels/ShareRestNullContentTypeTest.java
@@ -1,0 +1,96 @@
+package com.eveningoutpost.dexdrip.sharemodels;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Covers {@code ShareRest}'s network interceptor rebuilding the response body via
+ * {@code ResponseBody.create(bodyString, contentType)}, both when the server sends no
+ * {@code Content-Type} header (the null-media-type case the okhttp 4 argument-order swap
+ * makes interesting) and when it sends one. The interceptor consumes the original body to
+ * log it, so a test that successfully reads the returned body's content proves the rebuild
+ * happened and preserved the payload.
+ *
+ * @author Asbjørn Aarrestad - 2026.08
+ */
+public class ShareRestNullContentTypeTest extends RobolectricTestWithConfig {
+
+    private MockWebServer server;
+
+    @Before
+    public void setUpServer() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @After
+    public void tearDownServer() throws IOException {
+        server.shutdown();
+    }
+
+    private OkHttpClient getInterceptorEquippedClient() throws Exception {
+        ShareRest shareRest = new ShareRest(RuntimeEnvironment.application, new OkHttpClient());
+        Method method = ShareRest.class.getDeclaredMethod("getOkHttpClient");
+        method.setAccessible(true);
+        return (OkHttpClient) method.invoke(shareRest);
+    }
+
+    @Test
+    public void noContentTypeHeader_rebuiltBodyHasNullContentTypeAndOriginalString() throws Exception {
+        // :: Setup — a plain setBody() call sets no Content-Type header
+        server.enqueue(new MockResponse().setBody("\"session-abc\""));
+        OkHttpClient client = getInterceptorEquippedClient();
+
+        // :: Act
+        Request request = new Request.Builder()
+                .url(server.url("/test"))
+                .get()
+                .build();
+        Response response = client.newCall(request).execute();
+
+        // :: Verify — the header assertion confirms the no-Content-Type setup actually held
+        assertThat(response.header("Content-Type")).isNull();
+        assertThat(response.body().contentType()).isNull();
+        assertThat(response.body().string()).isEqualTo("\"session-abc\"");
+    }
+
+    @Test
+    public void jsonContentTypeHeader_rebuiltBodyPreservesTypeSubtypeAndPayload() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .setBody("{\"a\":1}")
+                .setHeader("Content-Type", "application/json"));
+        OkHttpClient client = getInterceptorEquippedClient();
+
+        // :: Act
+        Request request = new Request.Builder()
+                .url(server.url("/test"))
+                .get()
+                .build();
+        Response response = client.newCall(request).execute();
+        MediaType contentType = response.body().contentType();
+
+        // :: Verify — assert the stable parts only: okhttp appends a default charset=utf-8
+        // to a media type that doesn't carry one, so a whole-value comparison is brittle.
+        assertThat(contentType).isNotNull();
+        assertThat(contentType.type()).isEqualTo("application");
+        assertThat(contentType.subtype()).isEqualTo("json");
+        assertThat(response.body().string()).isEqualTo("{\"a\":1}");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/sharemodels/ShareRestTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/sharemodels/ShareRestTest.java
@@ -53,7 +53,7 @@ public class ShareRestTest extends RobolectricTestWithConfig {
         // :: Act
         okhttp3.Request request = new okhttp3.Request.Builder()
                 .url(server.url("/test"))
-                .post(RequestBody.create(okhttp3.MediaType.parse("application/json"), "{}"))
+                .post(RequestBody.create("{}", okhttp3.MediaType.parse("application/json")))
                 .build();
         client.newCall(request).execute();
         RecordedRequest recorded = server.takeRequest();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/InfoInterceptorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/InfoInterceptorTest.java
@@ -51,7 +51,7 @@ public class InfoInterceptorTest extends RobolectricTestWithConfig {
         server.enqueue(new MockResponse().setResponseCode(201).setBody("ok"));
         final Request request = new Request.Builder()
                 .url(server.url("/v1/data"))
-                .post(RequestBody.create(JSON, "{\"a\":1}"))
+                .post(RequestBody.create("{\"a\":1}", JSON))
                 .build();
 
         // :: Act

--- a/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/TidepoolIntegrationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/tidepool/TidepoolIntegrationTest.java
@@ -105,7 +105,7 @@ public class TidepoolIntegrationTest extends RobolectricTestWithConfig {
                 .setBody("{\"id\":\"ds1\",\"uploadId\":\"up1\"}")
                 .addHeader("Content-Type", "application/json"));
         RequestBody body = RequestBody.create(
-                MediaType.parse("application/json"), "{\"test\":true}");
+                "{\"test\":true}", MediaType.parse("application/json"));
 
         // :: Act
         api.openDataSet("my-token", "user42", body).execute();
@@ -125,7 +125,7 @@ public class TidepoolIntegrationTest extends RobolectricTestWithConfig {
                 .addHeader("Content-Type", "application/json"));
         String jsonBody = "[{\"type\":\"cbg\",\"value\":120}]";
         RequestBody body = RequestBody.create(
-                MediaType.parse("application/json"), jsonBody);
+                jsonBody, MediaType.parse("application/json"));
 
         // :: Act
         api.doUpload("session-tok", "session99", body).execute();
@@ -145,7 +145,7 @@ public class TidepoolIntegrationTest extends RobolectricTestWithConfig {
                 .setBody("{\"id\":\"ds1\"}")
                 .addHeader("Content-Type", "application/json"));
         RequestBody body = RequestBody.create(
-                MediaType.parse("application/json"), "{\"status\":\"closed\"}");
+                "{\"status\":\"closed\"}", MediaType.parse("application/json"));
 
         // :: Act
         api.closeDataSet("close-tok", "session77", body).execute();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutServiceIntegrationTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutServiceIntegrationTest.java
@@ -66,7 +66,7 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
     public void upload_withApiSecret_postsToEntries() throws Exception {
         // :: Setup
         server.enqueue(new MockResponse().setResponseCode(200));
-        final RequestBody body = RequestBody.create(JSON, "[{\"sgv\":120}]");
+        final RequestBody body = RequestBody.create("[{\"sgv\":120}]", JSON);
 
         // :: Act
         final Response<ResponseBody> response = service.upload(API_SECRET, body).execute();
@@ -84,7 +84,7 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
     public void upload_withoutApiSecret_postsToEntries() throws Exception {
         // :: Setup
         server.enqueue(new MockResponse().setResponseCode(200));
-        final RequestBody body = RequestBody.create(JSON, "[{\"sgv\":120}]");
+        final RequestBody body = RequestBody.create("[{\"sgv\":120}]", JSON);
 
         // :: Act
         final Response<ResponseBody> response = service.upload(body).execute();
@@ -102,7 +102,7 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
     public void uploadDeviceStatus_withoutApiSecret_postsToDevicestatus() throws Exception {
         // :: Setup
         server.enqueue(new MockResponse().setResponseCode(200));
-        final RequestBody body = RequestBody.create(JSON, "{\"device\":\"xDrip\"}");
+        final RequestBody body = RequestBody.create("{\"device\":\"xDrip\"}", JSON);
 
         // :: Act
         final Response<ResponseBody> response = service.uploadDeviceStatus(body).execute();
@@ -119,7 +119,7 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
     public void uploadDeviceStatus_withApiSecret_postsToDevicestatus() throws Exception {
         // :: Setup
         server.enqueue(new MockResponse().setResponseCode(200));
-        final RequestBody body = RequestBody.create(JSON, "{\"device\":\"xDrip\"}");
+        final RequestBody body = RequestBody.create("{\"device\":\"xDrip\"}", JSON);
 
         // :: Act
         final Response<ResponseBody> response = service.uploadDeviceStatus(API_SECRET, body).execute();
@@ -152,7 +152,7 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
     public void uploadTreatments_postsToTreatments() throws Exception {
         // :: Setup
         server.enqueue(new MockResponse().setResponseCode(200));
-        final RequestBody body = RequestBody.create(JSON, "{\"eventType\":\"Correction Bolus\"}");
+        final RequestBody body = RequestBody.create("{\"eventType\":\"Correction Bolus\"}", JSON);
 
         // :: Act
         final Response<ResponseBody> response = service.uploadTreatments(API_SECRET, body).execute();
@@ -169,7 +169,7 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
     public void upsertTreatments_putsToTreatments() throws Exception {
         // :: Setup
         server.enqueue(new MockResponse().setResponseCode(200));
-        final RequestBody body = RequestBody.create(JSON, "{\"eventType\":\"Correction Bolus\"}");
+        final RequestBody body = RequestBody.create("{\"eventType\":\"Correction Bolus\"}", JSON);
 
         // :: Act
         final Response<ResponseBody> response = service.upsertTreatments(API_SECRET, body).execute();
@@ -238,7 +238,7 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
     public void uploadActivity_postsToActivity() throws Exception {
         // :: Setup
         server.enqueue(new MockResponse().setResponseCode(200));
-        final RequestBody body = RequestBody.create(JSON, "{\"mills\":1234567890}");
+        final RequestBody body = RequestBody.create("{\"mills\":1234567890}", JSON);
 
         // :: Act
         final Response<ResponseBody> response = service.uploadActivity(API_SECRET, body).execute();
@@ -270,7 +270,7 @@ public class NightscoutServiceIntegrationTest extends RobolectricTestWithConfig 
                 gzipRetrofit.create(NightscoutUploader.NightscoutService.class);
 
         final String payload = "[{\"sgv\":120,\"type\":\"sgv\",\"direction\":\"Flat\"}]";
-        final RequestBody body = RequestBody.create(JSON, payload);
+        final RequestBody body = RequestBody.create(payload, JSON);
 
         // :: Act
         final Response<ResponseBody> response = gzipService.upload(API_SECRET, body).execute();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploaderGzipInterceptorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NightscoutUploaderGzipInterceptorTest.java
@@ -78,7 +78,7 @@ public class NightscoutUploaderGzipInterceptorTest extends RobolectricTestWithCo
         markSupportsGzip(url, true);
         final Request request = new Request.Builder()
                 .url(url)
-                .post(RequestBody.create(JSON, "{\"a\":1}"))
+                .post(RequestBody.create("{\"a\":1}", JSON))
                 .build();
 
         // :: Act
@@ -100,7 +100,7 @@ public class NightscoutUploaderGzipInterceptorTest extends RobolectricTestWithCo
         // no marker set -> supportsGzip returns false
         final Request request = new Request.Builder()
                 .url(url)
-                .post(RequestBody.create(JSON, "{\"a\":1}"))
+                .post(RequestBody.create("{\"a\":1}", JSON))
                 .build();
 
         // :: Act
@@ -142,7 +142,7 @@ public class NightscoutUploaderGzipInterceptorTest extends RobolectricTestWithCo
         final Request request = new Request.Builder()
                 .url(url)
                 .header("Content-Encoding", "identity")
-                .post(RequestBody.create(JSON, "already"))
+                .post(RequestBody.create("already", JSON))
                 .build();
 
         // :: Act

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utils/framework/GzipRequestInterceptorTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utils/framework/GzipRequestInterceptorTest.java
@@ -66,7 +66,7 @@ public class GzipRequestInterceptorTest extends RobolectricTestWithConfig {
         server.enqueue(new MockResponse().setResponseCode(200));
         final Request request = new Request.Builder()
                 .url(server.url("/upload"))
-                .post(RequestBody.create(JSON, "{\"a\":1}"))
+                .post(RequestBody.create("{\"a\":1}", JSON))
                 .build();
 
         // :: Act
@@ -104,7 +104,7 @@ public class GzipRequestInterceptorTest extends RobolectricTestWithConfig {
         final Request request = new Request.Builder()
                 .url(server.url("/upload"))
                 .header("Content-Encoding", "identity")
-                .post(RequestBody.create(JSON, "already"))
+                .post(RequestBody.create("already", JSON))
                 .build();
 
         // :: Act
@@ -126,7 +126,7 @@ public class GzipRequestInterceptorTest extends RobolectricTestWithConfig {
         server.enqueue(new MockResponse().setResponseCode(200));
         final Request request = new Request.Builder()
                 .url(server.url("/upload"))
-                .post(RequestBody.create(JSON, "{\"a\":1}"))
+                .post(RequestBody.create("{\"a\":1}", JSON))
                 .build();
 
         // :: Act
@@ -146,7 +146,7 @@ public class GzipRequestInterceptorTest extends RobolectricTestWithConfig {
         server.enqueue(new MockResponse().setResponseCode(200));
         final Request request = new Request.Builder()
                 .url(server.url("/upload"))
-                .post(RequestBody.create(JSON, "{\"a\":1}"))
+                .post(RequestBody.create("{\"a\":1}", JSON))
                 .build();
 
         // :: Act


### PR DESCRIPTION
okhttp 4 deprecated `RequestBody.create(MediaType, X)` and `ResponseBody.create(MediaType, X)` in favour of `create(X, MediaType)`. The old order is gone in okhttp 5, so this clears the way for that upgrade. Argument order only, no behaviour change.

With #4593 merged, this finishes the job: **no use of the deprecated overloads remains in the repo.**

### What changed

44 call sites across 18 files, plus one new test.

- **Production — 17 sites, 10 files:** `NightscoutUploader` (8), `TidepoolUploader`, `tidepool/BaseMessage`, `cgm/nsfollow/messages/BaseMessage`, `cgm/webfollow/Cmd`, `carelinkfollow/client/CareLinkClient`, `carelinkfollow/auth/CareLinkAuthenticator`, `deposit/WebDeposit`, `cloud/nightlite/NightLiteClient`, `sharemodels/ShareRest`
- **Tests — 27 sites, 8 classes:** `NightscoutServiceIntegrationTest` (8), `AuthenticatingCallbackTest` (6), `GzipRequestInterceptorTest` (4), `TidepoolIntegrationTest` (3), `NightscoutUploaderGzipInterceptorTest` (3), `InfoInterceptorTest`, `ShareRestTest`, `NightscoutCallbackTest`

Three commits: the new test first, then production, then tests.

### Why it is behaviour-preserving

The deprecated overloads are one-line delegations to the new ones. From `javap -c` on okhttp 4.12.0, `ResponseBody$Companion.create(MediaType, String)` is `aload_2; aload_1; invokevirtual create(String, MediaType)` — it swaps the arguments and calls the same method. `RequestBody$Companion.create(MediaType, byte[])` reaches `create$default` with the same target as the new-order overload. Same bytes on the wire either way, including when the media type is null.

Three sites take a null media type (`CareLinkAuthenticator`, `ShareRest`, and `AuthenticatingCallbackTest`). They carry an explicit `(MediaType)` cast so the reader can see which overload is selected; the compiler does not require it, and there is no null-specific path on either side.

### Not in this PR

`MediaType.parse` and `HttpUrl.parse` are **not** deprecated in 4.12.0 (checked with `javap`) and are left alone. `get` throws on invalid input where `parse` returns null, so converting them would be a behaviour change rather than a cleanup.

### Verification

`./gradlew :app:testFastDebugUnitTest :wear:testFastDebugUnitTest` — all green.

A javac deprecation lint over `:app` production and unit-test sources reports **zero** remaining uses of either method, down from 44.

`ShareRestNullContentTypeTest` is new. It drives the real `ShareRest` interceptor through a `MockWebServer` and asserts the rebuilt response body: null content type and payload preserved when the server sends no `Content-Type`, type and subtype preserved when it sends `application/json`. The interceptor consumes the original body in order to log it, so reading the returned body at all proves the rebuild ran. It is committed before the swap and was green against unmodified production code, so it pins existing behaviour rather than the change.

The gzip interceptor tests assert on the encoded request body, so those 7 sites are covered behaviourally too. Elsewhere the compiler is the real check — a wrong argument order does not type-check — and the integration tests that were touched build their own request bodies rather than asserting on these call sites. `CareLinkAuthenticator#refreshBrowserToken()` builds its client inline and has no unit-test seam.
