### PR TITLE
build: upgrade okhttp 4.12.0 to 5.3.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -303,11 +303,13 @@ dependencies {
     implementation "com.google.android.gms:play-services-oss-licenses:15.0.0"
     implementation "com.google.protobuf:protobuf-java:4.34.0"
     implementation 'com.squareup.wire:wire-runtime:2.2.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
-    // Nocturne SDK: targets OkHttp 4.12, matching xDrip's pinned version. We exclude
-    // its gson transitive to keep xDrip's own pinned gson. Jackson is only a
-    // transitive of jackson-databind-nullable and unused at runtime on the gson path.
+    implementation 'com.squareup.okhttp3:okhttp:5.3.2'
+    implementation 'com.squareup.okhttp3:logging-interceptor:5.3.2'
+    // Nocturne SDK: declares OkHttp 4.12, so it resolves up to the 5.x pinned above rather than
+    // matching it. Covered by NocturneApiClientTest / NocturneUploaderAuthTest, which drive the
+    // real (Context) constructor over MockWebServer. We exclude its gson transitive to keep
+    // xDrip's own pinned gson. Jackson is only a transitive of jackson-databind-nullable and
+    // unused at runtime on the gson path.
     implementation('org.nightscoutfoundation:nocturne-java:0.2.4') {
         exclude group: 'com.google.code.gson'
         exclude group: 'com.fasterxml.jackson.core'
@@ -375,8 +377,8 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation "org.robolectric:robolectric:4.16"
     testImplementation "com.google.truth:truth:1.4.5"
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
-    testImplementation 'com.squareup.okhttp3:okhttp-tls:4.12.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:5.3.2'
+    testImplementation 'com.squareup.okhttp3:okhttp-tls:5.3.2'
 
     testImplementation 'org.mockito:mockito-inline:2.13.0'
     testImplementation 'org.mockito:mockito-core:4.11.0'

--- a/app/src/test/java/com/eveningoutpost/dexdrip/RobolectricTestWithConfig.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/RobolectricTestWithConfig.java
@@ -2,6 +2,8 @@ package com.eveningoutpost.dexdrip;
 
 import android.util.Log;
 
+import okhttp3.OkHttp;
+
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -28,6 +30,11 @@ public abstract class RobolectricTestWithConfig {
     public void setUp() {
         // The next line can be used to output all logs from test-run to System.out
         // ShadowLog.stream = System.out;
+
+        // okhttp 5 reads its public suffix list from the AAR's assets through the Context that
+        // PlatformInitializer supplies at process start. androidx.startup does not run under
+        // Robolectric, so supply it here — before anything reads the list, since the failure is cached.
+        OkHttp.INSTANCE.initialize(RuntimeEnvironment.getApplication());
 
         xdrip.checkAppContext(RuntimeEnvironment.application);
     }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/desertsync/DesertTrustManagerTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/desertsync/DesertTrustManagerTest.java
@@ -106,7 +106,15 @@ public class DesertTrustManagerTest extends RobolectricTestWithConfig {
      * The refusal is what is asserted, not its reason — see the next test for why the reason is
      * currently the unreadable chain rather than a mismatched hash. The okhttp behaviour this pins
      * is real either way: a verifier returning false must fail the call before any request is
-     * transmitted, and it must fail it with {@link SSLPeerUnverifiedException}.
+     * transmitted, and {@link SSLPeerUnverifiedException} must be what refused it.
+     * <p>
+     * That exception is looked for through the suppressed list rather than as the thrown type,
+     * because {@code localhost} resolves to both {@code 127.0.0.1} and {@code [::1]} and okhttp 5
+     * races them. Its fast-fallback finder keeps the first failure to complete, attaches every later
+     * one with {@code addSuppressed}, and throws the first. The verifier only refuses after a full
+     * handshake, while the route MockWebServer is not listening on is refused outright — so
+     * {@code ConnectException: Connection refused} normally wins and the real refusal ends up
+     * suppressed. Asserting the thrown type directly would be asserting which route won a race.
      */
     @Test
     public void xdripHostVerifier_rejectsUnpinnedPeer() throws Exception {
@@ -116,10 +124,32 @@ public class DesertTrustManagerTest extends RobolectricTestWithConfig {
         Request request = new Request.Builder().url(server.url("/joh")).build();
 
         // :: Act
-        assertThrows(SSLPeerUnverifiedException.class, () -> client.newCall(request).execute());
+        IOException refusal = assertThrows(IOException.class, () -> client.newCall(request).execute());
 
-        // :: Verify — the client refused to transmit
+        // :: Verify — the verifier refused it, and the client transmitted nothing
+        assertThat(unverifiedPeerWithin(refusal)).isNotNull();
         assertThat(server.getRequestCount()).isEqualTo(0);
+    }
+
+    /**
+     * The {@link SSLPeerUnverifiedException} anywhere in {@code failure}: itself, its causes, or
+     * anything suppressed onto it or onto those. Null when the call failed for some other reason,
+     * which is the case this test needs to stay able to fail on.
+     */
+    private static SSLPeerUnverifiedException unverifiedPeerWithin(Throwable failure) {
+        if (failure == null) {
+            return null;
+        }
+        if (failure instanceof SSLPeerUnverifiedException) {
+            return (SSLPeerUnverifiedException) failure;
+        }
+        for (Throwable suppressed : failure.getSuppressed()) {
+            SSLPeerUnverifiedException found = unverifiedPeerWithin(suppressed);
+            if (found != null) {
+                return found;
+            }
+        }
+        return failure.getCause() == failure ? null : unverifiedPeerWithin(failure.getCause());
     }
 
     /**


### PR DESCRIPTION
Second of three. #4699 was the preparation; this is the bump.

Four version lines in `app/build.gradle` (`okhttp`, `logging-interceptor`, `mockwebserver`, `okhttp-tls`), 4.12.0 to 5.3.2. No production source changes. Two test files needed work.

It stops at 5.3.2 because `okhttp-android:5.4.0` declares `minCompileSdk=36` and xDrip is on `compileSdk 34`. Raising that is the third PR.

## Fast fallback changes which exception surfaces

okhttp 5 defaults `fastFallback` to true. Every client derives from the singleton in `OkHttpWrapper` without overriding it, so dual-stack hosts now have their IPv4 and IPv6 routes raced instead of tried in order.

`FastFallbackExchangeFinder.find()` keeps the first failure to *complete*, attaches the rest with `addSuppressed`, and throws the first. Which route completes first is a race.

This broke the Desert Sync pinning test. `localhost` is dual-stack; MockWebServer listens on one route, and the verifier rejects the peer there only after a full handshake. The other route is refused outright, so `ConnectException` completes first and the real refusal ends up suppressed. The test now searches the chain (self, cause, suppressed) for `SSLPeerUnverifiedException`, and still asserts nothing was transmitted. Set the verifier to accept everything and it goes red.

Every `catch (IOException)` behaves as before. Both exceptions are `IOException`, and no production code catches either by name or matches on a message. Two places test the concrete type inside such a catch:

- `UpdateActivity.java:469` checks `instanceof SSLHandshakeException` to fall back to the system browser for the APK download. If the other route's connect failure completes first, that fallback stops firing and the download just fails. Update-check UI only.
- `ResponseGetterImpl.java:89` checks `instanceof SocketTimeoutException` to retry in the web follower. Read timeouts are thrown directly off an established connection, so the common case is unaffected. Only a connect-phase timeout could be masked.

Neither is touched here. Re-shaping them is a separate change.

## Public suffix list needs a Context

okhttp 5 reads its public suffix list from the AAR's assets, through a `Context` that `androidx.startup`'s `InitializationProvider` hands to `PlatformInitializer` at process start. That provider is in the merged manifest after the bump, so devices need no change.

Robolectric does not run it. Any test parsing a cookie whose `Domain` crosses a registered-domain boundary failed with `IllegalStateException: Unable to load PublicSuffixDatabase.list resource`. The failure is cached per sandbox, one per test class, so `OkHttp.INSTANCE.initialize(...)` runs at the top of the shared `@Before` in `RobolectricTestWithConfig`.

## Nocturne resolves above its declared okhttp

`nocturne-java:0.2.4`'s POM declares `okhttp:4.12.0`; Gradle resolves it up to 5.3.2, so the SDK runs against a major it was not built for. `NocturneApiClientTest` and `NocturneUploaderAuthTest` cover that path, both driving the real `(Context)` constructor over MockWebServer. The comment above the dependency claimed the SDK matched xDrip's pin; corrected.

## What else the bump pulls in

okhttp 5 publishes an Android artifact, so `okhttp:5.3.2` resolves to the `okhttp-android` AAR rather than a jar. With it:

- `androidx.startup:startup-runtime:1.2.0`, already pulled in by `androidx.work:work-runtime:2.9.1`. The `InitializationProvider` was in the merged manifest before this PR; okhttp adds a `meta-data` entry to it.
- `assets/PublicSuffixDatabase.list`, a baseline profile, and consumer ProGuard rules that are only `-dontwarn`. `app/proguard-rules.pro` already has broader `-dontwarn okhttp3.**`.
- okio 3.6.0 to 3.16.4.

No new permissions. One okhttp and one okio on the resolved classpath: `nocturne-java`'s 4.12.0 and `logging-interceptor`'s transitive both bump up cleanly. The `wear` module has no okhttp references.

`compileSdk` stays at 34 and must not go lower, since `startup-runtime:1.2.0` declares `minCompileSdk=34`. `minSdk` and `targetSdk` untouched.

## Verification

Unit suites all green:

```
./gradlew :app:testFastDebugUnitTest :wear:testFastDebugUnitTest
```

On-device smoke test against a local Nightscout endpoint, Android 14 emulator, cleartext and TLS: HTTP 200 on both, TLS 1.3 on the https side, no `PublicSuffixDatabase.list` error.
