### PR TITLE
OB1: fix false "lost bonding" skip with Special Pairing Workaround (fixes #4706)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -365,9 +365,10 @@ public class Ob1G5CollectionService extends G5BaseService {
                         break;
                     case CONNECT_NOW:
                         if (specialPairingWorkaround()) {
+                            tryLoadingSavedMAC(); // transmitterMAC is cleared on every service start and an unknown MAC would read as not bonded
                             val locallyBonded = isDeviceLocallyBonded();
                             UserError.Log.d(TAG, "wasbonded = " + wasBonded + " local: " + locallyBonded);
-                            if (wasBonded.equals(getTransmitterID()) && !locallyBonded && skippedConnects < 10) {
+                            if (wasBonded.equals(getTransmitterID()) && transmitterMAC != null && !locallyBonded && skippedConnects < 10) {
                                 skippedConnects++;
                                 UserError.Log.wtf(TAG, "Appears to have lost bonding, skipping this connect! @ " + skippedConnects);
                                 changeState(CLOSE);


### PR DESCRIPTION
Fixes #4706

## Problem

Since commit 7213241f4 ("OB1: add mac caching fix"), users with **Special Pairing Workaround** enabled get bursts of false `Appears to have lost bonding, skipping this connect! @ 1 ... @ 10` and lose readings, even though the bonding is fine. Full root cause analysis is in #4706. 

Short version: `transmitterMAC` is now cleared on every service start, and `isDeviceLocallyBonded()` treats an unknown MAC as "not bonded". When the service restarts while the state machine is in `CONNECT_NOW`, the lost-bonding guard fires with no MAC to check against, and connects are skipped.

## Fix

Two small changes inside the `specialPairingWorkaround()` branch of `CONNECT_NOW`:

1. Call `tryLoadingSavedMAC()` before the bonding check, so the cached MAC is restored first. This is the same call the normal `SCAN` path already makes every cycle (via `useMinimizeScanningStrategy()`), and it is cheap — it returns early when the MAC is already set.
2. Add `transmitterMAC != null` to the skip condition. If no saved MAC exists, the  bonding state is unknown, and connecting (the behavior before 7213241f4) is the safe default instead of refusing to connect.

The guard keeps its real purpose: with a known MAC and the device missing from the bonded device list, it still skips as designed. The purpose of 7213241f4 is also kept: `tryLoadingSavedMAC()` only loads the MAC stored for the *current* transmitter ID, so a stale MAC from a previous transmitter cannot leak back in.

Users without the Special Pairing Workaround setting never run this code path and are not affected by this change.

## Testing (and its limits — please read)

Tested on a Samsung Galaxy Z Flip5 (Android 16, Dexcom G7, Special Pairing Workaround enabled):

- **Without the fix (master):** false skip bursts are reproducible by restarting the collector while it is scanning/connecting, and sometimes appear on their own after a missed reading. Log in #4706.
- **With the fix:** the same procedures did not produce any false skips during a few hours of testing.
- **The guard still works:** after manually removing the BT pairing ("Unbonded mac" in the log), the fix build correctly detected the genuinely lost bonding and skipped connects. So the check still protects against the real Samsung lost-pairing case it was written for.

I have to be honest about the limits: I could only run the fix for a few hours, because the sensor had to move to my son's live rig (now on 2026.06.17 where the bug does not exist), and I have no other test equipment. The change is two lines, scoped to the workaround path, and restores pre-regression behavior — but longer real-world testing by other affected Samsung users, or a review by @jamorham against the intent of 7213241f4, would be very welcome before merging.