### PR TITLE
[cleanup] Replace android.preference.PreferenceManager with androidx (Batch 4: 7 files)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java
@@ -11,7 +11,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.PowerManager;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.provider.BaseColumns;
 
 import com.activeandroid.Model;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/DoNothingService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/DoNothingService.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.IBinder;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.text.SpannableString;
 
 import com.eveningoutpost.dexdrip.GcmActivity;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/broadcastservice/BroadcastService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/broadcastservice/BroadcastService.java
@@ -11,7 +11,7 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.os.Parcelable;
 import android.os.PowerManager;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import com.eveningoutpost.dexdrip.BestGlucose;
 import com.eveningoutpost.dexdrip.models.Accuracy;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/PercentileView.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/PercentileView.java
@@ -9,10 +9,10 @@ import android.graphics.CornerPathEffect;
 import android.graphics.DashPathEffect;
 import android.graphics.Paint;
 import android.graphics.Path;
-import android.preference.PreferenceManager;
 import android.util.DisplayMetrics;
 
 import androidx.core.content.ContextCompat;
+import androidx.preference.PreferenceManager;
 
 import com.eveningoutpost.dexdrip.models.UserError.Log;
 import android.view.View;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilder.java
@@ -6,7 +6,7 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.DashPathEffect;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import android.text.format.DateFormat;
 import android.util.Log;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayTrendOld.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayTrendOld.java
@@ -2,7 +2,7 @@ package com.eveningoutpost.dexdrip.utilitymodels.pebble;
 
 import android.graphics.Bitmap;
 import android.os.PowerManager;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import com.eveningoutpost.dexdrip.BestGlucose;
 import com.eveningoutpost.dexdrip.Home;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/Amazfitservice.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/Amazfitservice.java
