### PR TITLE
Behavioural test coverage for the HTTP paths (no production changes)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -376,6 +376,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.16"
     testImplementation "com.google.truth:truth:1.4.5"
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'com.squareup.okhttp3:okhttp-tls:4.12.0'
 
     testImplementation 'org.mockito:mockito-inline:2.13.0'
     testImplementation 'org.mockito:mockito-core:4.11.0'

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/EditableCookieJarTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/EditableCookieJarTest.java
@@ -58,7 +58,7 @@ public class EditableCookieJarTest extends RobolectricTestWithConfig {
                 .build();
     }
 
-    // ===== session handoff =======================================================================
+    // ===== Session handoff =======================================================================
 
     /** A cookie set by the server is stored by the jar and replayed on the next request. */
     @Test
@@ -89,7 +89,7 @@ public class EditableCookieJarTest extends RobolectricTestWithConfig {
      * okhttp's bridge interceptor during {@code execute()} — not in this test's setup.
      */
     @Test
-    public void jar_replaysParentDomainCookieAcrossHosts() throws Exception {
+    public void cookiePolicy_replaysParentDomainCookieAcrossHosts() throws Exception {
         // :: Setup
         server.enqueue(new MockResponse()
                 .addHeader("Set-Cookie", AUTH_COOKIE + "=abc123; Domain=minimed.eu; Path=/")
@@ -124,7 +124,7 @@ public class EditableCookieJarTest extends RobolectricTestWithConfig {
      * still be green and this one would go red.
      */
     @Test
-    public void jar_refusesACookieScopedToAPublicSuffix() throws Exception {
+    public void cookiePolicy_refusesACookieScopedToAPublicSuffix() throws Exception {
         // :: Setup
         server.enqueue(new MockResponse()
                 .addHeader("Set-Cookie", AUTH_COOKIE + "=abc123; Domain=eu; Path=/")
@@ -147,7 +147,7 @@ public class EditableCookieJarTest extends RobolectricTestWithConfig {
         assertThat(cookieJar.getAllCookies()).isEmpty();
     }
 
-    // ===== jar bookkeeping =======================================================================
+    // ===== Jar bookkeeping =======================================================================
 
     /** Re-issuing a cookie replaces the stored one instead of accumulating a duplicate. */
     @Test

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/EditableCookieJarTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/EditableCookieJarTest.java
@@ -1,0 +1,193 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.utilitymodels.OkHttpWrapper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+
+import okhttp3.Cookie;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * The cookie jar CareLink follow authenticates through.
+ * <p>
+ * CareLink issues its session cookie on one host and is then called on another under the same
+ * registered domain, so the jar has to store a parent-domain cookie and replay it for a sibling
+ * host. Deciding whether {@code Domain=minimed.eu} is a legal scope for {@code carelink.minimed.eu}
+ * sends okhttp into its public suffix database, which okhttp 5 relocates into the Android AAR's
+ * assets — so this contract is asserted rather than assumed.
+ *
+ * @author Asbjørn Aarrestad - 2026.08
+ */
+public class EditableCookieJarTest extends RobolectricTestWithConfig {
+
+    private static final String AUTH_COOKIE = "auth_tmp_token";
+
+    private MockWebServer server;
+    private EditableCookieJar cookieJar;
+
+    @Before
+    public void setUpServerAndJar() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        cookieJar = new EditableCookieJar();
+    }
+
+    @After
+    public void tearDownServer() throws IOException {
+        server.shutdown();
+    }
+
+    /** A client that resolves every hostname to the loopback MockWebServer. */
+    private OkHttpClient clientResolvingEverythingToMockServer() {
+        return OkHttpWrapper.getClient().newBuilder()
+                .cookieJar(cookieJar)
+                .dns(hostname -> Collections.singletonList(InetAddress.getByName("127.0.0.1")))
+                .build();
+    }
+
+    // ===== session handoff =======================================================================
+
+    /** A cookie set by the server is stored by the jar and replayed on the next request. */
+    @Test
+    public void jar_replaysServerSetCookieOnTheNextRequest() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .addHeader("Set-Cookie", AUTH_COOKIE + "=abc123; Path=/")
+                .setBody("logged-in"));
+        server.enqueue(new MockResponse().setBody("data"));
+        OkHttpClient client = OkHttpWrapper.getClient().newBuilder().cookieJar(cookieJar).build();
+
+        // :: Act
+        client.newCall(new Request.Builder().url(server.url("/login")).build()).execute().close();
+        client.newCall(new Request.Builder().url(server.url("/data")).build()).execute().close();
+
+        // :: Verify
+        server.takeRequest();
+        RecordedRequest second = server.takeRequest();
+        assertThat(second.getHeader("Cookie")).contains(AUTH_COOKIE + "=abc123");
+        assertThat(cookieJar.getCookies(AUTH_COOKIE).get(0).value()).isEqualTo("abc123");
+    }
+
+    /**
+     * The §13.2 guard. A parent-domain cookie issued on the auth host is replayed on the API host.
+     * <p>
+     * Scoping {@code Domain=minimed.eu} against the request host {@code carelink.minimed.eu} is the
+     * one call on this path that consults okhttp's public suffix database, and it happens inside
+     * okhttp's bridge interceptor during {@code execute()} — not in this test's setup.
+     */
+    @Test
+    public void jar_replaysParentDomainCookieAcrossHosts() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .addHeader("Set-Cookie", AUTH_COOKIE + "=abc123; Domain=minimed.eu; Path=/")
+                .setBody("logged-in"));
+        server.enqueue(new MockResponse().setBody("data"));
+        OkHttpClient client = clientResolvingEverythingToMockServer();
+        int port = server.getPort();
+
+        // :: Act
+        client.newCall(new Request.Builder()
+                .url("http://carelink.minimed.eu:" + port + "/patient/sso/login")
+                .build()).execute().close();
+        client.newCall(new Request.Builder()
+                .url("http://clcloud.minimed.eu:" + port + "/connect/v2/display/message")
+                .build()).execute().close();
+
+        // :: Verify
+        server.takeRequest();
+        RecordedRequest onApiHost = server.takeRequest();
+        assertThat(onApiHost.getHeader("Cookie")).contains(AUTH_COOKIE + "=abc123");
+        assertThat(cookieJar.getCookies(AUTH_COOKIE).get(0).domain()).isEqualTo("minimed.eu");
+    }
+
+    /**
+     * A cookie scoped to a public suffix is refused outright.
+     * <p>
+     * The other half of the same database lookup, and the half that says the lookup happened at
+     * all: {@code Domain=eu} would be a supercookie readable by every host under the registry, so
+     * okhttp must reject it where it accepts {@code Domain=minimed.eu}. Measured on 2026-08-22, the
+     * two differ exactly this way at 4.12.0 — which is what makes the case above a guard rather
+     * than an assumption. If okhttp 5 ever stopped consulting the database, the case above would
+     * still be green and this one would go red.
+     */
+    @Test
+    public void jar_refusesACookieScopedToAPublicSuffix() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .addHeader("Set-Cookie", AUTH_COOKIE + "=abc123; Domain=eu; Path=/")
+                .setBody("logged-in"));
+        server.enqueue(new MockResponse().setBody("data"));
+        OkHttpClient client = clientResolvingEverythingToMockServer();
+        int port = server.getPort();
+
+        // :: Act
+        client.newCall(new Request.Builder()
+                .url("http://carelink.minimed.eu:" + port + "/patient/sso/login")
+                .build()).execute().close();
+        client.newCall(new Request.Builder()
+                .url("http://clcloud.minimed.eu:" + port + "/connect/v2/display/message")
+                .build()).execute().close();
+
+        // :: Verify
+        server.takeRequest();
+        assertThat(server.takeRequest().getHeader("Cookie")).isNull();
+        assertThat(cookieJar.getAllCookies()).isEmpty();
+    }
+
+    // ===== jar bookkeeping =======================================================================
+
+    /** Re-issuing a cookie replaces the stored one instead of accumulating a duplicate. */
+    @Test
+    public void jar_replacesACookieReissuedUnderTheSameName() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().addHeader("Set-Cookie", AUTH_COOKIE + "=first; Path=/"));
+        server.enqueue(new MockResponse().addHeader("Set-Cookie", AUTH_COOKIE + "=second; Path=/"));
+        OkHttpClient client = OkHttpWrapper.getClient().newBuilder().cookieJar(cookieJar).build();
+
+        // :: Act
+        client.newCall(new Request.Builder().url(server.url("/login")).build()).execute().close();
+        client.newCall(new Request.Builder().url(server.url("/login")).build()).execute().close();
+
+        // :: Verify
+        assertThat(cookieJar.getCookies(AUTH_COOKIE)).hasSize(1);
+        assertThat(cookieJar.getCookies(AUTH_COOKIE).get(0).value()).isEqualTo("second");
+    }
+
+    /**
+     * Cookies restored from the credential store are sent on the first request.
+     * <p>
+     * This is how CareLink follow resumes a session across process death:
+     * {@code createHttpClient()} seeds the jar via {@code AddCookies} before any call is made.
+     */
+    @Test
+    public void jar_sendsCookiesSeededFromTheCredentialStore() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setBody("data"));
+        cookieJar.AddCookies(new Cookie[]{new Cookie.Builder()
+                .name(AUTH_COOKIE)
+                .value("restored")
+                .domain("localhost")
+                .path("/")
+                .build()});
+        OkHttpClient client = OkHttpWrapper.getClient().newBuilder().cookieJar(cookieJar).build();
+
+        // :: Act
+        client.newCall(new Request.Builder().url(server.url("/data")).build()).execute().close();
+
+        // :: Verify
+        assertThat(server.takeRequest().getHeader("Cookie")).contains(AUTH_COOKIE + "=restored");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/messages/WireMessageRoundTripTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/messages/WireMessageRoundTripTest.java
@@ -1,0 +1,199 @@
+package com.eveningoutpost.dexdrip.messages;
+
+import com.squareup.wire.FieldEncoding;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import okio.ByteString;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Round trips for the protobuf messages that carry readings from the phone to the watch.
+ * <p>
+ * These four classes are Wire-generated and encode through okio, so they are the one place an okio
+ * change could silently alter a medical data path. Plain JUnit: the encoding is pure Java and needs
+ * no Android runtime.
+ *
+ * @author Asbjørn Aarrestad - 2026.08
+ */
+public class WireMessageRoundTripTest {
+
+    // ===== BgReadingMessage ======================================================================
+
+    /** A fully populated BgReadingMessage survives encode and decode field for field. */
+    @Test
+    public void bgReadingMessage_roundTripsEveryField() throws Exception {
+        // :: Setup
+        BgReadingMessage original = new BgReadingMessage.Builder()
+                .timestamp(1_754_000_000_000L)
+                .time_since_sensor_started(86_400_000d)
+                .raw_data(123.25d)
+                .filtered_data(122.75d)
+                .age_adjusted_raw_value(121.5d)
+                .calibration_flag(true)
+                .calculated_value(5.4d)
+                .filtered_calculated_value(5.3d)
+                .calculated_value_slope(0.0021d)
+                .a(1.5d).b(2.5d).c(3.5d)
+                .ra(4.5d).rb(5.5d).rc(6.5d)
+                .uuid("11111111-2222-3333-4444-555555555555")
+                .calibration_uuid("66666666-7777-8888-9999-000000000000")
+                .sensor_uuid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+                .ignoreforstats(false)
+                .raw_calculated(120.125d)
+                .hide_slope(true)
+                .noise("2")
+                .build();
+
+        // :: Act
+        byte[] encoded = BgReadingMessage.ADAPTER.encode(original);
+        BgReadingMessage decoded = BgReadingMessage.ADAPTER.decode(encoded);
+
+        // :: Verify
+        assertThat(encoded).isNotEmpty();
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    /** Fields left unset stay null through a round trip rather than becoming proto defaults. */
+    @Test
+    public void bgReadingMessage_roundTripsSparseMessage() throws Exception {
+        // :: Setup
+        BgReadingMessage original = new BgReadingMessage.Builder()
+                .timestamp(1_754_000_000_000L)
+                .calculated_value(7.1d)
+                .build();
+
+        // :: Act
+        BgReadingMessage decoded =
+                BgReadingMessage.ADAPTER.decode(BgReadingMessage.ADAPTER.encode(original));
+
+        // :: Verify
+        assertThat(decoded).isEqualTo(original);
+        assertThat(decoded.uuid).isNull();
+        assertThat(decoded.noise).isNull();
+    }
+
+    // ===== BgReadingMultiMessage =================================================================
+
+    /** A multi-message preserves both the contents and the order of its readings. */
+    @Test
+    public void bgReadingMultiMessage_roundTripsInOrder() throws Exception {
+        // :: Setup
+        List<BgReadingMessage> readings = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            readings.add(new BgReadingMessage.Builder()
+                    .timestamp(1_754_000_000_000L + i * 300_000L)
+                    .calculated_value(5.0d + i)
+                    .uuid("uuid-" + i)
+                    .build());
+        }
+        BgReadingMultiMessage original = new BgReadingMultiMessage.Builder()
+                .bgreading_message(readings)
+                .build();
+
+        // :: Act
+        BgReadingMultiMessage decoded = BgReadingMultiMessage.ADAPTER
+                .decode(BgReadingMultiMessage.ADAPTER.encode(original));
+
+        // :: Verify
+        assertThat(decoded).isEqualTo(original);
+        assertThat(decoded.bgreading_message).hasSize(3);
+        assertThat(decoded.bgreading_message.get(0).uuid).isEqualTo("uuid-0");
+        assertThat(decoded.bgreading_message.get(2).uuid).isEqualTo("uuid-2");
+    }
+
+    /** An empty multi-message round trips to an empty list, not to null. */
+    @Test
+    public void bgReadingMultiMessage_roundTripsEmptyList() throws Exception {
+        // :: Setup
+        BgReadingMultiMessage original = new BgReadingMultiMessage.Builder()
+                .bgreading_message(Collections.<BgReadingMessage>emptyList())
+                .build();
+
+        // :: Act
+        BgReadingMultiMessage decoded = BgReadingMultiMessage.ADAPTER
+                .decode(BgReadingMultiMessage.ADAPTER.encode(original));
+
+        // :: Verify
+        assertThat(decoded).isEqualTo(original);
+        assertThat(decoded.bgreading_message).isEmpty();
+    }
+
+    // ===== BloodTest messages ====================================================================
+
+    /** A fully populated BloodTestMessage survives encode and decode field for field. */
+    @Test
+    public void bloodTestMessage_roundTripsEveryField() throws Exception {
+        // :: Setup
+        BloodTestMessage original = new BloodTestMessage.Builder()
+                .timestamp(1_754_000_000_000L)
+                .mgdl(97.5d)
+                .created_timestamp(1_754_000_060_000L)
+                .state(4L)
+                .source("test-source")
+                .uuid("bbbbbbbb-cccc-dddd-eeee-ffffffffffff")
+                .build();
+
+        // :: Act
+        BloodTestMessage decoded =
+                BloodTestMessage.ADAPTER.decode(BloodTestMessage.ADAPTER.encode(original));
+
+        // :: Verify
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    /** A blood-test multi-message preserves both the contents and the order of its entries. */
+    @Test
+    public void bloodTestMultiMessage_roundTripsInOrder() throws Exception {
+        // :: Setup
+        BloodTestMultiMessage original = new BloodTestMultiMessage.Builder()
+                .bloodtest_message(Arrays.asList(
+                        new BloodTestMessage.Builder()
+                                .timestamp(1L).mgdl(90d).uuid("first").build(),
+                        new BloodTestMessage.Builder()
+                                .timestamp(2L).mgdl(110d).uuid("second").build()))
+                .build();
+
+        // :: Act
+        BloodTestMultiMessage decoded = BloodTestMultiMessage.ADAPTER
+                .decode(BloodTestMultiMessage.ADAPTER.encode(original));
+
+        // :: Verify
+        assertThat(decoded).isEqualTo(original);
+        assertThat(decoded.bloodtest_message).hasSize(2);
+        assertThat(decoded.bloodtest_message.get(0).uuid).isEqualTo("first");
+        assertThat(decoded.bloodtest_message.get(1).uuid).isEqualTo("second");
+    }
+
+    // ===== Unknown fields ========================================================================
+
+    /** Fields an older reader does not know survive decode and re-encode as bytes, unaltered. */
+    @Test
+    public void bgReadingMessage_preservesUnknownFields() throws Exception {
+        // :: Setup — tags 400 and 401 are not in the .proto, so they arrive as unknown fields
+        BgReadingMessage original = new BgReadingMessage.Builder()
+                .timestamp(1_754_000_000_000L)
+                .calculated_value(6.2d)
+                .addUnknownField(400, FieldEncoding.VARINT, 42L)
+                .addUnknownField(401, FieldEncoding.LENGTH_DELIMITED,
+                        ByteString.encodeUtf8("newer-sender"))
+                .build();
+
+        // :: Act
+        BgReadingMessage decoded =
+                BgReadingMessage.ADAPTER.decode(BgReadingMessage.ADAPTER.encode(original));
+        BgReadingMessage reEncoded =
+                BgReadingMessage.ADAPTER.decode(BgReadingMessage.ADAPTER.encode(decoded));
+
+        // :: Verify — the guard: without it the assertions below hold on an empty ByteString
+        assertThat(original.unknownFields()).isNotEqualTo(ByteString.EMPTY);
+        assertThat(decoded).isEqualTo(original);
+        assertThat(reEncoded).isEqualTo(original);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/nocturne/NocturneApiClientTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/nocturne/NocturneApiClientTest.java
@@ -1,0 +1,126 @@
+package com.eveningoutpost.dexdrip.nocturne;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * A real request driven through the third-party Nocturne SDK on xDrip's shared okhttp client.
+ * <p>
+ * {@code nocturne-java} is the one okhttp consumer in the tree that xDrip does not compile: it is
+ * handed {@link com.eveningoutpost.dexdrip.utilitymodels.OkHttpWrapper#getClient()} and builds its
+ * own requests with it. The other Nocturne tests cover request mapping and treatment routing, and
+ * no HTTP happens in either — so nothing else here would notice if the SDK linked against a new
+ * okhttp but behaved differently on the wire.
+ * <p>
+ * Client registration is the subject because it is the shortest production path that reaches the
+ * SDK's own request building: one call, one request, no session to fake. Cleartext only; the SDK's
+ * progress-reporting bodies are not covered.
+ *
+ * @author Asbjørn Aarrestad - 2026.08
+ */
+public class NocturneApiClientTest extends RobolectricTestWithConfig {
+
+    private static final String REGISTER_PATH = "/api/oauth/register";
+
+    private MockWebServer server;
+    private String basePath;
+
+    @Before
+    public void setUpServerAndInstanceUrl() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        // MockWebServer serves localhost, which getBaseUrl() leaves on http:// untouched
+        Pref.setString("nocturne_instance_url", server.url("/").toString());
+        PersistentStore.setString("nocturne_client_id", "");
+
+        basePath = "http://" + server.getHostName() + ":" + server.getPort();
+    }
+
+    @After
+    public void tearDownServer() throws IOException {
+        server.shutdown();
+        PersistentStore.setString("nocturne_client_id", "");
+    }
+
+    // ===== the SDK on the shared client ==========================================================
+
+    /**
+     * Registering leaves the phone as a POST the Nocturne API would recognise.
+     * <p>
+     * The assertions are read off the request the server received rather than off the return value
+     * alone: every failure inside {@code registerClient} is caught and reported as null, so a
+     * service that never sent anything looks the same from the outside as a rejected one.
+     */
+    @Test
+    public void registerClient_reachesTheServerThroughTheSharedClient() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"client_id\":\"granted-client-id\"}"));
+        NocturneOAuthService service = new NocturneOAuthService();
+
+        // :: Act
+        String clientId = service.registerClient();
+
+        // :: Verify
+        assertThat(clientId).isEqualTo("granted-client-id");
+        RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getMethod()).isEqualTo("POST");
+        assertThat(recorded.getPath()).isEqualTo(REGISTER_PATH);
+        assertThat(recorded.getHeader("Origin")).isEqualTo(basePath);
+        assertThat(recorded.getBody().readUtf8()).contains("xDrip+");
+    }
+
+    /** The registered client id is persisted, so a second call answers without a second request. */
+    @Test
+    public void registerClient_persistsTheClientIdAndDoesNotAskTwice() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"client_id\":\"granted-client-id\"}"));
+        NocturneOAuthService service = new NocturneOAuthService();
+
+        // :: Act
+        service.registerClient();
+        String second = service.registerClient();
+
+        // :: Verify
+        assertThat(second).isEqualTo("granted-client-id");
+        assertThat(server.getRequestCount()).isEqualTo(1);
+    }
+
+    /**
+     * A server error is reported as a failure, and the request was really made.
+     * <p>
+     * The recorded request is what separates this from a service that returned null because no
+     * instance URL was configured in the first place.
+     */
+    @Test
+    public void registerClient_reportsFailureOnServerError() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setResponseCode(500).setBody("boom"));
+        NocturneOAuthService service = new NocturneOAuthService();
+
+        // :: Act
+        String clientId = service.registerClient();
+
+        // :: Verify
+        assertThat(clientId).isNull();
+        assertThat(server.getRequestCount()).isEqualTo(1);
+        assertThat(server.takeRequest().getPath()).isEqualTo(REGISTER_PATH);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/nocturne/NocturneApiClientTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/nocturne/NocturneApiClientTest.java
@@ -56,7 +56,7 @@ public class NocturneApiClientTest extends RobolectricTestWithConfig {
         PersistentStore.setString("nocturne_client_id", "");
     }
 
