### PR TITLE
Inter-app data source

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -13,7 +13,7 @@
         <item>xDrip+ Sync Follower</item>
         <item>LibreAlarm</item>
         <item>Libre (patched App)</item>
-        <item>Inter-app</item>
+        <item>Inter-app broadcast</item>
         <item>Medtrum A6</item>
         <item>Nightscout Follower</item>
         <item>Dex Share Follower</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -13,7 +13,7 @@
         <item>xDrip+ Sync Follower</item>
         <item>LibreAlarm</item>
         <item>Libre (patched App)</item>
-        <item>640G / EverSense</item>
+        <item>Inter-app</item>
         <item>Medtrum A6</item>
         <item>Nightscout Follower</item>
         <item>Dex Share Follower</item>


### PR DESCRIPTION
This PR changes the title of one of the hardware data sources.
It renames 640G/Eversense to Inter-app.

The main reason I think we should change this title is that the existing title is too specific to only 2 of the possibilities.  
But, there are many other sources hat broadcast to xDrip and there will even be more in the future.
I believe we should change the title to something more general that would be valid for all of them.

Further, we should avoid using titles that may be trademarks.  

I know that this could cause confusion a little bit.
But, xDrip is alive, young and growing.  There will be changes.  We support users and help them adapt.  

I am not insisting this is the best title.
If you can think of alternatives, please let me know.

I did not like Broadcast receiver because receiver may bring to mind a receiving piece of hardware.
I didn't like receiver for the same reason.
I didn't like Listener because it was too vague.

I considered many others until I considered the existing "Inter-app settings" title.  Inter-app seems to be the best unless you can think of something better.

| Before | After|  
| ------- | ----- |  
| <img width="270" height="606" alt="Screenshot_20260828-194351" src="https://github.com/user-attachments/assets/f5e5fd08-c5c3-490f-b003-455c0f41d984" /> | <img width="270" height="606" alt="Screenshot_20260828-194508" src="https://github.com/user-attachments/assets/ae259b5f-02c2-469b-a0ed-e9e01fe03c53" /> |  

