### PR TITLE
fix: carelink not working for medtronic go users

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthenticator.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthenticator.java
@@ -75,7 +75,7 @@ public class CareLinkAuthenticator {
 
     private static final String TAG = "CareLinkAuthenticator";
 
-    protected static final String CAREPARTNER_APP_DISCO_URL = "https://clcloud.minimed.eu/connect/carepartner/v13/discover/android/3.6";
+    protected static final String CAREPARTNER_APP_DISCO_URL = "https://clcloud.minimed.eu/connect/carepartner/v13/discover/android/3.8";
     protected static final String CARELINK_CONNECT_SERVER_EU = "carelink.minimed.eu";
     protected static final String CARELINK_CONNECT_SERVER_US = "carelink.minimed.com";
     protected static final String CARELINK_LANGUAGE_EN = "en";

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClient.java
@@ -661,7 +661,7 @@ public class CareLinkClient {
         if(!JoH.emptyString(patientUsername))
             userJson.addProperty("patientId", patientUsername);
         if(useNewEndpoint){
-            userJson.addProperty("appVersion", "3.6.0");
+            userJson.addProperty("appVersion", "3.8.0");
         }
 
         gson = new GsonBuilder().create();

--- a/app/src/test/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClientCallerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/client/CareLinkClientCallerTest.java
@@ -159,7 +159,7 @@ public class CareLinkClientCallerTest extends RobolectricTestWithConfig {
         assertThat(body).contains("\"username\":\"testuser\"");
         assertThat(body).contains("\"role\":\"patient\"");
         assertThat(body).contains("\"patientId\":\"patient123\"");
-        assertThat(body).contains("\"appVersion\":\"3.6.0\"");
+        assertThat(body).contains("\"appVersion\":\"3.8.0\"");
         assertThat(request.getPath()).contains(CareLinkClient.API_PATH_DISPLAY_MESSAGE);
         assertThat(result).isNotNull();
     }


### PR DESCRIPTION
This PR updates the advertised app version from `3.6.0` to `3.8.0` for the Medtronic CareLink Follower, which fixes Medtronic Go users not being able to retrieve their data (see #4547)

This has been tested with a Medtronic 780G + Guardian 4 user and Medtronic InPen + Simplera user.

Note: This PR does not add the `os` field to the request. Manual testing showed no improvement while changing both the version and adding the field but after remove the field again (and keeping the new version) bg data was successfully retrieved.