-    // ===== the SDK on the shared client ==========================================================
+    // ===== The SDK on the shared client ==========================================================
 
     /**
      * Registering leaves the phone as a POST the Nocturne API would recognise.

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/OkHttpWrapperSharedClientTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/OkHttpWrapperSharedClientTest.java
@@ -19,7 +19,12 @@ import okhttp3.mockwebserver.RecordedRequest;
 import static com.google.common.truth.Truth.assertThat;
 
 /**
- * @author Asbjørn Aarrestad
+ * Contract tests for the single shared okhttp client every xDrip HTTP caller derives from.
+ * <p>
+ * Plain-HTTP Nightscout servers are a supported and widely used configuration, so the cleartext
+ * round trip is asserted here rather than left to incidental coverage.
+ *
+ * @author Asbjørn Aarrestad - 2026.08
  */
 public class OkHttpWrapperSharedClientTest extends RobolectricTestWithConfig {
 
@@ -36,6 +41,12 @@ public class OkHttpWrapperSharedClientTest extends RobolectricTestWithConfig {
         server.shutdown();
     }
 
+    // ===== Cleartext round trips =================================================================
+
+    /**
+     * The shared client reaches a plain-HTTP host, the request arrives as sent, and the response
+     * body comes back intact.
+     */
     @Test
     public void sharedClient_canPerformSimpleGet() throws Exception {
         // :: Setup
@@ -50,8 +61,15 @@ public class OkHttpWrapperSharedClientTest extends RobolectricTestWithConfig {
         // :: Verify
         assertThat(response.isSuccessful()).isTrue();
         assertThat(response.body().string()).isEqualTo("hello");
+
+        RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getPath()).isEqualTo("/test");
+        assertThat(recorded.getMethod()).isEqualTo("GET");
     }
 
+    // ===== Clients derived with newBuilder() =====================================================
+
+    /** A derived client overrides a timeout without detaching from the shared connection pool. */
     @Test
     public void sharedClient_newBuilder_canCustomizeTimeouts() throws Exception {
         // :: Setup
@@ -64,6 +82,7 @@ public class OkHttpWrapperSharedClientTest extends RobolectricTestWithConfig {
         assertThat(custom.connectionPool()).isSameInstanceAs(OkHttpWrapper.getClient().connectionPool());
     }
 
+    /** An interceptor added to a derived client reaches the wire. */
     @Test
     public void sharedClient_newBuilder_canAddInterceptor() throws Exception {
         // :: Setup
@@ -85,6 +104,9 @@ public class OkHttpWrapperSharedClientTest extends RobolectricTestWithConfig {
         assertThat(recorded.getHeader("X-Custom")).isEqualTo("test");
     }
 
+    // ===== Defaults every caller inherits ========================================================
+
+    /** The three timeouts on the shared client are the ones every xDrip caller starts from. */
     @Test
     public void sharedClient_hasCorrectDefaultTimeouts() {
         // :: Setup & Act

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/OkHttpWrapperSharedClientTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/OkHttpWrapperSharedClientTest.java
@@ -97,7 +97,9 @@ public class OkHttpWrapperSharedClientTest extends RobolectricTestWithConfig {
                 .build();
 
         // :: Act
-        custom.newCall(new Request.Builder().url(server.url("/")).build()).execute();
+        // The body is not the subject here, but an unclosed response leaks the connection and
+        // okhttp then logs the leak against whichever test happens to be running at the next GC.
+        custom.newCall(new Request.Builder().url(server.url("/")).build()).execute().close();
         RecordedRequest recorded = server.takeRequest();
 
         // :: Verify

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/OkHttpWrapperTlsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/OkHttpWrapperTlsTest.java
@@ -1,0 +1,83 @@
+package com.eveningoutpost.dexdrip.utilitymodels;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * TLS contract for the shared okhttp client.
+ * <p>
+ * Every HTTPS caller in xDrip — Nightscout, Dexcom, Tidepool, Desert Sync — derives its client from
+ * {@link OkHttpWrapper#getClient()} with {@code newBuilder()}, which keeps the production
+ * interceptors, timeouts and connection pool. This asserts that such a derived client completes a
+ * handshake and delivers a body, which is the only unit-level exercise of the platform TLS stack.
+ *
+ * @author Asbjørn Aarrestad - 2026.08
+ */
+public class OkHttpWrapperTlsTest extends RobolectricTestWithConfig {
+
+    private HeldCertificate localhostCertificate;
+    private HandshakeCertificates clientCertificates;
+    private MockWebServer server;
+
+    @Before
+    public void setUpHttpsServer() throws IOException {
+        localhostCertificate = new HeldCertificate.Builder()
+                .addSubjectAlternativeName("localhost")
+                .build();
+        HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+                .heldCertificate(localhostCertificate)
+                .build();
+        clientCertificates = new HandshakeCertificates.Builder()
+                .addTrustedCertificate(localhostCertificate.certificate())
+                .build();
+
+        server = new MockWebServer();
+        server.useHttps(serverCertificates.sslSocketFactory(), false);
+        server.start();
+    }
+
+    @After
+    public void tearDownHttpsServer() throws IOException {
+        server.shutdown();
+    }
+
+    /** A client derived from the shared client completes a TLS handshake and delivers the body. */
+    @Test
+    public void derivedClient_completesTlsRoundTrip() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setBody("tls-ok"));
+        OkHttpClient client = OkHttpWrapper.getClient().newBuilder()
+                .sslSocketFactory(clientCertificates.sslSocketFactory(),
+                        clientCertificates.trustManager())
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .build();
+        Request request = new Request.Builder().url(server.url("/api/v1/entries")).build();
+
+        // :: Act
+        Response response = client.newCall(request).execute();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body().string()).isEqualTo("tls-ok");
+        assertThat(response.handshake()).isNotNull();
+        assertThat(response.handshake().peerCertificates())
+                .contains(localhostCertificate.certificate());
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/desertsync/DesertTrustManagerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/desertsync/DesertTrustManagerTest.java
@@ -23,7 +23,7 @@ import okhttp3.tls.HandshakeCertificates;
 import okhttp3.tls.HeldCertificate;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 /**
  * The custom TLS trust and hostname verification behind Desert Sync.
@@ -116,14 +116,10 @@ public class DesertTrustManagerTest extends RobolectricTestWithConfig {
         Request request = new Request.Builder().url(server.url("/joh")).build();
 
         // :: Act
-        try {
-            client.newCall(request).execute();
-            fail("Expected the certificate pin to reject an unpinned peer");
-        } catch (SSLPeerUnverifiedException expected) {
+        assertThrows(SSLPeerUnverifiedException.class, () -> client.newCall(request).execute());
 
-            // :: Verify — the client refused to transmit
-            assertThat(server.getRequestCount()).isEqualTo(0);
-        }
+        // :: Verify — the client refused to transmit
+        assertThat(server.getRequestCount()).isEqualTo(0);
     }
 
     /**

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/desertsync/DesertTrustManagerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/desertsync/DesertTrustManagerTest.java
@@ -33,10 +33,11 @@ import static org.junit.Assert.fail;
  * certificate hash. What is asserted here is that trust accepts the untrusted peer, and that the
  * verifier refuses to let an unpinned peer's response through.
  * <p>
- * Neither branch of the hash comparison itself is reachable from a JVM test, and the third test
- * below says why and keeps that from going unnoticed. The accept branch is unreachable for a second
- * reason as well: it compares against a hardcoded SHA-256 of a certificate whose private key this
- * repository does not hold.
+ * Neither branch of the hash comparison itself is reachable from a JVM test, and the third case
+ * below says why and keeps that from going unnoticed. Serving the pinned certificate would not
+ * open the accept branch either: the repository does ship it, with its key, in
+ * {@code res/raw/localhost_cert.bks}, but the peer chain the verifier reads it back out of cannot
+ * be read at all on this JVM.
  *
  * @author Asbjørn Aarrestad - 2026.08
  */
@@ -74,7 +75,7 @@ public class DesertTrustManagerTest extends RobolectricTestWithConfig {
                 .build();
     }
 
-    // ===== naive trust manager ===================================================================
+    // ===== Naive trust manager ===================================================================
 
     /**
      * The naive trust manager lets a client reach a peer holding an untrusted self-signed cert.
@@ -97,7 +98,7 @@ public class DesertTrustManagerTest extends RobolectricTestWithConfig {
         assertThat(response.body().string()).isEqualTo("desert-ok");
     }
 
-    // ===== certificate pin =======================================================================
+    // ===== Certificate pin =======================================================================
 
     /**
      * The full Desert Sync client shape delivers nothing from a peer the verifier refuses.

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/desertsync/DesertTrustManagerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/desertsync/DesertTrustManagerTest.java
@@ -1,0 +1,165 @@
+package com.eveningoutpost.dexdrip.utilitymodels.desertsync;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.utilitymodels.OkHttpWrapper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * The custom TLS trust and hostname verification behind Desert Sync.
+ * <p>
+ * {@link TrustManager} supplies a deliberately naive trust manager — Desert Sync talks to a peer
+ * with a self-signed certificate — and pairs it with a hostname verifier that pins one specific
+ * certificate hash. What is asserted here is that trust accepts the untrusted peer, and that the
+ * verifier refuses to let an unpinned peer's response through.
+ * <p>
+ * Neither branch of the hash comparison itself is reachable from a JVM test, and the third test
+ * below says why and keeps that from going unnoticed. The accept branch is unreachable for a second
+ * reason as well: it compares against a hardcoded SHA-256 of a certificate whose private key this
+ * repository does not hold.
+ *
+ * @author Asbjørn Aarrestad - 2026.08
+ */
+public class DesertTrustManagerTest extends RobolectricTestWithConfig {
+
+    private MockWebServer server;
+
+    @Before
+    public void setUpSelfSignedServer() throws IOException {
+        HeldCertificate selfSigned = new HeldCertificate.Builder()
+                .addSubjectAlternativeName("localhost")
+                .build();
+        HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+                .heldCertificate(selfSigned)
+                .build();
+
+        server = new MockWebServer();
+        server.useHttps(serverCertificates.sslSocketFactory(), false);
+        server.start();
+    }
+
+    @After
+    public void tearDownSelfSignedServer() throws IOException {
+        server.shutdown();
+    }
+
+    /** The client shape Desert Sync builds: naive trust, and the verifier under examination. */
+    private OkHttpClient desertSyncClient(HostnameVerifier verifier) throws Exception {
+        return OkHttpWrapper.getClient().newBuilder()
+                .sslSocketFactory(TrustManager.getSSLSocketFactory(),
+                        TrustManager.getNaiveTrustManager())
+                .hostnameVerifier(verifier)
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .build();
+    }
+
+    // ===== naive trust manager ===================================================================
+
+    /**
+     * The naive trust manager lets a client reach a peer holding an untrusted self-signed cert.
+     * <p>
+     * Nothing else in the suite exercises a TLS handshake that the default trust manager would
+     * reject outright, so this is the only place the naive manager's whole point is visible.
+     */
+    @Test
+    public void naiveTrustManager_acceptsSelfSignedPeer() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setBody("desert-ok"));
+        OkHttpClient client = desertSyncClient((hostname, session) -> true);
+        Request request = new Request.Builder().url(server.url("/joh")).build();
+
+        // :: Act
+        Response response = client.newCall(request).execute();
+
+        // :: Verify
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body().string()).isEqualTo("desert-ok");
+    }
+
+    // ===== certificate pin =======================================================================
+
+    /**
+     * The full Desert Sync client shape delivers nothing from a peer the verifier refuses.
+     * <p>
+     * The refusal is what is asserted, not its reason — see the next test for why the reason is
+     * currently the unreadable chain rather than a mismatched hash. The okhttp behaviour this pins
+     * is real either way: a verifier returning false must fail the call before any request is
+     * transmitted, and it must fail it with {@link SSLPeerUnverifiedException}.
+     */
+    @Test
+    public void xdripHostVerifier_rejectsUnpinnedPeer() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setBody("must-not-be-delivered"));
+        OkHttpClient client = desertSyncClient(TrustManager.getXdripHostVerifier());
+        Request request = new Request.Builder().url(server.url("/joh")).build();
+
+        // :: Act
+        try {
+            client.newCall(request).execute();
+            fail("Expected the certificate pin to reject an unpinned peer");
+        } catch (SSLPeerUnverifiedException expected) {
+
+            // :: Verify — the client refused to transmit
+            assertThat(server.getRequestCount()).isEqualTo(0);
+        }
+    }
+
+    /**
+     * The peer certificate chain cannot be read on this JVM, so the pin never compares a hash.
+     * <p>
+     * Production reads the chain through {@code SSLSession#getPeerCertificateChain()}, which
+     * returns the legacy {@code javax.security.cert} type. The JDK this suite runs on no longer
+     * ships the implementation behind that type: {@code X509Certificate.getInstance(byte[])} fails
+     * with {@code ClassNotFoundException: com/sun/security/cert/internal/x509/X509V1CertImpl}.
+     * Conscrypt 2.5.2, which Robolectric installs, then masks that as an
+     * {@code IllegalArgumentException: Self-causation not permitted}, because its wrapper passes
+     * the new exception as its own cause.
+     * <p>
+     * The consequence outweighs the cause. Production catches {@code Exception} and returns false,
+     * so the rejection above is green whether the hash was compared or the chain was simply
+     * unavailable. This states that out loud, and turns red the day the chain becomes readable —
+     * which is the day the pin is genuinely under test again.
+     */
+    @Test
+    public void peerCertificateChain_isUnreadableSoTheHashIsNeverCompared() throws Exception {
+        // :: Setup
+        server.enqueue(new MockResponse().setBody("desert-ok"));
+        final AtomicReference<Throwable> chainFailure = new AtomicReference<>();
+        OkHttpClient client = desertSyncClient((hostname, session) -> {
+            try {
+                session.getPeerCertificateChain();
+            } catch (Throwable unreadable) {
+                chainFailure.set(unreadable);
+            }
+            return true;
+        });
+        Request request = new Request.Builder().url(server.url("/joh")).build();
+
+        // :: Act
+        client.newCall(request).execute().close();
+
+        // :: Verify
+        assertThat(chainFailure.get()).isNotNull();
+    }
+}