@@ -10,7 +10,7 @@ import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.IBinder;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import androidx.annotation.Nullable;
 import android.util.Base64;
 import android.util.Log;

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/BgReadingPreferencesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/BgReadingPreferencesTest.java
@@ -1,0 +1,190 @@
+package com.eveningoutpost.dexdrip.models;
+
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import com.activeandroid.query.Delete;
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Behavioural tests for the three preference-driven alert gates in {@link BgReading}.
+ * <p>
+ * All three methods read their switches straight from the default shared preferences, so the tests
+ * drive them through those preferences and observe the {@link UserNotification} row each path is
+ * meant to leave behind or clear. The rise and drop gates are {@code void}, and the row is their
+ * only observable: an alert that is switched off returns before it can touch the row, while an
+ * alert that is switched on reaches {@code Notifications} and clears it.
+ * <p>
+ * {@code getAndRaiseUnclearReading}'s two preference gates both end in "false, and the row is
+ * cleared", so a test can pin the read but not tell the two gates apart. Its live branch is out of
+ * reach: it is guarded by {@code DexCollectionType.hasFiltered()} and the two
+ * {@code Ob1G5CollectionService} checks, which all read through {@code Pref}, and {@code Pref}
+ * freezes on the first store it ever sees.
+ *
+ * @author Asbjørn Aarrestad - 2026.09
+ */
+public class BgReadingPreferencesTest extends RobolectricTestWithConfig {
+
+    private static final String RISE_ALERT = "bg_rise_alert";
+    private static final String FALL_ALERT = "bg_fall_alert";
+    private static final String UNCLEAR_ALERT = "bg_unclear_readings_alert";
+
+    // ===== Setup =================================================================================
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+        prefs().edit().clear().commit();                        // the preference file leaks between test methods
+        new Delete().from(UserNotification.class).execute();    // so do the rows
+    }
+
+    // ===== Rising alert ==========================================================================
+
+    /** With the rising alert switched off the method returns before it can touch the notification. */
+    @Test
+    public void risingAlertOff_leavesTheNotificationAlone() {
+        // :: Setup
+        seedNotification(RISE_ALERT);
+        prefs().edit().putBoolean("rising_alert", false).commit();
+
+        // :: Act
+        BgReading.checkForRisingAllert(xdrip.getAppContext());
+
+        // :: Verify
+        assertThat(UserNotification.GetNotificationByType(RISE_ALERT)).isNotNull();
+    }
+
+    /** All alerts snoozed until a future time stops the rising alert just as an off switch does. */
+    @Test
+    public void risingAlertOn_butAllAlertsDisabled_leavesTheNotificationAlone() {
+        // :: Setup
+        seedNotification(RISE_ALERT);
+        prefs().edit()
+                .putBoolean("rising_alert", true)
+                .putLong("alerts_disabled_until", JoH.tsl() + Constants.HOUR_IN_MS)
+                .commit();
+
+        // :: Act
+        BgReading.checkForRisingAllert(xdrip.getAppContext());
+
+        // :: Verify
+        assertThat(UserNotification.GetNotificationByType(RISE_ALERT)).isNotNull();
+    }
+
+    /** Switched on with no rise in the data, the method reaches the notification and clears it. */
+    @Test
+    public void risingAlertOn_andNoRiseInTheData_clearsTheNotification() {
+        // :: Setup
+        seedNotification(RISE_ALERT);
+        prefs().edit().putBoolean("rising_alert", true).commit();
+
+        // :: Act
+        BgReading.checkForRisingAllert(xdrip.getAppContext());
+
+        // :: Verify
+        assertThat(UserNotification.GetNotificationByType(RISE_ALERT)).isNull();
+    }
+
+    // ===== Drop alert ============================================================================
+
+    /** With the falling alert switched off the method returns before it can touch the notification. */
+    @Test
+    public void dropAlertOff_leavesTheNotificationAlone() {
+        // :: Setup
+        seedNotification(FALL_ALERT);
+        prefs().edit().putBoolean("falling_alert", false).commit();
+
+        // :: Act
+        BgReading.checkForDropAllert(xdrip.getAppContext());
+
+        // :: Verify
+        assertThat(UserNotification.GetNotificationByType(FALL_ALERT)).isNotNull();
+    }
+
+    /** All alerts snoozed until a future time stops the drop alert just as an off switch does. */
+    @Test
+    public void dropAlertOn_butAllAlertsDisabled_leavesTheNotificationAlone() {
+        // :: Setup
+        seedNotification(FALL_ALERT);
+        prefs().edit()
+                .putBoolean("falling_alert", true)
+                .putLong("alerts_disabled_until", JoH.tsl() + Constants.HOUR_IN_MS)
+                .commit();
+
+        // :: Act
+        BgReading.checkForDropAllert(xdrip.getAppContext());
+
+        // :: Verify
+        assertThat(UserNotification.GetNotificationByType(FALL_ALERT)).isNotNull();
+    }
+
+    /** Switched on with no drop in the data, the method reaches the notification and clears it. */
+    @Test
+    public void dropAlertOn_andNoDropInTheData_clearsTheNotification() {
+        // :: Setup
+        seedNotification(FALL_ALERT);
+        prefs().edit().putBoolean("falling_alert", true).commit();
+
+        // :: Act
+        BgReading.checkForDropAllert(xdrip.getAppContext());
+
+        // :: Verify
+        assertThat(UserNotification.GetNotificationByType(FALL_ALERT)).isNull();
+    }
+
+    // ===== Unclear readings ======================================================================
+
+    /** Alerts snoozed until a future time: no unclear reading is raised, and any standing one goes. */
+    @Test
+    public void unclearReadings_whileAllAlertsDisabled_isFalseAndClearsTheNotification() {
+        // :: Setup
+        seedNotification(UNCLEAR_ALERT);
+        prefs().edit()
+                .putBoolean("bg_unclear_readings_alerts", true)
+                .putLong("alerts_disabled_until", JoH.tsl() + Constants.HOUR_IN_MS)
+                .commit();
+
+        // :: Act
+        final boolean raised = BgReading.getAndRaiseUnclearReading(xdrip.getAppContext());
+
+        // :: Verify
+        assertThat(raised).isFalse();
+        assertThat(UserNotification.GetNotificationByType(UNCLEAR_ALERT)).isNull();
+    }
+
+    /** With the feature switched off the same holds, and it is the default state. */
+    @Test
+    public void unclearReadings_withTheFeatureOff_isFalseAndClearsTheNotification() {
+        // :: Setup
+        seedNotification(UNCLEAR_ALERT);
+        prefs().edit().putBoolean("bg_unclear_readings_alerts", false).commit();
+
+        // :: Act
+        final boolean raised = BgReading.getAndRaiseUnclearReading(xdrip.getAppContext());
+
+        // :: Verify
+        assertThat(raised).isFalse();
+        assertThat(UserNotification.GetNotificationByType(UNCLEAR_ALERT)).isNull();
+    }
+
+    // ===== Helpers ===============================================================================
+
+    private static void seedNotification(String type) {
+        UserNotification.create("standing alert", type, JoH.tsl());
+    }
+
+    private static SharedPreferences prefs() {
+        return PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/services/DoNothingServicePreferencesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/services/DoNothingServicePreferencesTest.java
@@ -1,0 +1,94 @@
+package com.eveningoutpost.dexdrip.services;
+
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+/**
+ * Behavioural tests for the foreground switch the follower service listens on.
+ * <p>
+ * {@code onCreate} registers a listener on the default shared preferences, and that registration is
+ * the file's only use of them: turning {@code run_service_in_foreground} off has to take the service
+ * out of the foreground, and turning it back on has to raise the ongoing notification again. A
+ * listener registered on the wrong store would leave the switch dead, so the tests drive the switch
+ * and watch the service move.
+ *
+ * @author Asbjørn Aarrestad - 2026.09
+ */
+public class DoNothingServicePreferencesTest extends RobolectricTestWithConfig {
+
+    private DoNothingService service;
+
+    // ===== Setup =================================================================================
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+        prefs().edit().clear().commit();                        // the preference file leaks between test methods
+        service = Robolectric.buildService(DoNothingService.class).create().get();
+    }
+
+    // ===== The foreground switch =================================================================
+
+    /** A freshly created service runs in the foreground. */
+    @Test
+    public void onCreate_leavesTheServiceInTheForeground() {
+        // :: Act
+        final boolean foregroundStopped = shadowOf(service).isForegroundStopped();
+
+        // :: Verify
+        assertThat(foregroundStopped).isFalse();
+    }
+
+    /** Switching the preference off takes the service out of the foreground. */
+    @Test
+    public void switchingTheForegroundPreferenceOff_stopsTheForeground() {
+        // :: Act
+        prefs().edit().putBoolean("run_service_in_foreground", false).commit();
+
+        // :: Verify
+        assertThat(shadowOf(service).isForegroundStopped()).isTrue();
+    }
+
+    /** Switching it back on raises the ongoing notification again. */
+    @Test
+    public void switchingTheForegroundPreferenceOn_raisesTheOngoingNotification() {
+        // :: Setup
+        prefs().edit().putBoolean("run_service_in_foreground", false).commit();
+
+        // :: Act
+        prefs().edit().putBoolean("run_service_in_foreground", true).commit();
+
+        // :: Verify
+        assertThat(shadowOf(service).getLastForegroundNotification()).isNotNull();
+    }
+
+    /** An unrelated preference leaves the service where it is. */
+    @Test
+    public void anUnrelatedPreferenceChange_leavesTheForegroundAlone() {
+        // :: Act
+        prefs().edit().putString("units", "mmol").commit();
+
+        // :: Verify
+        assertThat(shadowOf(service).isForegroundStopped()).isFalse();
+    }
+
+    // ===== Helpers ===============================================================================
+
+    private static SharedPreferences prefs() {
+        return PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/services/broadcastservice/BroadcastServicePreferencesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/services/broadcastservice/BroadcastServicePreferencesTest.java
@@ -1,0 +1,116 @@
+package com.eveningoutpost.dexdrip.services.broadcastservice;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+import androidx.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.services.broadcastservice.models.BroadcastModel;
+import com.eveningoutpost.dexdrip.services.broadcastservice.models.Settings;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Behavioural tests for the glucose unit that {@link BroadcastService} puts on the wire.
+ * <p>
+ * {@code prepareBgBundle} reads the stored unit and passes it on as {@code doMgdl}, which is what
+ * every third-party app bound to the broadcast API scales its numbers by. The bundle is the
+ * service's output, so the tests build one and read the flag back out.
+ * <p>
+ * The graph half of the bundle is left switched off: {@link Settings#isDisplayGraph()} defaults to
+ * false, and the graph block reads the same preferences that
+ * {@code BgGraphBuilderPreferencesTest} already covers.
+ *
+ * @author Asbjørn Aarrestad - 2026.09
+ */
+public class BroadcastServicePreferencesTest extends RobolectricTestWithConfig {
+
+    private BroadcastService service;
+
+    // ===== Setup =================================================================================
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+        prefs().edit().clear().commit();                        // the preference file leaks between test methods
+        service = new BroadcastService();
+    }
+
+    // ===== Glucose units on the wire =============================================================
+
+    /** mg/dL is passed on as the unit flag third-party apps scale by. */
+    @Test
+    public void unitsMgdl_isBroadcastAsMgdl() {
+        // :: Setup
+        prefs().edit().putString("units", "mgdl").commit();
+
+        // :: Act
+        final Bundle sent = bundle();
+
+        // :: Verify
+        assertThat(sent.getBoolean("doMgdl")).isTrue();
+    }
+
+    /** Anything other than the literal "mgdl" is broadcast as mmol/L. */
+    @Test
+    public void unitsMmol_isBroadcastAsMmol() {
+        // :: Setup
+        prefs().edit().putString("units", "mmol").commit();
+
+        // :: Act
+        final Bundle sent = bundle();
+
+        // :: Verify
+        assertThat(sent.getBoolean("doMgdl")).isFalse();
+    }
+
+    /** With no stored unit at all the broadcast falls back to mg/dL. */
+    @Test
+    public void noStoredUnits_isBroadcastAsMgdl() {
+        // :: Act
+        final Bundle sent = bundle();
+
+        // :: Verify
+        assertThat(sent.getBoolean("doMgdl")).isTrue();
+    }
+
+    // ===== Nothing to broadcast ==================================================================
+
+    /** Without a model there is nothing to send, and the preferences are never reached. */
+    @Test
+    public void noModel_producesNoBundle() {
+        // :: Act
+        final Bundle sent = service.prepareBgBundle(null);
+
+        // :: Verify
+        assertThat(sent).isNull();
+    }
+
+    /** A model whose settings never arrived is equally unsendable. */
+    @Test
+    public void modelWithoutSettings_producesNoBundle() {
+        // :: Act
+        final Bundle sent = service.prepareBgBundle(new BroadcastModel(null));
+
+        // :: Verify
+        assertThat(sent).isNull();
+    }
+
+    // ===== Helpers ===============================================================================
+
+    private Bundle bundle() {
+        return service.prepareBgBundle(new BroadcastModel(new Settings()));
+    }
+
+    private static SharedPreferences prefs() {
+        return PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/stats/PercentileViewPreferencesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/stats/PercentileViewPreferencesTest.java
@@ -1,0 +1,122 @@
+package com.eveningoutpost.dexdrip.stats;
+
+import android.content.SharedPreferences;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import androidx.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Behavioural tests for the preference-driven labels on the percentile chart.
+ * <p>
+ * {@code drawGrid} picks its level markings from the stored glucose unit, so the labels written on
+ * the chart are the read's observable effect. The tests draw the view onto a canvas that records
+ * the text it is asked to write, and read the labels back.
+ *
+ * @author Asbjørn Aarrestad - 2026.09
+ */
+public class PercentileViewPreferencesTest extends RobolectricTestWithConfig {
+
+    private PercentileView view;
+
+    // ===== Setup =================================================================================
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+        prefs().edit().clear().commit();                        // the preference file leaks between test methods
+        view = new PercentileView(xdrip.getAppContext());
+        view.setCalculatedData(emptyPercentiles());             // otherwise the view only draws "Calculating..."
+    }
+
+    // ===== Level markings ========================================================================
+
+    /** In mg/dL the grid is marked every 50 units. */
+    @Test
+    public void unitsMgdl_marksTheGridInMgdl() {
+        // :: Setup
+        prefs().edit().putString("units", "mgdl").commit();
+
+        // :: Act
+        final List<String> labels = drawnText();
+
+        // :: Verify
+        assertThat(labels).containsAtLeast("50", "100", "150", "200", "250", "300", "350");
+    }
+
+    /** In mmol/L the same grid carries the mmol level markings instead. */
+    @Test
+    public void unitsMmol_marksTheGridInMmol() {
+        // :: Setup
+        prefs().edit().putString("units", "mmol").commit();
+
+        // :: Act
+        final List<String> labels = drawnText();
+
+        // :: Verify
+        assertThat(labels).containsAtLeast("2.8", "5.5", "8.3", "11", "14", "17", "20");
+    }
+
+    /** With no stored unit the grid falls back to mg/dL. */
+    @Test
+    public void noStoredUnits_marksTheGridInMgdl() {
+        // :: Act
+        final List<String> labels = drawnText();
+
+        // :: Verify
+        assertThat(labels).containsAtLeast("50", "100", "150", "200", "250", "300", "350");
+    }
+
+    // ===== Helpers ===============================================================================
+
+    private List<String> drawnText() {
+        RecordingCanvas canvas = new RecordingCanvas();
+        view.onDraw(canvas);
+        return canvas.text;
+    }
+
+    /** All percentiles flat at zero: the polygons are degenerate, the grid and labels are not. */
+    private PercentileView.CalculatedData emptyPercentiles() {
+        PercentileView.CalculatedData data = view.new CalculatedData();
+        data.q10 = new double[PercentileView.NO_TIMESLOTS];
+        data.q25 = new double[PercentileView.NO_TIMESLOTS];
+        data.q50 = new double[PercentileView.NO_TIMESLOTS];
+        data.q75 = new double[PercentileView.NO_TIMESLOTS];
+        data.q90 = new double[PercentileView.NO_TIMESLOTS];
+        return data;
+    }
+
+    private static SharedPreferences prefs() {
+        return PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+    }
+
+    /** A canvas that keeps every string the view asks it to draw. */
+    private static class RecordingCanvas extends Canvas {
+        final List<String> text = new ArrayList<>();
+
+        RecordingCanvas() {
+            super(Bitmap.createBitmap(600, 400, Bitmap.Config.ARGB_8888));
+        }
+
+        @Override
+        public void drawText(String string, float x, float y, Paint paint) {
+            text.add(string);
+            super.drawText(string, x, y, paint);
+        }
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilderPreferencesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/BgGraphBuilderPreferencesTest.java
@@ -1,0 +1,151 @@
+package com.eveningoutpost.dexdrip.utilitymodels;
+
+import androidx.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Behavioural tests for the preference-controlled fields of {@link BgGraphBuilder}.
+ * <p>
+ * The constructor reads four display preferences and assigns them to public fields, which makes this
+ * the one file in the batch whose preference read is assertable with nothing but a constructor call.
+ * The fields are the graph's glucose scale and its high/low markers, so a silent change here would
+ * move every threshold line the user sees.
+ * <p>
+ * {@code forecastLowMark} is only asserted in its default shape. Its other branch is gated on
+ * {@code Pref.getBoolean("low_value_is_forecast_low_threshold")}, and {@code Pref} freezes on the
+ * first store it ever sees, so no test can flip it.
+ *
+ * @author Asbjørn Aarrestad - 2026.09
+ */
+public class BgGraphBuilderPreferencesTest extends RobolectricTestWithConfig {
+
+    private static final double TOLERANCE = 0.0001;
+
+    private long start;
+    private long end;
+
+    // ===== Setup =================================================================================
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+        prefs().edit().clear().commit();                        // the preference file leaks between test methods
+        end = JoH.tsl();
+        start = end - Constants.DAY_IN_MS;
+    }
+
+    // ===== Glucose units =========================================================================
+
+    /** mg/dL is the stored value the graph scales against directly. */
+    @Test
+    public void unitsMgdl_makesTheBuilderMgdl() {
+        // :: Setup
+        prefs().edit().putString("units", "mgdl").commit();
+
+        // :: Act
+        final BgGraphBuilder builder = build();
+
+        // :: Verify
+        assertThat(builder.doMgdl).isTrue();
+    }
+
+    /** Anything other than the literal "mgdl" is treated as mmol/L. */
+    @Test
+    public void unitsMmol_makesTheBuilderMmol() {
+        // :: Setup
+        prefs().edit().putString("units", "mmol").commit();
+
+        // :: Act
+        final BgGraphBuilder builder = build();
+
+        // :: Verify
+        assertThat(builder.doMgdl).isFalse();
+    }
+
+    /** With no stored unit at all the graph falls back to mg/dL. */
+    @Test
+    public void noStoredUnits_defaultsToMgdl() {
+        // :: Act
+        final BgGraphBuilder builder = build();
+
+        // :: Verify
+        assertThat(builder.doMgdl).isTrue();
+    }
+
+    // ===== High and low markers ==================================================================
+
+    /** The high and low markers come straight from the stored strings. */
+    @Test
+    public void storedThresholds_becomeTheHighAndLowMarks() {
+        // :: Setup
+        prefs().edit()
+                .putString("highValue", "180")
+                .putString("lowValue", "65")
+                .commit();
+
+        // :: Act
+        final BgGraphBuilder builder = build();
+
+        // :: Verify
+        assertThat(builder.highMark).isWithin(TOLERANCE).of(180d);
+        assertThat(builder.lowMark).isWithin(TOLERANCE).of(65d);
+    }
+
+    /** With nothing stored the markers fall back to 170 and 70. */
+    @Test
+    public void noStoredThresholds_fallBackTo170And70() {
+        // :: Act
+        final BgGraphBuilder builder = build();
+
+        // :: Verify
+        assertThat(builder.highMark).isWithin(TOLERANCE).of(170d);
+        assertThat(builder.lowMark).isWithin(TOLERANCE).of(70d);
+    }
+
+    /** An unparseable threshold falls back to the same default rather than throwing. */
+    @Test
+    public void unparseableThreshold_fallsBackToTheDefault() {
+        // :: Setup
+        prefs().edit().putString("highValue", "not a number").commit();
+
+        // :: Act
+        final BgGraphBuilder builder = build();
+
+        // :: Verify
+        assertThat(builder.highMark).isWithin(TOLERANCE).of(170d);
+    }
+
+    /** By default the forecast low marker mirrors the low marker. */
+    @Test
+    public void forecastLowMark_mirrorsTheLowMarkByDefault() {
+        // :: Setup
+        prefs().edit().putString("lowValue", "72").commit();
+
+        // :: Act
+        final BgGraphBuilder builder = build();
+
+        // :: Verify
+        assertThat(builder.forecastLowMark).isWithin(TOLERANCE).of(builder.lowMark);
+    }
+
+    // ===== Helpers ===============================================================================
+
+    private static android.content.SharedPreferences prefs() {
+        return PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+    }
+
+    private BgGraphBuilder build() {
+        return new BgGraphBuilder(xdrip.getAppContext(), start, end);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayTrendOldPreferencesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/pebble/PebbleDisplayTrendOldPreferencesTest.java
@@ -1,0 +1,138 @@
+package com.eveningoutpost.dexdrip.utilitymodels.pebble;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.BatteryManager;
+
+import androidx.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.BestGlucose;
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.utilitymodels.BgGraphBuilder;
+import com.eveningoutpost.dexdrip.utilitymodels.Constants;
+import com.eveningoutpost.dexdrip.xdrip;
+import com.getpebble.android.kit.util.PebbleDictionary;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Behavioural tests for the special-message preferences the Pebble watchface receives.
+ * <p>
+ * {@code buildDictionary} compares the glucose it is about to send against
+ * {@code pebble_special_value}, and on a match replaces the message with {@code pebble_special_text}.
+ * The dictionary it returns is the watch's payload, so the tests read the message back out of it.
+ *
+ * @author Asbjørn Aarrestad - 2026.09
+ */
+public class PebbleDisplayTrendOldPreferencesTest extends RobolectricTestWithConfig {
+
+    private PebbleDisplayTrendOld display;
+
+    // ===== Setup =================================================================================
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+        prefs().edit().clear().commit();                        // the preference file leaks between test methods
+        publishBatteryLevel();                                  // the dictionary carries a battery status
+
+        long end = JoH.tsl();
+        display = new PebbleDisplayTrendOld();
+        display.initDisplay(xdrip.getAppContext(), null,
+                new BgGraphBuilder(xdrip.getAppContext(), end - Constants.DAY_IN_MS, end));
+        display.dg = displayGlucose("5.5");
+    }
+
+    // ===== Special message =======================================================================
+
+    /** A glucose matching the special value swaps the message for the stored special text. */
+    @Test
+    public void glucoseMatchingTheSpecialValue_sendsTheSpecialText() {
+        // :: Setup
+        prefs().edit()
+                .putString("pebble_special_value", "5.5")
+                .putString("pebble_special_text", "steady as she goes")
+                .commit();
+
+        // :: Act
+        final String sent = message();
+
+        // :: Verify
+        assertThat(sent).isEqualTo("steady as she goes");
+    }
+
+    /** With no special text stored the match still fires, on the built-in text. */
+    @Test
+    public void glucoseMatchingTheSpecialValue_withNoStoredText_sendsTheDefault() {
+        // :: Setup
+        prefs().edit().putString("pebble_special_value", "5.5").commit();
+
+        // :: Act
+        final String sent = message();
+
+        // :: Verify
+        assertThat(sent).isEqualTo("BAZINGA!");
+    }
+
+    /** A glucose that does not match leaves the message empty, whatever the special text says. */
+    @Test
+    public void glucoseNotMatchingTheSpecialValue_sendsNoMessage() {
+        // :: Setup
+        prefs().edit()
+                .putString("pebble_special_value", "9.9")
+                .putString("pebble_special_text", "steady as she goes")
+                .commit();
+
+        // :: Act
+        final String sent = message();
+
+        // :: Verify
+        assertThat(sent).isEmpty();
+    }
+
+    /** With no special value stored nothing can match, so the message stays empty. */
+    @Test
+    public void noSpecialValueStored_sendsNoMessage() {
+        // :: Act
+        final String sent = message();
+
+        // :: Verify
+        assertThat(sent).isEmpty();
+    }
+
+    // ===== Helpers ===============================================================================
+
+    private String message() {
+        PebbleDictionary dictionary = display.buildDictionary();
+        return dictionary.getString(PebbleDisplayTrendOld.MESSAGE_KEY);
+    }
+
+    private static BestGlucose.DisplayGlucose displayGlucose(String unitized) {
+        BestGlucose.DisplayGlucose dg = new BestGlucose.DisplayGlucose();
+        dg.unitized = unitized;
+        dg.mgdl = 99;
+        dg.timestamp = JoH.tsl();
+        dg.mssince = 0;         // fresh, so the no-signal branch stays out of the way
+        dg.delta_name = "Flat";
+        return dg;
+    }
+
+    /** The battery status is read from the sticky broadcast, which the test environment has none of. */
+    private static void publishBatteryLevel() {
+        Intent battery = new Intent(Intent.ACTION_BATTERY_CHANGED);
+        battery.putExtra(BatteryManager.EXTRA_LEVEL, 50);
+        battery.putExtra(BatteryManager.EXTRA_SCALE, 100);
+        RuntimeEnvironment.application.sendStickyBroadcast(battery);
+    }
+
+    private static SharedPreferences prefs() {
+        return PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/wearintegration/AmazfitservicePreferencesTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/wearintegration/AmazfitservicePreferencesTest.java
@@ -1,0 +1,120 @@
+package com.eveningoutpost.dexdrip.wearintegration;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.shadows.ShadowBluetoothDevice;
+
+import java.util.Collections;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+/**
+ * Behavioural tests for the collector the Amazfit watch is told about.
+ * <p>
+ * {@code getCurrentDevice} reports the paired transmitter only when the stored collection method is
+ * the G5 one, and matches the paired device against the stored transmitter id. The reported name is
+ * what the watch face shows, so the tests read it back.
+ *
+ * @author Asbjørn Aarrestad - 2026.09
+ */
+public class AmazfitservicePreferencesTest extends RobolectricTestWithConfig {
+
+    private Amazfitservice service;
+
+    // ===== Setup =================================================================================
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application); // force re-bind to current Robolectric app
+        prefs().edit().clear().commit();                        // the preference file leaks between test methods
+        pairTransmitterNamed("Dexcom EF");
+        service = Robolectric.buildService(Amazfitservice.class).create().get();
+    }
+
+    // ===== Which collector the watch is told about ===============================================
+
+    /** With the G5 collector stored, the paired transmitter's id is what the watch is told. */
+    @Test
+    public void g5CollectionMethod_reportsThePairedTransmitter() {
+        // :: Setup
+        prefs().edit()
+                .putString("dex_collection_method", "DexcomG5")
+                .putString("dex_txid", "ABCDEF")
+                .commit();
+
+        // :: Act
+        final String device = service.getCurrentDevice();
+
+        // :: Verify
+        assertThat(device).isEqualTo("ABCDEF");
+    }
+
+    /** A transmitter id that does not match the paired device is not reported. */
+    @Test
+    public void g5CollectionMethod_withAnotherTransmitterId_reportsNoDevice() {
+        // :: Setup
+        prefs().edit()
+                .putString("dex_collection_method", "DexcomG5")
+                .putString("dex_txid", "ABCD99")
+                .commit();
+
+        // :: Act
+        final String device = service.getCurrentDevice();
+
+        // :: Verify
+        assertThat(device).isEqualTo("None Set");
+    }
+
+    /** Any other collection method never looks at the paired transmitter at all. */
+    @Test
+    public void otherCollectionMethod_reportsNoDevice() {
+        // :: Setup
+        prefs().edit()
+                .putString("dex_collection_method", "BluetoothWixel")
+                .putString("dex_txid", "ABCDEF")
+                .commit();
+
+        // :: Act
+        final String device = service.getCurrentDevice();
+
+        // :: Verify
+        assertThat(device).isEqualTo("None Set");
+    }
+
+    /** With nothing stored the default collection method applies, and it is not the G5 one. */
+    @Test
+    public void noStoredCollectionMethod_reportsNoDevice() {
+        // :: Act
+        final String device = service.getCurrentDevice();
+
+        // :: Verify
+        assertThat(device).isEqualTo("None Set");
+    }
+
+    // ===== Helpers ===============================================================================
+
+    /** The match is made on the last two characters of the device name. */
+    private static void pairTransmitterNamed(String name) {
+        BluetoothDevice device = ShadowBluetoothDevice.newInstance("11:22:33:44:55:66");
+        shadowOf(device).setName(name);
+        shadowOf(BluetoothAdapter.getDefaultAdapter()).setBondedDevices(Collections.singleton(device));
+    }
+
+    private static SharedPreferences prefs() {
+        return PreferenceManager.getDefaultSharedPreferences(xdrip.getAppContext());
+    }
+}


### PR DESCRIPTION
## What

Batch 4 of #4479, after #4595 / #4654 / #4710. Seven more files off the deprecated class, one import
line each:

```diff
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
```

`BgReading`, `DoNothingService`, `BroadcastService`, `PercentileView`, `BgGraphBuilder`,
`PebbleDisplayTrendOld`, `Amazfitservice`. Production diff is 7 × (1 insertion, 1 deletion); the rest
is tests. 36 Category-2 files left in the app module, `wear` untouched at 27.

Selection rule unchanged — only files whose preference read is reachable from a public API.
`PebbleDisplayTrendOld` is the near-twin of the `PebbleDisplayTrend.java` that #4697 edits. Different
file, no overlap, but worth saying out loud.

## Tests

One behavioural test class per file, written against the old import, green, then green again after
the swap. `pebble_trend_period` sits in a private method and is not covered; every other migrated
read has a test that goes red if the read is removed.

`NightscoutUploaderCallerTest` and `InfluxDBUploaderCallerTest` still seed through the old class on
purpose — that is the cross-API assertion, same as Batch 3. Please don't tidy those imports away.

`./gradlew :app:testFastDebugUnitTest :wear:testFastDebugUnitTest` — all green.

## On a device

`API34_Phone`, 12 h of seeded readings. The settings screens write through the platform class;
`BgGraphBuilder` and `PercentileView` now read through androidx and redraw exactly what was written —
thresholds 170/70 → 220/90, then mg/dL → mmol/L. One `com.eveningoutpost.dexdrip_preferences.xml` in
`shared_prefs`, no second store, and an empty crash buffer.

| Graph 170/70 | Set 220/90 | Graph 220/90 | Stats mg/dL |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch4-graph-test/01-graph-mgdl-170-70.png) | ![](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch4-graph-test/03-units-mgdl-220-90.png) | ![](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch4-graph-test/04-graph-mgdl-220-90.png) | ![](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch4-graph-test/05-stats-mgdl.png) |

| Set mmol/L | Graph mmol/L | Stats mmol/L |
|---|---|---|
| ![](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch4-graph-test/06-units-mmol.png) | ![](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch4-graph-test/07-graph-mmol.png) | ![](https://raw.githubusercontent.com/ahaarrestad/xDrip/assets-prefmgr-batch4-graph-test/08-stats-mmol.png) |
