### PR TITLE
Remove the disabled Parakeet battery check and the dead GCM location sender

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmActivity.java
@@ -392,12 +392,6 @@ public class GcmActivity extends FauxActivity {
         }
     }
 
-    static void sendLocation(final String location) {
-        if (JoH.pratelimit("gcm-plu", 180)) {
-            GcmActivity.sendMessage("plu", location);
-        }
-    }
-
     public static void sendSensorBattery(final int battery) {
         if (JoH.pratelimit("gcm-sbu", 3600)) {
             GcmActivity.sendMessage("sbu", Integer.toString(battery));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/GcmListenerSvc.java
@@ -371,7 +371,6 @@ public class GcmListenerSvc extends JamListenerSvc {
                     if (Home.get_follower()) {
                         Log.i(TAG, "Received parakeet battery level update");
                         Pref.setInt("parakeet_battery", Integer.parseInt(payload));
-                        CheckBridgeBattery.checkParakeetBattery();
                     }
                 } else if (action.equals("psu")) {
                     if (Home.get_follower()) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/WixelReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/WixelReader.java
@@ -18,7 +18,6 @@ import com.eveningoutpost.dexdrip.utilitymodels.BgGraphBuilder;
 import com.eveningoutpost.dexdrip.utilitymodels.MockDataSource;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.utilitymodels.StatusItem;
-import com.eveningoutpost.dexdrip.utils.CheckBridgeBattery;
 import com.eveningoutpost.dexdrip.utils.DexCollectionType;
 import com.eveningoutpost.dexdrip.utils.Mdns;
 import com.google.gson.Gson;
@@ -595,7 +594,6 @@ public class WixelReader extends AsyncTask<String, Void, Void> {
 
                 if (LastReading.UploaderBatteryLife > 0) {
                     Pref.setInt("parakeet_battery", LastReading.UploaderBatteryLife);
-                    CheckBridgeBattery.checkParakeetBattery();
                     if (Home.get_master()) {
                         GcmActivity.sendParakeetBattery(LastReading.UploaderBatteryLife);
                     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBattery.java
@@ -6,10 +6,7 @@ import android.content.Intent;
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.UserError;
-import com.eveningoutpost.dexdrip.R;
-import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels;
-import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
 import com.eveningoutpost.dexdrip.utilitymodels.Pref;
 import com.eveningoutpost.dexdrip.xdrip;
 
@@ -24,17 +21,11 @@ public class CheckBridgeBattery {
 
     private static final String TAG = CheckBridgeBattery.class.getSimpleName();
     private static final String PREFS_ITEM = "bridge_battery";
-    private static final String PARAKEET_PREFS_ITEM = "parakeet_battery";
-    private static final String LAST_PARAKEET_PREFS_ITEM = "last-parakeet-battery";
     private static final int NOTIFICATION_ITEM = 541;
-    private static final int PARAKEET_NOTIFICATION_ITEM = 542;
     private static final int repeat_seconds = 1200;
     private static final boolean d = false;
     private static int last_level = -1;
-    private static int last_parakeet_level = -1;
-    private static long last_parakeet_notification = -1;
     private static boolean notification_showing = false;
-    private static boolean parakeet_notification_showing = false;
     private static int threshold = 20;
 
 
@@ -106,42 +97,6 @@ public class CheckBridgeBattery {
         }
         return lowbattery;
     }
-
-    public static void checkParakeetBattery() {
-
-        if (!Pref.getBooleanDefaultFalse("bridge_battery_alerts")) return;
-
-        threshold = Pref.getStringToInt("bridge_battery_alert_level", 30);
-
-        final int this_level = Pref.getInt(PARAKEET_PREFS_ITEM, -1);
-        if (last_parakeet_level == -1) {
-            last_parakeet_level = (int) PersistentStore.getLong(LAST_PARAKEET_PREFS_ITEM);
-        }
-
-        if (d) UserError.Log.e(TAG, "checkParakeetBattery threshold:" + threshold + " this_level:" + this_level + " last:" + last_parakeet_level);
-        if ((this_level > 0) && (threshold > 0)) {
-            if ((this_level < threshold) && (this_level < last_parakeet_level)) {
-                if (JoH.pratelimit("parakeet-battery-warning", repeat_seconds)) {
-                    parakeet_notification_showing = true;
-                    final PendingIntent pendingIntent = android.app.PendingIntent.getActivity(xdrip.getAppContext(), 0, new Intent(xdrip.getAppContext(), Home.class), android.app.PendingIntent.FLAG_UPDATE_CURRENT);
-                    cancelNotification(PARAKEET_NOTIFICATION_ITEM);
-                    showNotification(xdrip.getAppContext().getString(R.string.low_parakeet_battery), "Parakeet battery dropped to: " + this_level + "%",
-                            pendingIntent, PARAKEET_NOTIFICATION_ITEM, NotificationChannels.LOW_BRIDGE_BATTERY_CHANNEL, true, true, null, null, null);
-                    UserError.Log.uel(TAG, "Parakeet battery dropped to: " + this_level + "%");
-                    last_parakeet_notification = JoH.tsl();
-                    if (d) UserError.Log.e(TAG, "checkParakeetBattery RAISED ALERT threshold:" + threshold + " this_level:" + this_level + " last:" + last_parakeet_level);
-                }
-            } else {
-                if ((parakeet_notification_showing) && (JoH.msSince(last_parakeet_level) > Constants.MINUTE_IN_MS * 25)) {
-                    cancelNotification(PARAKEET_NOTIFICATION_ITEM);
-                    parakeet_notification_showing = false;
-                }
-            }
-            last_parakeet_level = this_level;
-            PersistentStore.setLong(LAST_PARAKEET_PREFS_ITEM, this_level);
-        }
-    }
-
 
     public static void testHarness() {
         if (Pref.getInt(PREFS_ITEM, -1) < 1)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBattery.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBattery.java
@@ -23,7 +23,6 @@ public class CheckBridgeBattery {
     private static final String PREFS_ITEM = "bridge_battery";
     private static final int NOTIFICATION_ITEM = 541;
     private static final int repeat_seconds = 1200;
-    private static final boolean d = false;
     private static int last_level = -1;
     private static boolean notification_showing = false;
     private static int threshold = 20;

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrationsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrationsTest.java
@@ -8,6 +8,7 @@ import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
 
 public class IdempotentMigrationsTest extends RobolectricTestWithConfig {
 
@@ -57,6 +58,29 @@ public class IdempotentMigrationsTest extends RobolectricTestWithConfig {
         assertWithMessage("set new 5").that(Pref.isPreferenceSet(newPref)).isTrue();
         assertWithMessage("as expected 3").that(Pref.getString(newPref, "error")).isEqualTo("no_calibration");
 
+    }
+
+    // ===== legacySettingsFix ============================================================================================
+
+    /**
+     * The migration must keep forcing bridge battery alerts off. The preference is not
+     * Parakeet-specific — it also gates the alerts for every other bridge — so removing that line
+     * along with the Parakeet ones would switch low battery alerts back on for every user.
+     */
+    @Test
+    public void performAllForcesBridgeBatteryAlertsOff() {
+        // :: Setup
+        Pref.setBoolean("bridge_battery_alerts", true);
+        Pref.setString("bridge_battery_alert_level", "5");
+
+        // :: Act
+        new IdempotentMigrations(RuntimeEnvironment.getApplication().getApplicationContext()).performAll();
+
+        // :: Verify
+        assertWithMessage("bridge battery alerts stay forced off")
+                .that(Pref.getBooleanDefaultFalse("bridge_battery_alerts")).isFalse();
+        assertWithMessage("the alert level stays pinned to its migrated default")
+                .that(Pref.getString("bridge_battery_alert_level", "")).isEqualTo("30");
     }
 
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrationsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/IdempotentMigrationsTest.java
@@ -2,6 +2,8 @@ package com.eveningoutpost.dexdrip.utilitymodels;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import android.content.SharedPreferences;
+
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 
 
@@ -10,24 +12,61 @@ import org.junit.Before;
 import org.junit.Test;
 import org.robolectric.RuntimeEnvironment;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
 public class IdempotentMigrationsTest extends RobolectricTestWithConfig {
 
     private static final String oldPref = "calibrate_external_libre_2_algorithm";
     private static final String newPref = "calibrate_external_libre_2_algorithm_type";
 
+    private Map<String, ?> preferencesBefore;
+
     @Before
     public void before() {
+        preferencesBefore = new HashMap<>(Pref.getInstance().getAll());
         cleanup();
     }
 
     @After
     public void after() {
-        cleanup();
+        restorePreferences();
     }
 
     private void cleanup() {
         Pref.removeItem(oldPref);
         Pref.removeItem(newPref);
+    }
+
+    /**
+     * performAll() writes around three dozen preferences that have nothing to do with what is
+     * asserted here, and the whole module shares one preference store for the lifetime of the JVM,
+     * so anything left behind is visible to every later test class. This puts the store back
+     * exactly as it was found. The two AlertType rows performAll() inserts are not undone.
+     */
+    private void restorePreferences() {
+        final SharedPreferences.Editor editor = Pref.getInstance().edit();
+        for (final String key : new HashSet<>(Pref.getInstance().getAll().keySet())) {
+            if (!preferencesBefore.containsKey(key)) {
+                editor.remove(key);
+            }
+        }
+        for (final Map.Entry<String, ?> entry : preferencesBefore.entrySet()) {
+            final Object value = entry.getValue();
+            if (value instanceof Boolean) {
+                editor.putBoolean(entry.getKey(), (Boolean) value);
+            } else if (value instanceof String) {
+                editor.putString(entry.getKey(), (String) value);
+            } else if (value instanceof Integer) {
+                editor.putInt(entry.getKey(), (Integer) value);
+            } else if (value instanceof Long) {
+                editor.putLong(entry.getKey(), (Long) value);
+            } else if (value instanceof Float) {
+                editor.putFloat(entry.getKey(), (Float) value);
+            }
+        }
+        editor.commit();
     }
 
     @Test

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
@@ -25,4 +25,36 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
         assertWithMessage("got builder by reflection 2").that(mNotification.getClass()).isEqualTo(Notification.class);
         assertWithMessage("got builder by reflection 3").that(mNotification.vibrate).isEqualTo(pattern);
     }
+
+    // ===== channel name map =============================================================================================
+
+    /**
+     * Every channel that still has a name-map entry resolves to a display name rather than falling
+     * back to its raw channel id.
+     */
+    @Test
+    public void mappedChannelsResolveToDisplayNames() {
+        // :: Setup
+        val mappedChannels = new String[]{
+                NotificationChannels.LOW_BRIDGE_BATTERY_CHANNEL,
+                NotificationChannels.LOW_TRANSMITTER_BATTERY_CHANNEL,
+                NotificationChannels.NIGHTSCOUT_UPLOADER_CHANNEL,
+                NotificationChannels.REMINDER_CHANNEL,
+                NotificationChannels.BG_ALERT_CHANNEL,
+                NotificationChannels.BG_MISSED_ALERT_CHANNEL,
+                NotificationChannels.BG_RISE_DROP_CHANNEL,
+                NotificationChannels.BG_PREDICTED_LOW_CHANNEL,
+                NotificationChannels.BG_PERSISTENT_HIGH_CHANNEL,
+                NotificationChannels.CALIBRATION_CHANNEL,
+                NotificationChannels.ONGOING_CHANNEL,
+        };
+
+        // :: Act & Verify
+        for (val channel : mappedChannels) {
+            val name = NotificationChannels.getString(channel);
+            assertWithMessage("channel " + channel + " has a display name").that(name).isNotEmpty();
+            assertWithMessage("channel " + channel + " is not displayed as its raw id")
+                    .that(name).isNotEqualTo(channel);
+        }
+    }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
@@ -29,8 +29,9 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
     // ===== channel name map =============================================================================================
 
     /**
-     * Every channel that still has a name-map entry resolves to a display name rather than falling
-     * back to its raw channel id.
+     * Each of these channels resolves to a display name rather than falling back to its raw channel
+     * id. {@code PARAKEET_STATUS_CHANNEL} is deliberately left out although it is currently mapped:
+     * it is removed later in this series, and listing it here would make this test fail that change.
      */
     @Test
     public void mappedChannelsResolveToDisplayNames() {

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBatteryTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBatteryTest.java
@@ -1,0 +1,102 @@
+package com.eveningoutpost.dexdrip.utils;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.utilitymodels.Pref;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Pins the bridge battery alerting behaviour that must survive the removal of the Parakeet
+ * battery check from {@link CheckBridgeBattery}.
+ *
+ * @author Asbjørn Aarrestad - 2026.08
+ */
+public class CheckBridgeBatteryTest extends RobolectricTestWithConfig {
+
+    private static final String ALERTS = "bridge_battery_alerts";
+    private static final String LEVEL = "bridge_battery_alert_level";
+    private static final String BATTERY = "bridge_battery";
+    private static final String FORCE_WEAR = "disable_wearG5_on_lowbattery";
+
+    @Before
+    public void before() {
+        cleanup();
+    }
+
+    @After
+    public void after() {
+        cleanup();
+    }
+
+    private void cleanup() {
+        Pref.removeItem(ALERTS);
+        Pref.removeItem(LEVEL);
+        Pref.removeItem(BATTERY);
+        Pref.removeItem(FORCE_WEAR);
+    }
+
+    // ===== checkBridgeBattery ===========================================================================================
+
+    /** With bridge battery alerts switched off, no low battery is ever reported. */
+    @Test
+    public void checkBridgeBatteryReturnsFalseWhenAlertsDisabled() {
+        // :: Setup
+        Pref.setBoolean(ALERTS, false);
+        Pref.setString(LEVEL, "30");
+        Pref.setInt(BATTERY, 5);
+
+        // :: Act
+        final boolean lowBattery = CheckBridgeBattery.checkBridgeBattery();
+
+        // :: Verify
+        assertWithMessage("alerts disabled suppresses the low bridge battery result")
+                .that(lowBattery).isFalse();
+    }
+
+    // ===== checkForceWearBridgeBattery ==================================================================================
+
+    /** Forcing the watch off needs both the alert switch and the force-wear switch enabled. */
+    @Test
+    public void checkForceWearBridgeBatteryRequiresBothSwitches() {
+        // :: Setup
+        Pref.setString(LEVEL, "30");
+        Pref.setInt(BATTERY, 10);
+
+        // :: Act
+        Pref.setBoolean(ALERTS, false);
+        Pref.setBoolean(FORCE_WEAR, true);
+        final boolean alertsOff = CheckBridgeBattery.checkForceWearBridgeBattery();
+
+        Pref.setBoolean(ALERTS, true);
+        Pref.setBoolean(FORCE_WEAR, false);
+        final boolean forceWearOff = CheckBridgeBattery.checkForceWearBridgeBattery();
+
+        // :: Verify
+        assertWithMessage("alerts disabled means no forced wear switch off").that(alertsOff).isFalse();
+        assertWithMessage("force wear disabled means no forced wear switch off").that(forceWearOff).isFalse();
+    }
+
+    /** Below the threshold, with 5% leeway subtracted, the watch is switched off. */
+    @Test
+    public void checkForceWearBridgeBatteryReportsLowBatteryBelowThreshold() {
+        // :: Setup
+        Pref.setBoolean(ALERTS, true);
+        Pref.setBoolean(FORCE_WEAR, true);
+        Pref.setString(LEVEL, "30");
+
+        // :: Act
+        Pref.setInt(BATTERY, 10);
+        final boolean below = CheckBridgeBattery.checkForceWearBridgeBattery();
+
+        Pref.setInt(BATTERY, 90);
+        final boolean above = CheckBridgeBattery.checkForceWearBridgeBattery();
+
+        // :: Verify
+        assertWithMessage("10% is below the 25% effective threshold").that(below).isTrue();
+        assertWithMessage("90% is above the 25% effective threshold").that(above).isFalse();
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBatteryTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utils/CheckBridgeBatteryTest.java
@@ -89,14 +89,14 @@ public class CheckBridgeBatteryTest extends RobolectricTestWithConfig {
         Pref.setString(LEVEL, "30");
 
         // :: Act
-        Pref.setInt(BATTERY, 10);
+        Pref.setInt(BATTERY, 24);
         final boolean below = CheckBridgeBattery.checkForceWearBridgeBattery();
 
-        Pref.setInt(BATTERY, 90);
+        Pref.setInt(BATTERY, 26);
         final boolean above = CheckBridgeBattery.checkForceWearBridgeBattery();
 
         // :: Verify
-        assertWithMessage("10% is below the 25% effective threshold").that(below).isTrue();
-        assertWithMessage("90% is above the 25% effective threshold").that(above).isFalse();
+        assertWithMessage("24% is below the 25% effective threshold").that(below).isTrue();
+        assertWithMessage("26% is above the 25% effective threshold").that(above).isFalse();
     }
 }


### PR DESCRIPTION
First slice of removing Parakeet support. Dead code only, nothing user-visible changes.

### `CheckBridgeBattery.checkParakeetBattery()`

It cannot run. `legacySettingsFix()` sets `bridge_battery_alerts` to false on every start
(`xdrip.onCreate` -> `performAll()`), and the switch that used to set it was removed in 6a0c27188
("Retire Parakeet Alerts", June 2025). No preference XML declares the key any more, and restoring
settings from SD goes through `hardReset()`, so the migration runs again before anything reads it.
The method early-returned on that key, so removing it and its two call sites (`WixelReader`,
`GcmListenerSvc`) changes nothing. The six private fields only it used go with it.

### `GcmActivity.sendLocation()`

Package-private, and its only reference in the repo is a commented-out line in `MapsActivity`. The
matching `"plu"` receive handler in `GcmListenerSvc` stays, since older masters still send it.

### Left alone on purpose

- The `parakeet_battery` preference key. Still written and read on six paths.
- The `"pbu"` GCM action and its handler.
- `R.string.low_parakeet_battery`, unreferenced now. It goes with the rest of the strings later.
- `checkBridgeBattery()` and `checkForceWearBridgeBattery()`. They sit behind the same disabled
  preference and are just as dead in practice, but retiring collector battery alerts altogether is
  a bigger call than this PR.

### Tests

Regression pins, written first and green against unmodified master:

- `CheckBridgeBatteryTest` covers the two surviving methods, including the 5% wear leeway.
- `IdempotentMigrationsTest.performAllForcesBridgeBatteryAlertsOff`. `bridge_battery_alerts` is not
  Parakeet-only, it also gates the alerts for every other bridge, so that line has to survive the
  rest of this removal. The class now snapshots and restores the preference store, because
  `performAll()` writes a lot of unrelated keys into a store the whole module shares.
- `NotificationChannelsTest.mappedChannelsResolveToDisplayNames` pins that a mapped channel resolves
  to a name instead of falling back to its raw id.

All green:

```
./gradlew :app:testFastDebugUnitTest :wear:testFastDebugUnitTest
./gradlew :app:assembleProdRelease
```