### PR DESCRIPTION
Behavioural test coverage for the HTTP paths, written ahead of an okhttp 4 → 5 upgrade so that upgrade has something to be measured against.

**No production code changes. No version changes.** Five new test classes, one existing test class extended, and one `testImplementation` dependency (`okhttp-tls`, matching the okhttp version already declared). Nothing here ships in the APK.

### Why separately

`master` has no round-trip coverage of these paths today. It is not that they are untested in every sense — `DesertCommsTest` and `CareLinkClientTest` exist and assert structure, e.g. that a factory returns non-null. What is missing is any test that sends a request and looks at what arrived:

- `OkHttpWrapperTlsTest` — the shared client completes a TLS handshake and a cleartext round trip.
- `OkHttpWrapperSharedClientTest` — extended: what `newBuilder()` derivations inherit, and what they can override. Twenty-two call sites across `:app:` and `:wear:` derive from this one client.
- `DesertTrustManagerTest` — the naive trust manager reaches a self-signed peer; the pinning hostname verifier refuses an unpinned one.
- `EditableCookieJarTest` — CareLink issues its session cookie on one host and is called on another under the same registered domain. That decision goes through okhttp's public suffix database, which okhttp 5 relocates into the Android artifact's assets.
- `WireMessageRoundTripTest` — the phone → watch message format, including unknown-field preservation. okio crosses a major version in the upgrade.
- `NocturneApiClientTest` — the Nocturne SDK driven over the shared client.

