### PR TITLE
Make snooze alert texts translatable

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
@@ -1,6 +1,6 @@
 package com.eveningoutpost.dexdrip;
 
-import java.text.MessageFormat;
+import java.text.DateFormat;
 import java.util.Date;
 
 import android.app.Dialog;
@@ -118,9 +118,9 @@ public class SnoozeActivity extends ActivityWithMenu {
 
     static String getNameFromTime(int time) {
         if (time < 120) {
-            return time + " minutes";
+            return time + " " + gs(R.string.unit_minutes);
         }
-        return (time / 60.0) + " hours";
+        return (time / 60.0) + " " + gs(R.string.unit_hours);
     }
 
     static int getTimeFromSnoozeValue(int pickedNumber) {
@@ -374,8 +374,10 @@ public class SnoozeActivity extends ActivityWithMenu {
         } else {
             sendRemoteSnooze.setVisibility(View.GONE);
             if(!aba.ready_to_alarm()) {
-                status = MessageFormat.format("Active alert exists named \"{0}\" {1,choice,0#Alert will rerise at|1#Alert snoozed until} {2,time} ({3} minutes left)",
-                        activeBgAlert.name, aba.is_snoozed ? 1 : 0 , new Date(aba.next_alert_at),(aba.next_alert_at - now) / 60000);
+                status = getString(aba.is_snoozed ? R.string.active_alert_snoozed_until : R.string.active_alert_rerise_at,
+                        activeBgAlert.name,
+                        DateFormat.getTimeInstance().format(new Date(aba.next_alert_at)),
+                        String.valueOf((aba.next_alert_at - now) / 60000));
             } else {
                 status = getString(R.string.active_alert_exists_named)+" \"" + activeBgAlert.name + "\" "+getString(R.string.bracket_not_snoozed);
             }
@@ -384,24 +386,29 @@ public class SnoozeActivity extends ActivityWithMenu {
 
         //check if there are disabled alerts and if yes add warning
         if (prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0) > now) {
-            String textToAdd = MessageFormat.format("{0,choice,0#{1,time}|1#you re-enable}",
-                    (prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0) > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000) ? 1 : 0 , new Date(prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0)));
-            status = getString(R.string.all_alerts_disabled_until) + textToAdd;
+            status = getString(R.string.all_alerts_disabled_until) + disabledUntilText(prefs.getLong(SnoozeType.ALL_ALERTS.getPrefKey(), 0), now);
         } else {
             if (prefs.getLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0) > now) {
-                String textToAdd = MessageFormat.format("{0,choice,0#{1,time}|1#you re-enable}",
-                        (prefs.getLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0) > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000) ? 1 : 0 , new Date(prefs.getLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0)));
-                status += "\n\n"+getString(R.string.low_alerts_disabled_until) + textToAdd;
+                status += "\n\n"+getString(R.string.low_alerts_disabled_until) + disabledUntilText(prefs.getLong(SnoozeType.LOW_ALERTS.getPrefKey(), 0), now);
             }
             if (prefs.getLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0) > now) {
-                String textToAdd = MessageFormat.format("{0,choice,0#{1,time}|1#you re-enable}",
-                        (prefs.getLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0) > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000) ? 1 : 0 , new Date(prefs.getLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0)));
-                status += "\n\n"+getString(R.string.high_alerts_disabled_until) + textToAdd;
+                status += "\n\n"+getString(R.string.high_alerts_disabled_until) + disabledUntilText(prefs.getLong(SnoozeType.HIGH_ALERTS.getPrefKey(), 0), now);
             }
         }
 
         alertStatus.setText(status);
 
+    }
+
+    /**
+     * Returns the text shown after "... disabled until ": either the localized
+     * "you re-enable" when alerts are disabled forever, or the time they get re-enabled.
+     */
+    private String disabledUntilText(long disabledUntil, long now) {
+        //if alerts were disabled "until you re-enable", and this test is done less than 365 * 24 * 60 minutes later, then this test will give true
+        return (disabledUntil > now + (infiniteSnoozeValueInMinutes - 365 * 24 * 60) * 60 * 1000)
+                ? getString(R.string.you_reenable)
+                : DateFormat.getTimeInstance().format(new Date(disabledUntil));
     }
 
     public void setSendRemoteSnoozeOnClick(View v) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -382,6 +382,9 @@
     <string name="all_alerts_disabled_until">"All alerts disabled until "</string>
     <string name="low_alerts_disabled_until">"Low alerts disabled until "</string>
     <string name="high_alerts_disabled_until">"High alerts disabled until "</string>
+    <string name="you_reenable">you re-enable</string>
+    <string name="active_alert_rerise_at">Active alert exists named \"%1$s\" Alert will rerise at %2$s (%3$s minutes left)</string>
+    <string name="active_alert_snoozed_until">Active alert exists named \"%1$s\" Alert snoozed until %2$s (%3$s minutes left)</string>
     <string name="default_snooze">Default Snooze</string>
     <string name="until_you_reenable">Until you re-enable</string>
     <string name="set">Set</string>


### PR DESCRIPTION
Some texts on the Snooze screen were hardcoded in English and could not be translated:

- The snooze time picker values ("30 minutes", "2.0 hours")
- The status line "Active alert exists named ... (X minutes left)"
- The "you re-enable" part of "All/Low/High alerts disabled until ..."

This PR moves them to string resources:

- The picker reuses the existing `unit_minutes` / `unit_hours` strings, so it is translated right away in all languages.
- The active alert status line becomes two format strings with placeholders (snoozed / will rerise).
- "you re-enable" becomes a new string, and the three duplicated `MessageFormat` blocks are replaced by one small helper method.

No visible change in English. Time formatting is unchanged (`DateFormat.getTimeInstance()` gives the same format as `{n,time}` did).

**Tested:** built and ran the app with temporary Norwegian translations of the new strings. All three places show the translated texts as expected. 

Note: `wear/.../SnoozeActivity.java` has the same hardcoded texts, but this PR stays phone-only on purpose. The wear module currently ships no translations and is not part of `crowdin.yml`, so moving its texts to string resources would not change anything for users. If the wear module is added to Crowdin at some point (a maintainer decision), I can do the same fix for wear in a follow-up PR. See discussion below.

**Some screenshots when xDrip is using Norwegian display language**

| Before | After |
|--------|--------|
| <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/aea4e86b-659e-434c-af94-b01f58906b4b" /> | <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/1db0a709-d04b-4071-a149-bf4db3e3840d" /> |
| <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/5b405782-18e9-48ac-a4b3-57ddae44292e" /> | <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/0dd4c24e-9592-4ca6-9f2e-c002a950cd9d" /> |
| <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/ed949e85-ef8e-4767-a7fe-f4211d77a6b7" /> | <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/07d98ce6-41f9-4016-a7ee-97e5cc47b430" /> |