### PR TITLE
Silent alert logs

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/AlertList.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/AlertList.java
@@ -48,7 +48,7 @@ public class AlertList extends ActivityWithMenu {
     final int EDIT_ALERT = 2;
     SharedPreferences prefs;
     Animation anim;
-    private final static String TAG = AlertPlayer.class.getSimpleName();
+    private final static String TAG = AlertList.class.getSimpleName();
 
     String stringTimeFromAlert(AlertType alert) {
         if (alert.all_day) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -111,7 +111,7 @@ public class EditAlertActivity extends ActivityWithMenu {
     private final int MIN_ALERT = 40;
     private final int MAX_ALERT = 400;
 
-    private final static String TAG = AlertPlayer.class.getSimpleName();
+    private final static String TAG = EditAlertActivity.class.getSimpleName();
 
     String getExtra(Bundle savedInstanceState, String paramName, String defaultVal) {
         String newString;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/MissedReadingActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/MissedReadingActivity.java
@@ -61,7 +61,7 @@ public class MissedReadingActivity extends ActivityWithMenu {
     private int endHour = 23;
     private int endMinute = 59;
     private int missedMinutes = 59;
-    private final static String TAG = AlertPlayer.class.getSimpleName();
+    private final static String TAG = MissedReadingActivity.class.getSimpleName();
     EditAlertActivity editAlert = new EditAlertActivity();
     
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SnoozeActivity.java
@@ -152,7 +152,7 @@ public class SnoozeActivity extends ActivityWithMenu {
     }
 
 
-    private final static String TAG = AlertPlayer.class.getSimpleName();
+    private final static String TAG = SnoozeActivity.class.getSimpleName();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/UserNotification.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/UserNotification.java
@@ -57,7 +57,7 @@ public class UserNotification extends PlusModel {
             "bg_alert", "calibration_alert", "double_calibration_alert",
             "extra_calibration_alert", "bg_unclear_readings_alert",
             "bg_missed_alerts", "bg_rise_alert", "bg_fall_alert");
-    private final static String TAG = AlertPlayer.class.getSimpleName();
+    private final static String TAG = UserNotification.class.getSimpleName();
 
     private static boolean patched = false;
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/AlertPlayer.java
@@ -2,6 +2,7 @@ package com.eveningoutpost.dexdrip.utilitymodels;
 
 import static com.eveningoutpost.dexdrip.Home.startWatchUpdaterService;
 import static com.eveningoutpost.dexdrip.models.JoH.delayedMediaPlayerRelease;
+import static com.eveningoutpost.dexdrip.models.JoH.pratelimit;
 import static com.eveningoutpost.dexdrip.models.JoH.setMediaDataSource;
 import static com.eveningoutpost.dexdrip.models.JoH.stopAndReleasePlayer;
 import static com.eveningoutpost.dexdrip.receiver.InfoContentProvider.ping;
@@ -56,7 +57,7 @@ import lombok.Getter;
 // This is needed in order for the callbackst to work.
 class MediaPlayerCreaterHelper {
 
-    private final static String TAG = AlertPlayer.class.getSimpleName();
+    private final static String TAG = MediaPlayerCreaterHelper.class.getSimpleName();
     private final Object creationThreadLock = new Object();
     private volatile boolean mplayerCreated_ = false;
     private volatile MediaPlayer mediaPlayer_ = null;
@@ -615,12 +616,15 @@ public class AlertPlayer {
                 builder.setFullScreenIntent(notificationIntent(context, new Intent(context, Home.class)), true);
             }
 
+            Log.ueh(TAG, contentLog); // Glucose level alert log
             if (notSilencedDueToCall()) {
                 if (overrideSilent || isLoudPhone(context)) {
                     playFile(context, alert.mp3_file, volumeFrac, forceSpeaker, overrideSilent, priority, tag);
+                } else if (pratelimit("silent-alert-log", 1200)) {
+                    UserError.Log.uel(TAG, "No " + tag + " in silent mode");
                 }
             } else {
-                Log.i(TAG, "Silenced Alert Noise due to ongoing call");
+                Log.i(TAG, "No sound due to ongoing call");
             }
         }
         if (profile != ALERT_PROFILE_SILENT && alert.vibrate) {
@@ -629,12 +633,14 @@ public class AlertPlayer {
                     JoH.vibrateInternal(Notifications.vibratePattern, priority, tag);
                 }
             } else {
-                Log.i(TAG, "Vibration silenced due to ongoing call");
+                Log.i(TAG, "No vibration due to ongoing call");
             }
+        }
+        if (profile == ALERT_PROFILE_SILENT && pratelimit("silent-alert-log", 1200)) {
+            UserError.Log.uel(TAG, "No " + tag + " with silent volume profile");
         }
         // Let's keep this dummy pattern so the notification still mirrors to watches
         builder.setVibrate(new long[]{1, 0});
-        Log.ueh(TAG, contentLog);
         final NotificationManager mNotifyMgr = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         //mNotifyMgr.cancel(Notifications.exportAlertNotificationId); // this appears to confuse android wear version 2.0.0.141773014.gms even though it shouldn't - can we survive without this?
         mNotifyMgr.notify(Notifications.exportAlertNotificationId, XdripNotificationCompat.build(builder));
@@ -720,6 +726,9 @@ public class AlertPlayer {
         int profile = getAlertProfile(context);
         if (profile == ALERT_PROFILE_SILENT) {
             activeTag = "";
+            if (priority > 70) {
+                UserError.Log.uel(TAG, "No " + type + " with silent volume profile");
+            }
             return;
         }
 
@@ -749,6 +758,9 @@ public class AlertPlayer {
         } else {
             // No sound will play, so reset priority now so the gate doesn't stay locked.
             activeTag = "";
+            if (priority > 70) {
+                UserError.Log.uel(TAG, "No " + type + " in silent mode");
+            }
         }
     }
 
@@ -767,11 +779,14 @@ public class AlertPlayer {
         if (t.contains("persistent_high_alert")) return 87;
         if (t.contains("high_glucose_level")) return 85;
         if (t.contains("bg_predict_alert")) return 80;
-        if (t.contains("bluereader alarm")) return 75;
-        if (t.contains("bg_fall_alert") || t.contains("bg_rise_alert")) return 70;
-        if (t.contains("bg_unclear_readings_alert")) return 60;
-        if (t.contains("reminder")) return 50;
-        if (t.contains("sensor_expiry")) return 40;
+        // The default sound for the items above this line is our default alarm sound.
+        // The default sound for the items below this line is our default notification sound.
+        if (t.contains("bg_fall_alert") || t.contains("bg_rise_alert")) return 75;
+        // If the phone is in DND and override silent mode is not enabled for an item above this line, we create a trigger log.
+        if (t.contains("sensor_expiry")) return 60;
+        if (t.contains("bluereader alarm")) return 50;
+        if (t.contains("bg_unclear_readings_alert")) return 40;
+        if (t.contains("reminder")) return 30;
         if (t.contains("ob1_session_restart")) return 20;
         if (t.contains("general_notification")) return 10;
         return 5;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -1054,12 +1054,12 @@ public class Notifications extends IntentService {
             mBuilder.setVibrate(vibratePattern);
 
             float minVolume = (type.equals("bg_missed_alerts") || type.equals("persistent_high_alert")) ? MIN_ALARM_VOLUME : MIN_ALERT_VOLUME;
+            Log.ueh(TAG, message); // Other alert log
             AlertPlayer.getPlayer().triggerSoundAndVibration(context, true, otherAlertsSound, extraAlertsOverrideSilent, minVolume, type, otherAlertsVibrateOnAlert, vibratePattern);
 
             NotificationManager mNotifyMgr = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             //mNotifyMgr.cancel(notificatioId);
             //Log.d(TAG, "Notify");
-            Log.ueh(TAG, message);
             mNotifyMgr.notify(notificatioId, XdripNotificationCompat.build(mBuilder));
 
             if (Pref.getBooleanDefaultFalse("pref_amazfit_enable_key")


### PR DESCRIPTION
Fixes: https://github.com/NightscoutFoundation/xDrip/issues/4744 

If you wake up in the morning and notice your glucose has been low all night and you were never woken up and look at the logs and see that xDrip triggered alerts, you have no way of knowing if those alerts made any sound or not!  With our current Nightly release, the logs look exactly the same if the alerts were silent or made a sound.  

This PR changes that.  If an alert that triggers is silent, we now create a log explaining why it was silent.  After this, if you see no such logs, it means that xDrip did make a sound.  

Additional changes this PR makes:
1- There are AlertPlayer log tags in xDrip in classes other than AlertPlayer.  After this PR, a log tagged with AlertPlayer will only be a log really created by the AlertPlayer class.  
2- Rearranged a few items in the alert priority list.
3- The silent alert log is not added for basic notifications (priority less than 70)  
4- If your volume profile is the ascending volume and silent logs are required, they will be limited to one log per 20 minutes to avoid cluttering the logs.  

Please let me know if I have overlooked anything.