### PR TITLE
Inter-app broadcast renaming completion

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SourceWizard.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/SourceWizard.java
@@ -53,7 +53,7 @@ public class SourceWizard {
         Tree<Item> other = root.addChild(new Item(gs(R.string.other), gs(R.string.which_type_of_device), R.drawable.wikimedia_question_mark));
         {
             other.addChild(new Item("xDrip Sync Follower", DexCollectionType.Follower, R.drawable.x_sync_follow_icon));
-            other.addChild(new Item("640G / 670G", DexCollectionType.NSEmulator, R.drawable.mm600_series));
+            other.addChild(new Item("Inter-app broadcast", DexCollectionType.NSEmulator, R.drawable.mm600_series));
             other.addChild(new Item("CareSens Air", DexCollectionType.NSEmulator, R.drawable.caresens_air_icon_image));
             other.addChild(new Item("Medtrum A6 / S7", DexCollectionType.Medtrum, R.drawable.a6_icon));
             other.addChild(new Item("SmartGuide", DexCollectionType.GluPro,R.drawable.smartguide_jamorham));

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -1613,11 +1613,10 @@
 
                 <CheckBoxPreference
                     android:defaultValue="false"
-                    android:dependency="engineering_mode"
                     android:enabled="true"
                     android:key="Eversense_one_minute"
-                    android:summary="Accept data at one-minute intervals from 640G/Eversense. WARNING: This feature is still under development and may break different things. Please report anything you notice not working. Reboot your phone for changes to take effect. Requires engineering mode"
-                    android:title="640G/Eversense 1-minute" />
+                    android:summary="Accept data at one-minute intervals from Inter-app broadcast.  Reboot your phone for changes to take effect."
+                    android:title="1-min Inter-app broadcast" />
 
                 <CheckBoxPreference
                     android:defaultValue="false"


### PR DESCRIPTION
I forgot to rename a few other instances.  This PR takes care of that.

While doing that, I noticed that the 1-minute option for the inter-app broadcast was still behind engineering mode.  I have heard no horror stories.  So, this PR also removes that from engineering mode.  I hope this is acceptable.  

I feel we should also update the image in the source wizard.  I will do that some time in the future.  