### What this does not cover

Every one of these is findable by anyone reading the diff, so they are stated up front rather than left to be discovered.

- **The certificate pin's *accept* path is not asserted.** Not for want of the certificate: `res/raw/localhost_cert.bks` holds it and its key, and its SHA-256 is `TrustManager.CERTIFICATE_PIN` verbatim. Serving it from `MockWebServer` still would not reach the accept branch — see the next point.
- **The pin's hash comparison never runs in these tests at all.** `TrustManager.getXdripHostVerifier()` reads the peer chain through the long-deprecated `SSLSession.getPeerCertificateChain()`, and on a modern JDK that chain cannot be read: the JDK no longer ships the implementation behind `javax.security.cert` (`ClassNotFoundException: com/sun/security/cert/internal/x509/X509V1CertImpl`), and Conscrypt masks it as `IllegalArgumentException: Self-causation not permitted`. Production catches `Exception` and returns false, so the rejection test proves the client refuses to transmit — it does not prove a hash was compared. `peerCertificateChain_isUnreadableSoTheHashIsNeverCompared` says so in the file and goes red the day that changes. This is unrelated to okhttp and unchanged by the upgrade. The pin is presumed live on Android, which still ships those classes; this does not measure that. Related, and also not addressed here: on JDK 21 the same call resolves to `NoClassDefFoundError`, an `Error` that `catch (Exception)` does not catch.
- **The trust tests pin the mechanism, not the wiring.** `DesertComms.getHttpInstance()` is private and statically cached, so the tests reassemble its builder chain by hand. If `.hostnameVerifier(...)` were dropped from production tomorrow, they would still pass.
- **`NocturneApiClientTest` covers client registration over cleartext, not the SGV upload.** The SDK is shown to work on the shared client; the upload path, the device-flow endpoints and the SDK's progress-reporting bodies carry no runtime coverage here.
- **`WireMessageRoundTripTest` encodes and decodes inside `:app:` only.** The real contract is app-encode → wear-decode across two okio majors, and that crossing is not tested.
- **`ShareRest` is not an uncovered custom client** — `getOkHttpClient()` derives from `OkHttpWrapper.getClient().newBuilder()` like the rest. What is untestable is its own wiring: the method is private, the Retrofit base URLs are hardcoded to Dexcom's hosts, and the injectable-client constructor bypasses it. Its hostname verifier returns `true` unconditionally, so unlike Desert Sync there is no pin to test. Adding a production seam for it is out of scope.

### Verification

All green, and the release gate passes:

```
./gradlew :app:testFastDebugUnitTest :wear:testFastDebugUnitTest
./gradlew assembleProdRelease testProdReleaseUnitTest
bash ./etc/CheckBuild/check-release.sh test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPhzyz5ToRGSBC9pECwqZu
