### PR TITLE
Invalid treatment time

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/PhoneKeypadInputActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/PhoneKeypadInputActivity.java
@@ -2,6 +2,7 @@ package com.eveningoutpost.dexdrip;
 
 import static com.eveningoutpost.dexdrip.Home.startHomeWithExtra;
 
+import android.app.AlertDialog;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
@@ -377,7 +378,11 @@ public class PhoneKeypadInputActivity extends BaseActivity {
         }
 
         if (isInvalidTime()) {
-            Log.d(TAG, "Time value is invalid - not processing button click");
+            new AlertDialog.Builder(this)
+                    .setTitle("Invalid time")
+                    .setMessage("Please enter a valid time or clear the time tab.")
+                    .setPositiveButton(android.R.string.ok, null)
+                    .show();
             return;
         }
 
@@ -518,18 +523,15 @@ public class PhoneKeypadInputActivity extends BaseActivity {
         }
         String value = getValue(currenttab);
         mDialTextView.setText(value + append);
-        // show green tick
-        boolean showSubmitButton;
+        // show green tick if any treatment tab has data
+        boolean showSubmitButton = isNonzeroValueInTab("bloodtest")
+                || isNonzeroValueInTab("carbs")
+                || isNonzeroValueInTab("insulin-1")
+                || isNonzeroValueInTab("insulin-2")
+                || isNonzeroValueInTab("insulin-3");
 
-        if (isInvalidTime())
-            showSubmitButton = false;
-
-        else if (currenttab.equals("time"))
-            showSubmitButton = value.length() > 0 && ( isNonzeroValueInTab("bloodtest") || isNonzeroValueInTab("carbs") || isNonzeroValueInTab("insulin-1") || isNonzeroValueInTab("insulin-2") || isNonzeroValueInTab("insulin-3"));
-        else
-            showSubmitButton = isNonzeroValueInTab(currenttab);
-
-        mDialTextView.getBackground().setAlpha(showSubmitButton ? 255 : 0);    }
+        mDialTextView.getBackground().setAlpha(showSubmitButton ? 255 : 0);
+    }
 
 
     @Override


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/4640  

Recreate the problem:
Go to the treatment menu.  Enter an insulin value.  You will see a green checkmark for submission.  
Now, go to the time tab and enter just 1.  This is an invalid time value.  Go back to the insulin tab.  You will see that the green checkmark has disappeared.  

This PR shows the green checkmark as long as there is something (insulin, carbs or glucose) to submit even if the time value is invalid.
Tapping on it with an invalid time will bring up a dialog:

<img width="280" height="624" alt="Screenshot_20260824-164835" src="https://github.com/user-attachments/assets/8174c4e8-8ff4-407b-be6a-73f91ae56ae4" />
